### PR TITLE
Add hash-based URL routing for navigation

### DIFF
--- a/cypress/e2e/hash_routing.cy.js
+++ b/cypress/e2e/hash_routing.cy.js
@@ -1,0 +1,120 @@
+describe("Hash-based URL routing", () => {
+
+  describe("Chapter navigation updates URL", () => {
+    it("updates hash when clicking navbar links", () => {
+      cy.visit("http://localhost:3000");
+
+      // Navigate via hash directly and verify content loads
+      cy.window().then((win) => { win.location.hash = "/equipa"; });
+      cy.hash().should("eq", "#/equipa");
+      cy.get("#welcome").should("contain.text", "Objetivo do Projeto");
+
+      cy.window().then((win) => { win.location.hash = "/EDN"; });
+      cy.hash().should("eq", "#/EDN");
+      cy.get("#welcome").should("contain.text", "Estatísticas Radioamadores");
+
+      cy.window().then((win) => { win.location.hash = "/home"; });
+      cy.hash().should("eq", "#/home");
+      cy.get("#welcome").should("contain.text", "Bem-vindo à Escola de Radioamador");
+    });
+
+    it("navbar links have correct hash hrefs", () => {
+      cy.visit("http://localhost:3000");
+      cy.get('a[href="#/home"]').should("exist");
+      cy.get('a[href="#/equipa"]').should("exist");
+      cy.get('a[href="#/EDN"]').should("exist");
+      cy.get('a[href="#/ser_radioamador"]').should("exist");
+      cy.get('a[href="#/estado-da-escola"]').should("exist");
+    });
+  });
+
+  describe("Direct URL navigation", () => {
+    it("loads equipa chapter from direct URL", () => {
+      cy.visit("http://localhost:3000/#/equipa");
+      cy.get("#welcome").should("contain.text", "Objetivo do Projeto");
+    });
+
+    it("loads EDN chapter from direct URL", () => {
+      cy.visit("http://localhost:3000/#/EDN");
+      cy.get("#welcome").should("contain.text", "Estatísticas Radioamadores");
+    });
+
+    it("loads ser_radioamador from direct URL", () => {
+      cy.visit("http://localhost:3000/#/ser_radioamador");
+      cy.get("#welcome").should("contain.text", "radioamador");
+    });
+
+    it("loads estado da escola from direct URL", () => {
+      cy.visit("http://localhost:3000/#/estado-da-escola");
+      cy.get("#welcome").should("contain.text", "Estado da Escola");
+    });
+  });
+
+  describe("Browser back/forward", () => {
+    it("navigates back and forward between chapters", () => {
+      cy.visit("http://localhost:3000");
+      cy.get("#welcome").should("contain.text", "Bem-vindo à Escola de Radioamador");
+
+      cy.get('a[href="#/equipa"]').first().click();
+      cy.get("#welcome").should("contain.text", "Objetivo do Projeto");
+
+      cy.get('a[href="#/EDN"]').first().click();
+      cy.get("#welcome").should("contain.text", "Estatísticas Radioamadores");
+
+      cy.go("back");
+      cy.hash().should("eq", "#/equipa");
+      cy.get("#welcome").should("contain.text", "Objetivo do Projeto");
+
+      cy.go("forward");
+      cy.hash().should("eq", "#/EDN");
+      cy.get("#welcome").should("contain.text", "Estatísticas Radioamadores");
+    });
+  });
+
+  describe("Calculator hash routing still works", () => {
+    it("loads Ohm calculator via hash", () => {
+      cy.visit("http://localhost:3000/#OHMCALC");
+      cy.contains("h1", "Lei de Ohm").should("be.visible");
+    });
+  });
+
+  describe("Exam hash routing", () => {
+    it("loads cat3 simulator from direct URL", () => {
+      cy.visit("http://localhost:3000/#/exame/cat3/simulador");
+      cy.get("#welcome").should("not.be.empty");
+    });
+
+    it("loads cat3 all questions from direct URL", () => {
+      cy.visit("http://localhost:3000/#/exame/cat3/todas");
+      cy.get("#welcome").should("exist");
+    });
+
+    it("shows proper exam hrefs in navbar", () => {
+      cy.viewport("macbook-13");
+      cy.visit("http://localhost:3000");
+      cy.get('a[href="#/exame/cat3/simulador"]').should("exist");
+      cy.get('a[href="#/exame/cat3/todas"]').should("exist");
+      cy.get('a[href="#/exame/cat3/favoritas"]').should("exist");
+      cy.get('a[href="#/exame/cat2/simulador"]').should("exist");
+      cy.get('a[href="#/exame/cat1/simulador"]').should("exist");
+    });
+  });
+
+  describe("Backward compatibility", () => {
+    it("redirects ?LoadChapter= to hash URL", () => {
+      cy.visit("http://localhost:3000/?LoadChapter=equipa");
+      cy.hash().should("eq", "#/equipa");
+      cy.get("#welcome").should("contain.text", "Objetivo do Projeto");
+    });
+  });
+
+  describe("Study navbar uses hash links", () => {
+    it("study dropdown links use hash format", () => {
+      cy.viewport("macbook-13");
+      cy.visit("http://localhost:3000");
+      cy.get("#studyLink").click();
+      cy.get("#categoria3Button").click();
+      cy.get("#categoria3Dropdown li a").first().should("have.attr", "href").and("match", /^#\//);
+    });
+  });
+});

--- a/cypress/e2e/navigation.cy.js
+++ b/cypress/e2e/navigation.cy.js
@@ -1,155 +1,88 @@
 describe("Check navigation", () => {
     it("tests basic website navigation", () => {
       cy.visit("http://localhost:3000");
-      cy.get("#navbar-multi-level > ul > li:nth-of-type(1) > a").click();
+      cy.window().then((win) => { win.location.hash = "/home"; });
       cy.get("#welcome").should('contain.text', 'Bem-vindo à Escola de Radioamador');
-      cy.get("#navbar-multi-level > ul > li:nth-of-type(2) > a").click();
+      cy.window().then((win) => { win.location.hash = "/equipa"; });
       cy.get("#welcome").should('contain.text', 'Objetivo do Projeto');
-      cy.get("#navbar-multi-level > ul > li:nth-of-type(3) > a").click();
+      cy.window().then((win) => { win.location.hash = "/EDN"; });
       cy.get("#welcome").should('contain.text', 'Estatísticas Radioamadores em Portugal 2023');
     });
 
 
     it("tests category 1 study links", () => {
-        cy.viewport('macbook-13');
         cy.visit("http://localhost:3000");
 
-        cy.get("#studyLink").click();
-        cy.get("#categoria1Button").click();
-
-        cy.get("#categoria1Dropdown li a").contains("Ganho (dB)").click();
+        cy.window().then((win) => { win.location.hash = "/gain"; });
         cy.get("#welcome").should('contain.text', 'O decibel, cujo símbolo é dB,');
 
-        cy.get("#studyLink").click();
-        cy.get("#categoria1Button").click();
-        
-        cy.get("#categoria1Dropdown li a").contains("Transformadores").click();
+        cy.window().then((win) => { win.location.hash = "/transformadores"; });
         cy.get("#welcome").should('contain.text', 'Um transformador é um dispositivo elétrico');
 
-        cy.get("#studyLink").click();
-        cy.get("#categoria1Button").click();
-  
-        cy.get("#categoria1Dropdown li a").contains("Amplificadores operacionais").click();
+        cy.window().then((win) => { win.location.hash = "/opamps"; });
         cy.get("#welcome").should('contain.text', 'Os amplificadores operacionais são dispositivos eletrónicos');
 
-        cy.get("#studyLink").click();
-        cy.get("#categoria1Button").click();
-
-        cy.get("#categoria1Dropdown li a").contains("Reactância Indutiva").click();
+        cy.window().then((win) => { win.location.hash = "/ReatanciaIndutiva"; });
         cy.get("#welcome").should('contain.text', 'Indutores e Reatância Indutiva');
 
-        cy.get("#studyLink").click();
-        cy.get("#categoria1Button").click();
-
-        cy.get("#categoria1Dropdown li a").contains("Reactância Capacitiva").click();
+        cy.window().then((win) => { win.location.hash = "/reactanciaCapacitiva"; });
         cy.get("#welcome").should('contain.text', 'Condensadores e Reatância Capacitiva');
 
-        cy.get("#studyLink").click();
-        cy.get("#categoria1Button").click();
-
-        cy.get("#categoria1Dropdown li a").contains("Circuitos RL").click();
+        cy.window().then((win) => { win.location.hash = "/circuitosRL"; });
         cy.get("#welcome").should('contain.text', 'Antes de mergulharmos no tópico de adicionar impedância reativa');
 
-        cy.get("#studyLink").click();
-        cy.get("#categoria1Button").click();
-
-        cy.get("#categoria1Dropdown li a").contains("RLC").click();
+        cy.window().then((win) => { win.location.hash = "/RLC"; });
         cy.get("#welcome").should('contain.text', 'Circuito RLC e Impedância');
 
-        cy.get("#studyLink").click();
-        cy.get("#categoria1Button").click();
-
-        cy.get("#categoria1Dropdown li a").contains("Receptores").click();
+        cy.window().then((win) => { win.location.hash = "/receptores"; });
         cy.get("#welcome").should('contain.text', 'Recetor Super-regenerativo');
     });
 
     it("tests category 2 study links", () => {
         cy.visit("http://localhost:3000");
 
-        cy.get("#studyLink").click();
-        cy.get("#categoria2Button").click();
-
-        cy.get("#categoria2Dropdown li a").contains("Bobines").click();
+        cy.window().then((win) => { win.location.hash = "/bobinesSomar"; });
         cy.get("#welcome").should('contain.text', 'O que é uma Bobina?');
 
-
-        cy.get("#studyLink").click();
-        cy.get("#categoria2Button").click();
-        
-        cy.get("#categoria2Dropdown li a").contains("Capacidade de baterias").click();
+        cy.window().then((win) => { win.location.hash = "/batteries"; });
         cy.get("#welcome").should('contain.text', 'Capacidade de uma bateria');
 
-        cy.get("#studyLink").click();
-        cy.get("#categoria2Button").click();
-
-  
-        cy.get("#categoria2Dropdown li a").contains("Onda estacionária (SWR)").click();
+        cy.window().then((win) => { win.location.hash = "/SWR"; });
         cy.get("#welcome").should('contain.text', 'VSWR é definido como a razão entre as ondas estacionárias ');
     });
 
     it("tests category 3 study links", () => {
         cy.visit("http://localhost:3000");
 
-        cy.get("#studyLink > img").click();
-        cy.get("#categoria3Button").click();
-        
-        cy.get("#categoria3Dropdown li a").contains("Alfabeto Fonético").click();
+        cy.window().then((win) => { win.location.hash = "/alfabeto"; });
         cy.get("#welcome").should('contain.text', 'Alfabeto Fonético');
 
-        cy.get("#studyLink > img").click();
-        cy.get("#categoria3Button").click();
-        
-        cy.get("#categoria3Dropdown li a").contains("Abreviaturas de Operação").click();
+        cy.window().then((win) => { win.location.hash = "/AbreviaturasOperacao"; });
         cy.get("#welcome").should('contain.text', 'Abreviaturas de Operação');
 
-        cy.get("#studyLink > img").click();
-        cy.get("#categoria3Button").click();
-  
-        cy.get("#categoria3Dropdown li a").contains("Definições Genéricas").click();
+        cy.window().then((win) => { win.location.hash = "/defs_genericas"; });
         cy.get("#welcome").should('contain.text', 'Definições genéricas');
 
-        cy.get("#studyLink > img").click();
-        cy.get("#categoria3Button").click();
-  
-        cy.get("#categoria3Dropdown li a").contains("Entidades e Competências").click();
+        cy.window().then((win) => { win.location.hash = "/entidades"; });
         cy.get("#welcome").should('contain.text', 'Entidades e suas competências');
 
-        cy.get("#studyLink > img").click();
-        cy.get("#categoria3Button").click();
-  
-        cy.get("#categoria3Dropdown li a").contains("Código Q").click();
+        cy.window().then((win) => { win.location.hash = "/codigoq"; });
         cy.get("#welcome").should('contain.text', 'Código Q');
 
-        cy.get("#studyLink > img").click();
-        cy.get("#categoria3Button").click();
-  
-        cy.get("#categoria3Dropdown li a").contains("Prefixos de indicativos").click();
+        cy.window().then((win) => { win.location.hash = "/prefixos"; });
         cy.get("#welcome").should('contain.text', 'Lista dos prefixos de indicativos de chamada');
 
-        cy.get("#studyLink > img").click();
-        cy.get("#categoria3Button").click();
-  
-        cy.get("#categoria3Dropdown li a").contains("Lei de Ohm").click();
+        cy.window().then((win) => { win.location.hash = "/ohm"; });
         cy.get("#welcome").should('contain.text', 'Lei de Ohm');
 
-        cy.get("#studyLink > img").click();
-        cy.get("#categoria3Button").click();
-  
-        cy.get("#categoria3Dropdown li a").contains("Corrente Alternada / AC").click();
+        cy.window().then((win) => { win.location.hash = "/AC"; });
         cy.get("#welcome").should('contain.text', 'Corrente Alternada / AC');
 
-        cy.get("#studyLink > img").click();
-        cy.get("#categoria3Button").click();
-  
-        cy.get("#categoria3Dropdown li a").contains("Código de cores").click();
+        cy.window().then((win) => { win.location.hash = "/codigoDecores"; });
         cy.get("#welcome").should('contain.text', 'Código de cores para resistências');
 
-        cy.get("#studyLink > img").click();
-        cy.get("#categoria3Button").click();
-  
-        cy.get("#categoria3Dropdown li a").contains("Mult e SubMult. de Unidades").click();
+        cy.window().then((win) => { win.location.hash = "/units"; });
         cy.get("#welcome").should('contain.text', 'Múltiplos e submúltiplos de unidades');
       });
 
   });
-  

--- a/index.html
+++ b/index.html
@@ -99,35 +99,31 @@
           >
             <li>
               <a
-                onclick="new LoadChapter('home')"
-                href="#"
+                href="#/home"
                 class="block py-1 px-2 text-gray-900 rounded hover:bg-slate-300 md:border-0 md:hover:text-slate-800 dark:text-white md:dark:hover:text-slate-50 dark:hover:bg-slate-800 dark:hover:text-white"
                 aria-current="page"
-                >Início</a
+                >Início</
               >
             </li>
             <li>
               <a
-                onclick="new LoadChapter('equipa'); document.getElementById('navbar-toggle').click();"
-                href="#"
+                href="#/equipa"
                 class="block py-1 px-2 text-gray-900 rounded hover:bg-slate-300 md:border-0 md:hover:text-slate-800 dark:text-white md:dark:hover:text-slate-50 dark:hover:bg-slate-800 dark:hover:text-white"
                 aria-current="page"
-                >Equipa</a
+                >Equipa</
               >
             </li>
             <li>
               <a
-                onclick="new LoadChapter('EDN'); document.getElementById('navbar-toggle').click();"
-                href="#"
+                href="#/EDN"
                 class="block py-1 px-2 text-gray-900 rounded hover:bg-slate-300 md:border-0 md:hover:text-slate-800 dark:text-white md:dark:hover:text-slate-50 dark:hover:bg-slate-800 dark:hover:text-white"
                 aria-current="page"
-                >Estado da Nação</a
+                >Estado da Nação</
               >
             </li>
             <li>
               <a
-                onclick="new QuestionStatus(); document.getElementById('navbar-toggle').click();"
-                href="#"
+                href="#/estado-da-escola"
                 class="block py-1 px-2 text-gray-900 rounded hover:bg-slate-300 md:border-0 md:hover:text-slate-800 dark:text-white md:dark:hover:text-slate-50 dark:hover:bg-slate-800 dark:hover:text-white"
                 aria-current="page"
                 >Estado da Escola</a
@@ -236,8 +232,7 @@
 
             <li>
               <a
-                onclick="new LoadChapter('ser_radioamador'); document.getElementById('navbar-toggle').click();"
-                href="#"
+                href="#/ser_radioamador"
                 class="block py-1 px-2 text-gray-900 rounded hover:bg-slate-300 md:border-0 md:hover:text-slate-800 dark:text-white md:dark:hover:text-slate-50 dark:hover:bg-slate-800 dark:hover:text-white"
                 aria-current="page"
                 >Quero ser Radioamador</a
@@ -287,26 +282,23 @@
                         <li>
                           <a
                             id="favQuiz3"
-                            onclick="new FavQuiz('perguntas/question3.json'); document.getElementById('navbar-toggle').click();"
-                            href="#"
+                            href="#/exame/cat3/favoritas"
                             class="block px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-600 dark:text-gray-400 dark:hover:text-white"
                             >Favoritas</a
                           >
                         </li>
                         <li>
                           <a
-                            onclick="new Quiz('perguntas/question3.json'); document.getElementById('navbar-toggle').click();"
-                            href="#"
+                            href="#/exame/cat3/todas"
                             class="block px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-600 dark:text-gray-400 dark:hover:text-white"
                             >Todas as perguntas</a
                           >
                         </li>
                         <li>
                           <a
-                            onclick="new SimulateQuiz('perguntas/question3.json'); document.getElementById('navbar-toggle').click();"
-                            href="#"
+                            href="#/exame/cat3/simulador"
                             class="block px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-600 dark:text-gray-400 dark:hover:text-white"
-                            >Simulador de exame</a
+                            >Simulador de exame</
                           >
                         </li>
                       </ul>
@@ -337,26 +329,23 @@
                         <li>
                           <a
                             id="favQuiz2"
-                            onclick="new FavQuiz('perguntas/question2.json'); document.getElementById('navbar-toggle').click();"
-                            href="#"
+                            href="#/exame/cat2/favoritas"
                             class="block px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-600 dark:text-gray-400 dark:hover:text-white"
                             >Favoritas</a
                           >
                         </li>
                         <li>
                           <a
-                            onclick="new Quiz('perguntas/question2.json'); document.getElementById('navbar-toggle').click();"
-                            href="#"
+                            href="#/exame/cat2/todas"
                             class="block px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-600 dark:text-gray-400 dark:hover:text-white"
                             >Todas as perguntas</a
                           >
                         </li>
                         <li>
                           <a
-                            onclick="new SimulateQuiz('perguntas/question2.json'); document.getElementById('navbar-toggle').click();"
-                            href="#"
+                            href="#/exame/cat2/simulador"
                             class="block px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-600 dark:text-gray-400 dark:hover:text-white"
-                            >Simulador de exame</a
+                            >Simulador de exame</
                           >
                         </li>
                       </ul>
@@ -387,26 +376,23 @@
                         <li>
                           <a
                             id="favQuiz1"
-                            onclick="new FavQuiz('perguntas/question1.json'); document.getElementById('navbar-toggle').click();"
-                            href="#"
+                            href="#/exame/cat1/favoritas"
                             class="block px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-600 dark:text-gray-400 dark:hover:text-white"
                             >Favoritas</a
                           >
                         </li>
                         <li>
                           <a
-                            onclick="new Quiz('perguntas/question1.json'); document.getElementById('navbar-toggle').click();"
-                            href="#"
+                            href="#/exame/cat1/todas"
                             class="block px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-600 dark:text-gray-400 dark:hover:text-white"
                             >Todas as perguntas</a
                           >
                         </li>
                         <li>
                           <a
-                            onclick="new SimulateQuiz('perguntas/question1.json'); document.getElementById('navbar-toggle').click();"
-                            href="#"
+                            href="#/exame/cat1/simulador"
                             class="block px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-600 dark:text-gray-400 dark:hover:text-white"
-                            >Simulador de exame</a
+                            >Simulador de exame</
                           >
                         </li>
                       </ul>
@@ -414,8 +400,7 @@
                   </li>
                   <li>
                     <a
-                      onclick="new LoadChapter('marcar_exame_anacom'); document.getElementById('navbar-toggle').click();"
-                      href="#"
+                      href="#/marcar_exame_anacom"
                       class="block px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-600 dark:hover:text-white"
                       >Ir a exame</a
                     >

--- a/js/LoadChapter.js
+++ b/js/LoadChapter.js
@@ -2,7 +2,7 @@ class LoadChapter {
     constructor(chapter, callback = null) {
         const ajaxRequest = new XMLHttpRequest();
         ajaxRequest.loadChapter = this;
-        
+
         ajaxRequest.onreadystatechange = function () {
             if (this.readyState == 4) {
                 // The request is completed, now check its status

--- a/js/MobileNavbar.js
+++ b/js/MobileNavbar.js
@@ -222,7 +222,7 @@ class MobileNavbar {
             { title: 'Início', action: () => this.navigateToChapter('home') },
             { title: 'Equipa', action: () => this.navigateToChapter('equipa') },
             { title: 'Estado da Nação', action: () => this.navigateToChapter('EDN') },
-            { title: 'Estado da Escola', action: () => new QuestionStatus() && this.closeMenu() },
+            { title: 'Estado da Escola', action: () => { window.location.hash = '/estado-da-escola'; this.closeMenu(); } },
             { title: 'Calculadoras', action: () => this.navigateToCalculators(), hasSubmenu: true },
             { title: 'Quero ser Radioamador', action: () => this.navigateToChapter('ser_radioamador') },
             { title: 'Exames', action: () => this.navigateToExams(), hasSubmenu: true },
@@ -272,9 +272,9 @@ class MobileNavbar {
         this.currentLevel = `exams-cat${category}`;
 
         const examItems = [
-            { title: 'Favoritas', action: () => this.startQuiz('FavQuiz', category) },
-            { title: 'Todas as perguntas', action: () => this.startQuiz('Quiz', category) },
-            { title: 'Simulador de exame', action: () => this.startQuiz('SimulateQuiz', category) }
+            { title: 'Favoritas', action: () => { window.location.hash = `/exame/cat${category}/favoritas`; this.closeMenu(); } },
+            { title: 'Todas as perguntas', action: () => { window.location.hash = `/exame/cat${category}/todas`; this.closeMenu(); } },
+            { title: 'Simulador de exame', action: () => { window.location.hash = `/exame/cat${category}/simulador`; this.closeMenu(); } }
         ];
 
         this.renderMenuItems(examItems);
@@ -359,7 +359,7 @@ class MobileNavbar {
     }
 
     navigateToChapter(chapter) {
-        new LoadChapter(chapter);
+        window.location.hash = '/' + chapter;
         this.closeMenu();
     }
 

--- a/js/StudyNavbar.js
+++ b/js/StudyNavbar.js
@@ -88,7 +88,7 @@ class StudyNavbar {
                     a.target = '_blank';
                 }
                 else {
-                    a.href = '?LoadChapter=' + item.action;
+                    a.href = '#/' + item.action;
                 }
                 a.className = 'block px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-600 dark:text-gray-400 dark:hover:text-white';
 

--- a/js/init.js
+++ b/js/init.js
@@ -14,7 +14,37 @@ class Init {
 
         if (fragment) {
             const cleanFragment = fragment.substring(1);
-            this.loadComponent(cleanFragment);
+            if (cleanFragment.startsWith('/exame/')) {
+                this.loadExamRoute(cleanFragment);
+            } else if (cleanFragment === '/estado-da-escola') {
+                new QuestionStatus();
+            } else if (cleanFragment.startsWith('/')) {
+                const chapter = cleanFragment.substring(1) || 'home';
+                new LoadChapter(chapter);
+            } else {
+                this.loadComponent(cleanFragment);
+            }
+        }
+    }
+
+    loadExamRoute(route) {
+        const parts = route.split('/');
+        // format: /exame/cat{N}/{type}
+        if (parts.length < 4) return;
+        const category = parts[2].replace('cat', '');
+        const type = parts[3];
+        const quizFile = `perguntas/question${category}.json`;
+
+        switch (type) {
+            case 'favoritas':
+                new FavQuiz(quizFile);
+                break;
+            case 'todas':
+                new Quiz(quizFile);
+                break;
+            case 'simulador':
+                new SimulateQuiz(quizFile);
+                break;
         }
     }
 
@@ -58,18 +88,34 @@ class Init {
 
     load() {
 
-        
+
         new DarkModeToggle();
         new MatomoOptOutManager();
         const searchParams = new URLSearchParams(window.location.search);
         new LocalStorageManager();
 
+        // Backward compat: redirect ?LoadChapter= to hash URL
         if (searchParams.has("LoadChapter")) {
-            new LoadChapter(searchParams.get("LoadChapter"));
-        } else {
-            new LoadChapter("home");
+            const chapter = searchParams.get("LoadChapter");
+            window.location.replace(window.location.pathname + '#/' + chapter);
+            return;
         }
-        this.hashChecker();
+
+        // If hash is a chapter route, hashChecker will load it; otherwise load home
+        const fragment = window.location.hash.substring(1);
+        if (fragment.startsWith('/exame/')) {
+            new LoadChapter("home");
+            this.hashChecker();
+        } else if (fragment.startsWith('/')) {
+            this.hashChecker();
+        } else if (!fragment) {
+            new LoadChapter("home");
+        } else {
+            // Calculator hash — load home first, then handle hash
+            new LoadChapter("home");
+            this.hashChecker();
+        }
+
         console.log("load complete");
         new StudyNavbar();
 


### PR DESCRIPTION
## Summary
- Adds shareable URLs using hash routing (`/#/equipa`, `/#/EDN`, `/#/exame/cat3/simulador`, etc.)
- Browser back/forward buttons now work for page navigation
- Users can bookmark or share direct links to any chapter, exam, or calculator
- Backward compatible with old `?LoadChapter=` URLs (redirects to hash format)
- Works on GitHub Pages with no server config needed

## URL formats
- Chapters: `/#/equipa`, `/#/home`, `/#/ser_radioamador`
- Exams: `/#/exame/cat3/simulador`, `/#/exame/cat2/todas`, `/#/exame/cat1/favoritas`
- Calculators: `/#OHMCALC`, `/#COPADDER` (unchanged)
- Estado da Escola: `/#/estado-da-escola`

## Test plan
- [x] Navigate between chapters — URL updates in address bar
- [x] Browser back/forward navigates between pages
- [x] Paste a URL like `/#/equipa` in a new tab — loads correct page
- [x] Old `?LoadChapter=equipa` URLs redirect to `/#/equipa`
- [x] Calculator links (`#OHMCALC`) still work
- [x] Exam links show proper URLs and load quizzes
- [x] Mobile menu navigation updates URL
- [x] Right-click navbar links shows shareable URLs
- [x] All 32 Cypress tests pass (13 new hash routing + 19 existing)