### PR TITLE
Fix npm security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "radioescola",
 			"devDependencies": {
 				"@tailwindcss/cli": "^4.1.13",
 				"@tailwindcss/forms": "^0.5.10",
@@ -14,9 +15,9 @@
 			}
 		},
 		"node_modules/@cypress/request": {
-			"version": "3.0.9",
-			"resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.9.tgz",
-			"integrity": "sha512-I3l7FdGRXluAS44/0NguwWlO83J18p0vlr2FYHrJkWdNYhgVoiYo61IXPqaOsL+vNxU1ZqMACzItGK3/KKDsdw==",
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.10.tgz",
+			"integrity": "sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -33,7 +34,7 @@
 				"json-stringify-safe": "~5.0.1",
 				"mime-types": "~2.1.19",
 				"performance-now": "^2.1.0",
-				"qs": "6.14.0",
+				"qs": "~6.14.1",
 				"safe-buffer": "^5.1.2",
 				"tough-cookie": "^5.0.0",
 				"tunnel-agent": "^0.6.0",
@@ -766,6 +767,13 @@
 			"integrity": "sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==",
 			"dev": true
 		},
+		"node_modules/@types/tmp": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+			"integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/yauzl": {
 			"version": "2.10.3",
 			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -797,16 +805,16 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
 				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
@@ -1083,9 +1091,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1264,15 +1272,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/check-more-types": {
-			"version": "2.24.0",
-			"resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
-			"integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8.0"
 			}
 		},
 		"node_modules/chownr": {
@@ -1753,10 +1752,11 @@
 			"license": "MIT"
 		},
 		"node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -1767,24 +1767,24 @@
 			}
 		},
 		"node_modules/cypress": {
-			"version": "15.2.0",
-			"resolved": "https://registry.npmjs.org/cypress/-/cypress-15.2.0.tgz",
-			"integrity": "sha512-J4ehSzOSb58SkXyldCe9y/oZ8ep8Bl6+q9kDUjnkqNqc2ZKzDq5KSbhIc2lHFAFR5Jtj10oNqr9JRAZbr8DA8A==",
+			"version": "15.13.1",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-15.13.1.tgz",
+			"integrity": "sha512-jLkgo75zlwo7PhXp0XJot+zIfFSDzN1SvTml6Xf3ETM1XHRWnH3Q4LAR3orCo/BsnxPnhjG3m5HYSvn9DAtwBg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"@cypress/request": "^3.0.9",
+				"@cypress/request": "^3.0.10",
 				"@cypress/xvfb": "^1.2.4",
 				"@types/sinonjs__fake-timers": "8.1.1",
 				"@types/sizzle": "^2.3.2",
+				"@types/tmp": "^0.2.3",
 				"arch": "^2.2.0",
 				"blob-util": "^2.0.2",
 				"bluebird": "^3.7.2",
 				"buffer": "^5.7.1",
 				"cachedir": "^2.3.0",
 				"chalk": "^4.1.0",
-				"check-more-types": "^2.24.0",
 				"ci-info": "^4.1.0",
 				"cli-cursor": "^3.1.0",
 				"cli-table3": "0.6.1",
@@ -1801,9 +1801,8 @@
 				"fs-extra": "^9.1.0",
 				"hasha": "5.2.2",
 				"is-installed-globally": "~0.4.0",
-				"lazy-ass": "^1.6.0",
 				"listr2": "^3.8.3",
-				"lodash": "^4.17.21",
+				"lodash": "^4.17.23",
 				"log-symbols": "^4.0.0",
 				"minimist": "^1.2.8",
 				"ospath": "^1.2.2",
@@ -1811,11 +1810,11 @@
 				"process": "^0.11.10",
 				"proxy-from-env": "1.0.0",
 				"request-progress": "^3.0.0",
-				"semver": "^7.7.1",
 				"supports-color": "^8.1.1",
-				"systeminformation": "5.27.7",
+				"systeminformation": "^5.31.1",
 				"tmp": "~0.2.4",
 				"tree-kill": "1.2.2",
+				"tslib": "1.14.1",
 				"untildify": "^4.0.0",
 				"yauzl": "^2.10.0"
 			},
@@ -1823,7 +1822,7 @@
 				"cypress": "bin/cypress"
 			},
 			"engines": {
-				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+				"node": "^20.1.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/cypress/node_modules/ansi-styles": {
@@ -1962,6 +1961,13 @@
 			"funding": {
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
+		},
+		"node_modules/cypress/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"dev": true,
+			"license": "0BSD"
 		},
 		"node_modules/dashdash": {
 			"version": "1.14.1",
@@ -2309,6 +2315,23 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/fast-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/fd-slicer": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -2357,9 +2380,9 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2864,15 +2887,6 @@
 				"verror": "1.10.0"
 			}
 		},
