### PR TITLE
Redesign the /donativos page

### DIFF
--- a/app/donativos/page.tsx
+++ b/app/donativos/page.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Heart, Coffee, Server, Star, Receipt, Sparkles, Tent, Radio, Trophy } from 'lucide-react';
+import { Heart, Coffee, Server, Star, Sparkles, Tent, Radio, Trophy } from 'lucide-react';
 import { getTranslations } from 'next-intl/server';
 import { EXTERNAL_LINKS } from '@/lib/config';
 
@@ -7,6 +7,23 @@ const DONATION_TIERS = [
   { amountKey: 'coffeeAmount', labelKey: 'coffee', icon: Coffee, recommended: false },
   { amountKey: 'hosting10Amount', labelKey: 'hosting10', icon: Server, recommended: true },
   { amountKey: 'sponsorAmount', labelKey: 'sponsor', icon: Star, recommended: false },
+] as const;
+
+/**
+ * Annual cost breakdown. `share` is each line's slice of the total, used for the
+ * proportion bar — keep it in sync with the expense* amounts in the messages
+ * files (server €5.52/mo ≈ €66/yr ≈ 67%, domain €32.37/yr ≈ 33%).
+ */
+const COSTS = [
+  { nameKey: 'expenseHosting', amountKey: 'expenseHostingAmount', provider: 'Hetzner', share: 67, segment: 'bg-amber-500' },
+  { nameKey: 'expenseDomain', amountKey: 'expenseDomainAmount', provider: 'radioescola.pt', share: 33, segment: 'bg-amber-500/40' },
+] as const;
+
+const EXCESS_ITEMS = [
+  { icon: Tent, key: 'excessFairs', chip: 'bg-emerald-100 text-emerald-600 dark:bg-emerald-950/40 dark:text-emerald-400' },
+  { icon: Heart, key: 'excessStickers', chip: 'bg-rose-100 text-rose-600 dark:bg-rose-950/40 dark:text-rose-400' },
+  { icon: Radio, key: 'excessEquipment', chip: 'bg-sky-100 text-sky-600 dark:bg-sky-950/40 dark:text-sky-400' },
+  { icon: Trophy, key: 'excessPrizes', chip: 'bg-amber-100 text-amber-600 dark:bg-amber-950/40 dark:text-amber-400' },
 ] as const;
 
 export default async function DonativosPage() {
@@ -18,31 +35,23 @@ export default async function DonativosPage() {
 
   return (
     <main className="-mx-4 sm:mx-0 pb-8">
-      {/* Hero */}
-      <div className="bg-gradient-to-br from-slate-800 to-slate-900 dark:from-slate-900 dark:to-black px-4 sm:px-8 py-10 sm:rounded-2xl mb-8">
-        <div className="flex items-start gap-4 mb-4">
-          <div className="p-3 rounded-xl bg-rose-500/20 shrink-0 mt-1">
-            <Heart className="w-7 h-7 sm:w-8 sm:h-8 text-rose-400 animate-heartbeat" />
-          </div>
-          <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-white">{t('title')}</h1>
+      {/* Hero — emotional, funding goal front and center */}
+      <div className="relative overflow-hidden bg-gradient-to-br from-slate-800 to-slate-900 dark:from-slate-900 dark:to-black px-6 py-10 text-center sm:rounded-2xl sm:px-8 md:py-12">
+        <div className="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-2xl bg-rose-500/20 ring-1 ring-rose-500/30">
+          <Heart className="h-8 w-8 text-rose-400 animate-heartbeat" />
         </div>
-        <p className="text-slate-300 max-w-2xl text-lg leading-relaxed">
-          {t('subtitle')}
-        </p>
+        <h1 className="mx-auto max-w-2xl text-2xl font-bold text-white sm:text-3xl md:text-4xl">{t('title')}</h1>
+        <p className="mx-auto mt-3 max-w-xl text-lg leading-relaxed text-slate-300">{t('subtitle')}</p>
 
-        {/* Funding progress — prominent, inside the hero */}
-        <div className="mt-8 max-w-md">
-          <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 mb-2">
-            <p className="text-sm font-medium text-slate-400">{t('fundingTitle')}</p>
-            <p className="text-sm text-slate-400">
-              <span className="text-lg font-bold text-white">{t('fundingReceived')}</span>
-              <span className="mx-1">/</span>
-              {t('fundingGoal')}
-            </p>
+        <div className="mx-auto mt-8 max-w-md">
+          <p className="text-xs font-medium uppercase tracking-widest text-slate-400">{t('fundingTitle')}</p>
+          <div className="mt-2 flex items-end justify-center gap-2">
+            <span className="font-mono text-4xl font-bold text-white">{t('fundingReceived')}</span>
+            <span className="mb-1 text-slate-400">/ {t('fundingGoal')}</span>
           </div>
-          <div className="h-4 rounded-full bg-slate-700 overflow-hidden">
+          <div className="mt-3 h-3 overflow-hidden rounded-full bg-slate-700">
             <div
-              className="h-full rounded-full bg-amber-500 transition-all duration-500"
+              className="h-full rounded-full bg-gradient-to-r from-amber-400 to-orange-500 transition-all duration-500"
               style={{ width: `${Math.max(percent, 2)}%` }}
             />
           </div>
@@ -50,14 +59,9 @@ export default async function DonativosPage() {
         </div>
       </div>
 
-      {/* Donation amounts */}
-      <div className="px-4 sm:px-0">
-        <div className="flex items-center gap-3 mb-4">
-          <div className="p-2 rounded-lg bg-amber-100 dark:bg-amber-900/30">
-            <Heart className="w-5 h-5 text-amber-600 dark:text-amber-400" />
-          </div>
-          <h2 className="text-xl font-semibold text-slate-900 dark:text-white">{t('chooseAmount')}</h2>
-        </div>
+      {/* Donation tiers */}
+      <div className="px-4 sm:px-0 mt-10">
+        <h2 className="mb-5 text-center text-xl font-semibold text-slate-900 dark:text-white">{t('chooseAmount')}</h2>
         <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
           {DONATION_TIERS.map((tier) => {
             const amount = t(tier.amountKey);
@@ -68,20 +72,28 @@ export default async function DonativosPage() {
                 href={`${EXTERNAL_LINKS.PAYPAL_DONATE}/${amount}`}
                 target="_blank"
                 rel="noopener noreferrer"
-                className={`group relative flex flex-col items-center gap-2 sm:gap-3 rounded-xl border bg-white dark:bg-slate-800 p-4 sm:p-6 hover:shadow-lg hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-amber-500 outline-none transition-all duration-200 ${
+                className={`group relative flex flex-col items-center gap-2 sm:gap-3 rounded-2xl border p-4 sm:p-6 text-center outline-none transition-all duration-200 hover:-translate-y-1 hover:shadow-lg focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 ${
                   tier.recommended
-                    ? 'border-amber-400 dark:border-amber-500 shadow-md'
-                    : 'border-slate-200 dark:border-slate-700 hover:border-amber-300 dark:hover:border-amber-600'
+                    ? 'border-transparent bg-gradient-to-br from-amber-500 to-orange-600 text-white shadow-lg shadow-amber-500/20'
+                    : 'border-slate-200 bg-white hover:border-amber-300 dark:border-slate-700 dark:bg-slate-800 dark:hover:border-amber-600'
                 }`}
               >
                 {tier.recommended && (
-                  <span className="absolute -top-2.5 left-1/2 -translate-x-1/2 whitespace-nowrap text-[11px] sm:text-xs font-semibold text-amber-700 dark:text-amber-300 bg-amber-100 dark:bg-amber-900/30 px-2 sm:px-2.5 py-0.5 rounded-full">
+                  <span className="absolute -top-2.5 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full bg-white px-2.5 py-0.5 text-[11px] sm:text-xs font-bold text-amber-700 shadow-sm">
                     {t('recommended')}
                   </span>
                 )}
-                <Icon className="w-6 h-6 text-amber-600 dark:text-amber-400 transition-transform duration-200 group-hover:-translate-y-1" />
-                <span className="text-2xl font-bold text-slate-900 dark:text-white">{amount}€</span>
-                <span className="text-sm text-slate-600 dark:text-slate-400 text-center">{t(tier.labelKey)}</span>
+                <Icon
+                  className={`h-6 w-6 transition-transform duration-200 group-hover:-translate-y-1 ${
+                    tier.recommended ? 'text-white' : 'text-amber-600 dark:text-amber-400'
+                  }`}
+                />
+                <span className={`text-2xl font-bold ${tier.recommended ? 'text-white' : 'text-slate-900 dark:text-white'}`}>
+                  {amount}€
+                </span>
+                <span className={`text-sm ${tier.recommended ? 'text-white/90' : 'text-slate-600 dark:text-slate-400'}`}>
+                  {t(tier.labelKey)}
+                </span>
               </a>
             );
           })}
@@ -89,75 +101,64 @@ export default async function DonativosPage() {
             href={EXTERNAL_LINKS.PAYPAL_DONATE}
             target="_blank"
             rel="noopener noreferrer"
-            className="group flex flex-col items-center gap-2 sm:gap-3 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 sm:p-6 hover:border-amber-300 dark:hover:border-amber-600 hover:shadow-lg hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-amber-500 outline-none transition-all duration-200"
+            className="group flex flex-col items-center justify-center gap-2 sm:gap-3 rounded-2xl border border-slate-200 bg-white p-4 text-center outline-none transition-all duration-200 hover:-translate-y-1 hover:border-amber-300 hover:shadow-lg focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 sm:p-6 dark:border-slate-700 dark:bg-slate-800 dark:hover:border-amber-600"
           >
-            <Heart className="w-6 h-6 text-amber-600 dark:text-amber-400 transition-transform duration-200 group-hover:-translate-y-1" />
+            <Heart className="h-6 w-6 text-amber-600 transition-transform duration-200 group-hover:-translate-y-1 dark:text-amber-400" />
             <span className="text-2xl font-bold text-slate-900 dark:text-white">{t('otherAmount')}</span>
-            <span className="text-sm text-slate-600 dark:text-slate-400 text-center">{t('otherAmountDesc')}</span>
+            <span className="text-sm text-slate-600 dark:text-slate-400">{t('otherAmountDesc')}</span>
           </a>
         </div>
-
-        <p className="mt-4 text-center text-xs text-slate-400 dark:text-slate-500">
-          {t('donateVia')}
-        </p>
+        <p className="mt-4 text-center text-xs text-slate-400 dark:text-slate-500">{t('donateVia')}</p>
       </div>
 
-      {/* Transparency */}
-      <div className="px-4 sm:px-0 mt-16 md:mt-20">
-        <div className="flex items-center gap-3 mb-4">
-          <div className="p-2 rounded-lg bg-slate-100 dark:bg-slate-800">
-            <Receipt className="w-5 h-5 text-slate-600 dark:text-slate-400" />
+      {/* Transparency + extra support */}
+      <div className="px-4 sm:px-0 mt-16 grid gap-6 md:mt-20 md:grid-cols-2">
+        {/* Cost ledger — the split visualized */}
+        <div className="rounded-2xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-800">
+          <h2 className="text-sm font-semibold text-slate-900 dark:text-white">{t('transparency')}</h2>
+          <p className="mt-1 text-xs leading-relaxed text-slate-500 dark:text-slate-400">{t('transparencyDesc')}</p>
+
+          <div className="mt-5 flex h-2 gap-0.5 overflow-hidden rounded-full">
+            {COSTS.map((c) => (
+              <div key={c.nameKey} className={c.segment} style={{ width: `${c.share}%` }} />
+            ))}
           </div>
-          <h2 className="text-xl font-semibold text-slate-900 dark:text-white">{t('transparency')}</h2>
-        </div>
-        <p className="text-sm text-slate-600 dark:text-slate-400 mb-4">{t('transparencyDesc')}</p>
-        <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 overflow-hidden">
-          <div className="flex items-center justify-between px-5 py-4 border-b border-slate-100 dark:border-slate-700/50">
-            <div className="flex items-center gap-3">
-              <Server className="w-4 h-4 text-slate-500 dark:text-slate-400" />
-              <div>
-                <p className="text-sm font-medium text-slate-900 dark:text-white">{t('expenseHosting')}</p>
-                <p className="text-xs text-slate-500 dark:text-slate-400">Hetzner</p>
+
+          <div className="mt-3 divide-y divide-slate-100 dark:divide-slate-700/60">
+            {COSTS.map((c) => (
+              <div key={c.nameKey} className="flex items-center justify-between py-2.5">
+                <div className="flex items-center gap-3">
+                  <span className={`h-2 w-2 shrink-0 rounded-full ${c.segment}`} aria-hidden />
+                  <p className="text-sm font-medium text-slate-900 dark:text-white">
+                    {t(c.nameKey)} <span className="font-normal text-slate-400">· {c.provider}</span>
+                  </p>
+                </div>
+                <span className="font-mono text-sm text-slate-700 dark:text-slate-300">{t(c.amountKey)}</span>
               </div>
-            </div>
-            <span className="text-sm font-semibold text-slate-900 dark:text-white">{t('expenseHostingAmount')}</span>
+            ))}
           </div>
-          <div className="flex items-center justify-between px-5 py-4 border-b border-slate-100 dark:border-slate-700/50">
-            <div className="flex items-center gap-3">
-              <span className="w-4 h-4 text-slate-500 dark:text-slate-400 text-center text-xs font-bold leading-4">.pt</span>
-              <div>
-                <p className="text-sm font-medium text-slate-900 dark:text-white">{t('expenseDomain')}</p>
-                <p className="text-xs text-slate-500 dark:text-slate-400">radioescola.pt</p>
-              </div>
-            </div>
-            <span className="text-sm font-semibold text-slate-900 dark:text-white">{t('expenseDomainAmount')}</span>
-          </div>
-          <div className="flex items-center justify-between px-5 py-4 bg-slate-50 dark:bg-slate-800/80">
-            <p className="text-sm font-semibold text-slate-900 dark:text-white">{t('expenseTotal')}</p>
-            <span className="font-bold text-amber-600 dark:text-amber-400">{t('expenseTotalAmount')}</span>
+
+          <div className="mt-3 flex items-center justify-between rounded-xl bg-amber-50 px-3.5 py-3 dark:bg-amber-950/20">
+            <span className="text-sm font-semibold text-slate-900 dark:text-white">{t('expenseTotal')}</span>
+            <span className="font-mono text-base font-bold text-amber-600 dark:text-amber-400">{t('expenseTotalAmount')}</span>
           </div>
         </div>
 
-        {/* Beyond the basics */}
-        <div className="mt-8">
-          <div className="flex items-center gap-2 mb-4">
-            <Sparkles className="w-4 h-4 text-amber-600 dark:text-amber-400" />
+        {/* Beyond the basics — what extra support unlocks */}
+        <div className="rounded-2xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-800">
+          <div className="mb-4 flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-amber-500" />
             <p className="text-sm font-semibold text-slate-900 dark:text-white">{t('excessTitle')}</p>
           </div>
-          <div className="grid gap-3 sm:grid-cols-2">
-            {([
-              { icon: Tent, key: 'excessFairs', color: 'bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400' },
-              { icon: Heart, key: 'excessStickers', color: 'bg-rose-100 dark:bg-rose-900/30 text-rose-600 dark:text-rose-400' },
-              { icon: Radio, key: 'excessEquipment', color: 'bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400' },
-              { icon: Trophy, key: 'excessPrizes', color: 'bg-amber-100 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400' },
-            ] as const).map((item) => {
+          <div className="space-y-1">
+            {EXCESS_ITEMS.map((item) => {
               const Icon = item.icon;
               return (
-                <div key={item.key} className="flex items-center gap-3 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-4 py-3">
-                  <div className={`p-1.5 rounded-lg shrink-0 ${item.color}`}>
-                    <Icon className="w-4 h-4" />
-                  </div>
-                  <p className="text-sm font-medium text-slate-700 dark:text-slate-300">{t(item.key)}</p>
+                <div key={item.key} className="flex items-center gap-3 rounded-lg px-2 py-2 transition-colors hover:bg-slate-50 dark:hover:bg-slate-700/40">
+                  <span className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${item.chip}`}>
+                    <Icon className="h-4 w-4" />
+                  </span>
+                  <p className="text-sm text-slate-700 dark:text-slate-300">{t(item.key)}</p>
                 </div>
               );
             })}


### PR DESCRIPTION
## Summary

Full visual redesign of the donations page for a warmer, more motivating feel, while preserving all content and the existing PayPal links. Chosen from rendered in-app alternatives.

## Changes

- **Hero** — an emotional centered hero with the funding goal as the centerpiece: a large mono total over an amber→orange progress bar.
- **Tiers** — the recommended 10€ is now a bold amber-gradient card (echoing the landing-page drill banner); the others stay clean, plus the "Other amount" card. PayPal links unchanged.
- **Transparency** — reworked into two distinct cards instead of two flat twins:
  - a **cost ledger** that visualizes the server/domain split with a proportion bar, color-matched dots, and a highlighted total box;
  - an **extra-support** list with per-item colored icon chips (emerald / rose / sky / amber).

Uses the existing `Donate` i18n keys, so it stays fully translated (no new strings).

## Verification

Reviewed in light, dark, and mobile.

- `bun run type-check` — passes
- `bun run lint` — 0 problems
- `bun run build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)