-		"node_modules/lazy-ass": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
-			"integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
-			"dev": true,
-			"engines": {
-				"node": "> 0.8"
-			}
-		},
 		"node_modules/lightningcss": {
 			"version": "1.30.1",
 			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
@@ -3223,10 +3237,11 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lodash.once": {
 			"version": "4.1.1",
@@ -3468,9 +3483,9 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3500,9 +3515,9 @@
 			}
 		},
 		"node_modules/minizlib": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
-			"integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3510,22 +3525,6 @@
 			},
 			"engines": {
 				"node": ">= 18"
-			}
-		},
-		"node_modules/mkdirp": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-			"integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"mkdirp": "dist/cjs/src/bin.js"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/mri": {
@@ -3686,9 +3685,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3744,20 +3743,10 @@
 				"once": "^1.3.1"
 			}
 		},
-		"node_modules/punycode": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/qs": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+			"version": "6.14.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -3902,28 +3891,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/serve": {
-			"version": "14.2.5",
-			"resolved": "https://registry.npmjs.org/serve/-/serve-14.2.5.tgz",
-			"integrity": "sha512-Qn/qMkzCcMFVPb60E/hQy+iRLpiU8PamOfOSYoAHmmF+fFFmpPpqa6Oci2iWYpTdOUM3VF+TINud7CfbQnsZbA==",
+			"version": "14.2.6",
+			"resolved": "https://registry.npmjs.org/serve/-/serve-14.2.6.tgz",
+			"integrity": "sha512-QEjUSA+sD4Rotm1znR8s50YqA3kYpRGPmtd5GlFxbaL9n/FdUNbqMhxClqdditSk0LlZyA/dhud6XNRTOC9x2Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@zeit/schemas": "2.36.0",
-				"ajv": "8.12.0",
+				"ajv": "8.18.0",
 				"arg": "5.0.2",
 				"boxen": "7.0.0",
 				"chalk": "5.0.1",
@@ -3931,7 +3907,7 @@
 				"clipboardy": "3.0.0",
 				"compression": "1.8.1",
 				"is-port-reachable": "4.0.0",
-				"serve-handler": "6.1.6",
+				"serve-handler": "6.1.7",
 				"update-check": "1.5.4"
 			},
 			"bin": {
@@ -3942,16 +3918,16 @@
 			}
 		},
 		"node_modules/serve-handler": {
-			"version": "6.1.6",
-			"resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.6.tgz",
-			"integrity": "sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==",
+			"version": "6.1.7",
+			"resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.7.tgz",
+			"integrity": "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bytes": "3.0.0",
 				"content-disposition": "0.5.2",
 				"mime-types": "2.1.18",
-				"minimatch": "3.1.2",
+				"minimatch": "3.1.5",
 				"path-is-inside": "1.0.2",
 				"path-to-regexp": "3.3.0",
 				"range-parser": "1.2.0"
@@ -4045,14 +4021,14 @@
 			}
 		},
 		"node_modules/side-channel-list": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3"
+				"object-inspect": "^1.13.4"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -4234,9 +4210,9 @@
 			}
 		},
 		"node_modules/systeminformation": {
-			"version": "5.27.7",
-			"resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
-			"integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+			"version": "5.31.5",
+			"resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.5.tgz",
+			"integrity": "sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ==",
 			"dev": true,
 			"license": "MIT",
 			"os": [
@@ -4282,17 +4258,16 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-			"integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+			"version": "7.5.13",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+			"integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/fs-minipass": "^4.0.0",
 				"chownr": "^3.0.0",
 				"minipass": "^7.1.2",
-				"minizlib": "^3.0.1",
-				"mkdirp": "^3.0.1",
+				"minizlib": "^3.1.0",
 				"yallist": "^5.0.0"
 			},
 			"engines": {
@@ -4447,16 +4422,6 @@
 			"dependencies": {
 				"registry-auth-token": "3.3.2",
 				"registry-url": "3.1.0"
-			}
-		},
-		"node_modules/uri-js": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"punycode": "^2.1.0"
 			}
 		},
 		"node_modules/uuid": {


### PR DESCRIPTION
## Summary
- Run `npm audit fix` to resolve 13 security vulnerabilities (9 high, 3 moderate, 1 low)
- Updated transitive dependencies: cross-spawn, picomatch, tar, minimatch, lodash, ajv, qs, systeminformation, brace-expansion
- No changes to direct dependencies in package.json

## Test plan
- [x] Verify `npm audit` reports 0 vulnerabilities
- [x] Verify `npm run dev` still works correctly
- [x] Verify Cypress tests still pass