### PR TITLE
Fix gamification data-loss, staleness, and streak/date bugs

### DIFF
--- a/__tests__/contracts/test-gamification-wiring.test.ts
+++ b/__tests__/contracts/test-gamification-wiring.test.ts
@@ -22,6 +22,24 @@ describe("Contract: Gamification wiring", () => {
     });
   });
 
+  describe("browse and flash pages award gamification per question", () => {
+    it("ProgressProvider wires processQuestionAnswered to recordQuestionWithGamification", () => {
+      const source = readSource("components/providers/ProgressProvider.tsx");
+      expect(source).toContain("processQuestionAnswered");
+      expect(source).toContain("recordQuestionWithGamification");
+    });
+
+    it("browse page uses recordQuestionWithGamification", () => {
+      const source = readSource("app/browse/[category]/page.tsx");
+      expect(source).toContain("recordQuestionWithGamification");
+    });
+
+    it("flash page uses recordQuestionWithGamification", () => {
+      const source = readSource("app/browse/[category]/flash/page.tsx");
+      expect(source).toContain("recordQuestionWithGamification");
+    });
+  });
+
   describe("smart practice page calls recordSmartPracticeSession on completion", () => {
     it("destructures recordSmartPracticeSession from context", () => {
       const source = readSource("app/browse/[category]/smart-practice/page.tsx");

--- a/__tests__/unit/test-gamification-engine.test.ts
+++ b/__tests__/unit/test-gamification-engine.test.ts
@@ -10,7 +10,11 @@ import { createInitialGamificationState } from "@/lib/types/gamification";
 import type { GamificationState } from "@/lib/types/gamification";
 import { createEmptyProgress } from "@/lib/types/progress";
 import type { ExamAttempt, UserProgress } from "@/lib/types/progress";
-import { ensureTodayProgress } from "@/lib/gamification/daily-goals";
+import {
+  ensureTodayProgress,
+  getTodayDateString,
+  getYesterdayDateString,
+} from "@/lib/gamification/daily-goals";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -372,6 +376,139 @@ describe("daily goal consistency across activity types", () => {
 
     expect(newState.lifetimeStats.questionsAnswered).toBe(10);
     expect(newState.lifetimeStats.questionsCorrect).toBe(8);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Daily goal streak (consecutive-day reset)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a state whose (single) daily goal is already complete and whose bonus
+ * has not yet been claimed, so the next processor call enters the
+ * "all daily goals complete" branch and bumps the streak.
+ */
+function stateWithAllGoalsComplete(
+  base: GamificationState,
+  lastGoalCompletionDate: string | null,
+  dailyGoalStreak: number
+): GamificationState {
+  const today = getTodayDateString();
+  const goal = {
+    id: `${today}-done`,
+    type: "questions_answered" as const,
+    target: 1,
+    xpReward: 10,
+  };
+  return {
+    ...base,
+    dailyGoalStreak,
+    lastGoalCompletionDate,
+    dailyProgress: {
+      date: today,
+      goals: [goal],
+      progress: { [goal.id]: 1 },
+      completed: [goal.id],
+      bonusClaimed: false,
+    },
+  };
+}
+
+describe("dailyGoalStreak consecutive-day handling", () => {
+  const base = createInitialGamificationState();
+  const today = getTodayDateString();
+
+  it("increments when the previous completion was yesterday", () => {
+    const state = stateWithAllGoalsComplete(base, getYesterdayDateString(today), 3);
+    const { newState } = processQuestionAnswered(state, true);
+
+    expect(newState.dailyGoalStreak).toBe(4);
+    expect(newState.lastGoalCompletionDate).toBe(today);
+  });
+
+  it("resets to 1 after a missed day (gap)", () => {
+    const twoDaysAgo = getYesterdayDateString(getYesterdayDateString(today));
+    const state = stateWithAllGoalsComplete(base, twoDaysAgo, 3);
+    const { newState } = processQuestionAnswered(state, true);
+
+    expect(newState.dailyGoalStreak).toBe(1);
+    expect(newState.lastGoalCompletionDate).toBe(today);
+  });
+
+  it("starts at 1 on the first ever completion", () => {
+    const state = stateWithAllGoalsComplete(base, null, 0);
+    const { newState } = processQuestionAnswered(state, true);
+
+    expect(newState.dailyGoalStreak).toBe(1);
+    expect(newState.lastGoalCompletionDate).toBe(today);
+  });
+
+  it("increments dailyGoalSetsCompleted once and flags the bonus as just claimed", () => {
+    const state = stateWithAllGoalsComplete(base, getYesterdayDateString(today), 1);
+    const { newState, result } = processQuestionAnswered(state, true);
+
+    expect(newState.lifetimeStats.dailyGoalSetsCompleted).toBe(1);
+    expect(result.allDailyGoalsComplete).toBe(true);
+  });
+
+  it("unlocks daily_champion after 7 goal SETS, not 7 individual goals", () => {
+    let state = stateWithAllGoalsComplete(base, getYesterdayDateString(today), 6);
+    state = {
+      ...state,
+      lifetimeStats: { ...state.lifetimeStats, dailyGoalSetsCompleted: 6 },
+    };
+
+    const { result } = processQuestionAnswered(state, true, createEmptyProgress());
+
+    expect(result.newAchievements.some((a) => a.id === "daily_champion")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Achievements unlock outside of exams
+// ---------------------------------------------------------------------------
+
+describe("achievements evaluate on non-exam activity", () => {
+  let progress: UserProgress;
+
+  beforeEach(() => {
+    progress = createEmptyProgress();
+  });
+
+  it("unlocks a question-count achievement from a browsed question", () => {
+    let state = stateWithDailyGoals(createInitialGamificationState());
+    state = { ...state, lifetimeStats: { ...state.lifetimeStats, questionsAnswered: 99 } };
+
+    const { result } = processQuestionAnswered(state, true, progress);
+
+    expect(result.newAchievements.some((a) => a.id === "hundred_questions")).toBe(true);
+  });
+
+  it("does not evaluate achievements when no progress is supplied", () => {
+    let state = stateWithDailyGoals(createInitialGamificationState());
+    state = { ...state, lifetimeStats: { ...state.lifetimeStats, questionsAnswered: 99 } };
+
+    const { result } = processQuestionAnswered(state, true);
+
+    expect(result.newAchievements).toHaveLength(0);
+  });
+
+  it("unlocks a streak achievement via progress.stats from a question", () => {
+    const state = stateWithDailyGoals(createInitialGamificationState());
+    progress.stats.longestStreak = 7;
+
+    const { result } = processQuestionAnswered(state, true, progress);
+
+    expect(result.newAchievements.some((a) => a.id === "week_streak")).toBe(true);
+  });
+
+  it("unlocks achievements from a drill", () => {
+    let state = stateWithDailyGoals(createInitialGamificationState());
+    state = { ...state, lifetimeStats: { ...state.lifetimeStats, questionsAnswered: 99 } };
+
+    const { result } = processDrillComplete(state, 1, 1, progress);
+
+    expect(result.newAchievements.some((a) => a.id === "hundred_questions")).toBe(true);
   });
 });
 

--- a/app/browse/[category]/flash/page.tsx
+++ b/app/browse/[category]/flash/page.tsx
@@ -53,7 +53,7 @@ export default function FlashBrowsePage() {
   const [isLoading, setIsLoading] = useState(true);
   const [answeredCount, setAnsweredCount] = useState(0);
   const { openCalculator } = useCalculators();
-  const { recordQuestion, progress, refreshProgress } = useProgressContext();
+  const { recordQuestionWithGamification, progress, refreshProgress } = useProgressContext();
   const t = useTranslations("Browse");
 
   const isBookmarked = useCallback((questionId: number) => {
@@ -135,14 +135,14 @@ export default function FlashBrowsePage() {
       return;
     }
     setSelectedOption(choice);
-    // Record question attempt for progress tracking
-    recordQuestion({
+    // Record question attempt (+ XP / daily goals) for progress tracking
+    recordQuestionWithGamification({
       questionId: currentQuestion.id,
       category: catId,
       correct: choice === currentQuestion.correctIndex,
       timestamp: Date.now(),
     });
-  }, [selectedOption, currentQuestion, recordQuestion, catId]);
+  }, [selectedOption, currentQuestion, recordQuestionWithGamification, catId]);
 
   const handleNext = useCallback(() => {
     if (!category || order.length === 0) {

--- a/app/browse/[category]/page.tsx
+++ b/app/browse/[category]/page.tsx
@@ -22,7 +22,7 @@ export default function BrowsePage() {
       : '3';
   const [answers, setAnswers] = useState<Record<number, number>>({});
   const { openCalculator } = useCalculators();
-  const { recordQuestion, progress, refreshProgress } = useProgressContext();
+  const { recordQuestionWithGamification, progress, refreshProgress } = useProgressContext();
   const t = useTranslations('Browse');
 
   const isBookmarked = useCallback((questionId: number) => {
@@ -80,8 +80,8 @@ export default function BrowsePage() {
               onSelect={(choice) => {
                 setAnswers((prev) => {
                   if (Object.prototype.hasOwnProperty.call(prev, q.id)) return prev;
-                  // Record question attempt for progress tracking
-                  recordQuestion({
+                  // Record question attempt (+ XP / daily goals) for progress tracking
+                  recordQuestionWithGamification({
                     questionId: q.id,
                     category: categoryId,
                     correct: choice === q.correctIndex,

--- a/app/exam/[category]/page.tsx
+++ b/app/exam/[category]/page.tsx
@@ -129,11 +129,6 @@ export default function ExamPage() {
       answers: { ...answers },
     };
 
-    // Record exam with gamification (returns XP result)
-    recordExamWithGamification(examAttempt, timeLeft).then((result) => {
-      setGamificationResult(result);
-    });
-
     // Record individual question attempts
     const questionAttempts: QuestionAttempt[] = category.questions
       .filter(q => answers[q.id] !== undefined)
@@ -144,9 +139,15 @@ export default function ExamPage() {
         timestamp: Date.now(),
       }));
 
-    if (questionAttempts.length > 0) {
-      recordQuestionBatch(questionAttempts);
-    }
+    // Sequence the writes so they don't race on localStorage: record the exam
+    // (+ gamification, persisted atomically) first, then the per-question batch.
+    // Running them concurrently let one overwrite the other's just-saved data.
+    recordExamWithGamification(examAttempt, timeLeft).then((result) => {
+      setGamificationResult(result);
+      if (questionAttempts.length > 0) {
+        recordQuestionBatch(questionAttempts);
+      }
+    });
   }, [quizEnded, category, answers, score, timeLeft, recordExamWithGamification, recordQuestionBatch]);
 
   React.useEffect(() => {

--- a/components/gamification/AchievementToast.tsx
+++ b/components/gamification/AchievementToast.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import * as LucideIcons from "lucide-react";
 import { X } from "lucide-react";
@@ -34,6 +34,14 @@ export function AchievementToast({
 
   const IconComponent = (LucideIcons as unknown as Record<string, React.ComponentType<{ className?: string }>>)[achievement.icon] ?? LucideIcons.Star;
 
+  // Keep the latest onDismiss in a ref so the auto-hide effect can run once on
+  // mount without a fresh inline onDismiss closure (passed by the container on
+  // every parent re-render) restarting the timer and re-firing indefinitely.
+  const onDismissRef = useRef(onDismiss);
+  useEffect(() => {
+    onDismissRef.current = onDismiss;
+  });
+
   useEffect(() => {
     // Animate in
     const showTimer = setTimeout(() => setIsVisible(true), 100);
@@ -46,7 +54,7 @@ export function AchievementToast({
     if (autoHide) {
       hideTimer = setTimeout(() => {
         setIsVisible(false);
-        setTimeout(onDismiss, 300);
+        setTimeout(() => onDismissRef.current(), 300);
       }, autoHideDelay);
     }
 
@@ -54,7 +62,7 @@ export function AchievementToast({
       clearTimeout(showTimer);
       if (hideTimer) clearTimeout(hideTimer);
     };
-  }, [autoHide, autoHideDelay, celebrate, onDismiss]);
+  }, [autoHide, autoHideDelay, celebrate]);
 
   const handleDismiss = () => {
     setIsVisible(false);

--- a/components/gamification/StreakCalendar.tsx
+++ b/components/gamification/StreakCalendar.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import { useTranslations } from "next-intl";
 import type { XPEvent } from "@/lib/types/gamification";
+import { toLocalDateString } from "@/lib/gamification/daily-goals";
 
 interface StreakCalendarProps {
   xpHistory: XPEvent[];
@@ -17,7 +18,7 @@ function aggregateXPByDate(xpHistory: XPEvent[]): Map<string, number> {
   const dailyXP = new Map<string, number>();
 
   for (const event of xpHistory) {
-    const date = new Date(event.timestamp).toISOString().split("T")[0];
+    const date = toLocalDateString(new Date(event.timestamp));
     if (date) {
       // Cap individual event amounts to prevent corrupted data from skewing display
       const safeAmount = Math.min(event.amount, MAX_EVENT_XP);
@@ -61,7 +62,7 @@ function getCalendarDates(weeks: number): string[][] {
       const currentDate = new Date(startDate);
       currentDate.setDate(startDate.getDate() + (week * 7) + day);
       if (currentDate <= today) {
-        weekDates.push(currentDate.toISOString().split("T")[0]!);
+        weekDates.push(toLocalDateString(currentDate));
       }
     }
     if (weekDates.length > 0) {
@@ -96,33 +97,20 @@ export function StreakCalendar({ xpHistory, weeks = 16 }: StreakCalendarProps) {
 
   // Calculate streak
   const { currentStreak, totalDays } = useMemo(() => {
-    const today = new Date().toISOString().split("T")[0]!;
-    const sortedDates = [...dailyXP.keys()].sort().reverse();
-
     let streak = 0;
-    let checkDate = new Date();
+    const checkDate = new Date();
     checkDate.setHours(0, 0, 0, 0);
 
-    // Check if there's activity today or yesterday (to not break streak on current day)
-    const todayStr = checkDate.toISOString().split("T")[0]!;
-    const yesterdayDate = new Date(checkDate);
-    yesterdayDate.setDate(yesterdayDate.getDate() - 1);
-    const yesterdayStr = yesterdayDate.toISOString().split("T")[0]!;
-
-    if (!dailyXP.has(todayStr)) {
-      // No activity today, start counting from yesterday
+    // Don't break the streak just because there's no activity yet today: if
+    // today has no XP, start counting from yesterday.
+    if (!dailyXP.has(toLocalDateString(checkDate))) {
       checkDate.setDate(checkDate.getDate() - 1);
     }
 
-    // Count consecutive days
-    while (true) {
-      const dateStr = checkDate.toISOString().split("T")[0]!;
-      if (dailyXP.has(dateStr)) {
-        streak++;
-        checkDate.setDate(checkDate.getDate() - 1);
-      } else {
-        break;
-      }
+    // Count consecutive days backwards
+    while (dailyXP.has(toLocalDateString(checkDate))) {
+      streak++;
+      checkDate.setDate(checkDate.getDate() - 1);
     }
 
     return { currentStreak: streak, totalDays: dailyXP.size };

--- a/components/providers/ProgressProvider.tsx
+++ b/components/providers/ProgressProvider.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
 import { useProgress } from "@/hooks/useProgress";
+import { storageProvider } from "@/lib/storage";
 import type {
   UserProgress,
   ExamAttempt,
@@ -27,8 +28,11 @@ import { useGamification, type UseGamificationReturn } from "@/hooks/useGamifica
 type ProgressContextType = {
   progress: UserProgress | null;
   isLoading: boolean;
-  recordExam: (attempt: ExamAttempt) => Promise<void>;
+  recordExam: (attempt: ExamAttempt) => Promise<UserProgress | null>;
   recordQuestion: (attempt: QuestionAttempt) => Promise<void>;
+  recordQuestionWithGamification: (
+    attempt: QuestionAttempt
+  ) => Promise<GamificationResult>;
   recordQuestionBatch: (attempts: QuestionAttempt[]) => Promise<void>;
   recordQuestionWithSR: (
     category: string,
@@ -68,6 +72,20 @@ const ProgressContext = createContext<ProgressContextType | undefined>(
   undefined
 );
 
+/** Neutral gamification result used when gamification is disabled or absent. */
+function makeEmptyResult(level: number): GamificationResult {
+  return {
+    xpGained: 0,
+    xpEvents: [],
+    newAchievements: [],
+    levelUp: false,
+    previousLevel: level,
+    newLevel: level,
+    dailyGoalsCompleted: [],
+    allDailyGoalsComplete: false,
+  };
+}
+
 export function useProgressContext() {
   const context = useContext(ProgressContext);
   if (!context) {
@@ -88,101 +106,78 @@ export default function ProgressProvider({
 
   // Get gamification state from progress
   const gamificationState = progressData.progress?.gamification ?? null;
-  const gamification = useGamification(gamificationState);
+  const gamification = useGamification(gamificationState, progressData.progress?.stats);
+
+  // Run a gamification processor against the freshest persisted progress, then
+  // persist the result atomically. Reading fresh (instead of the possibly stale
+  // React snapshot) fixes achievement counts lagging by one activity and avoids
+  // clobbering concurrent writes.
+  const runGamification = useCallback(
+    async (
+      run: (
+        state: GamificationState,
+        progress: UserProgress
+      ) => { newState: GamificationState; result: GamificationResult }
+    ): Promise<GamificationResult> => {
+      const fresh = await storageProvider.getProgress();
+      const state = fresh?.gamification ?? null;
+
+      if (!fresh || !state || !state.settings.enabled) {
+        return makeEmptyResult(state?.currentLevel ?? 1);
+      }
+
+      const { newState, result } = run(state, fresh);
+      await progressData.updateGamificationState(newState);
+      setLastGamificationResult(result);
+      return result;
+    },
+    [progressData]
+  );
 
   // Record exam with gamification processing
   const recordExamWithGamification = useCallback(
     async (attempt: ExamAttempt, timeRemaining: number = 0): Promise<GamificationResult> => {
-      // First record the exam normally
+      // Record the exam first (updates stats/streak/history), then process
+      // gamification against the freshly-persisted progress.
       await progressData.recordExam(attempt);
-
-      // Then process gamification if enabled and state exists
-      if (gamificationState && gamificationState.settings.enabled && progressData.progress) {
-        const { newState, result } = processExamComplete(
-          gamificationState,
-          progressData.progress,
-          attempt,
-          timeRemaining
-        );
-
-        await progressData.updateGamificationState(newState);
-        setLastGamificationResult(result);
-        return result;
-      }
-
-      // Return empty result if gamification is disabled
-      const emptyResult: GamificationResult = {
-        xpGained: 0,
-        xpEvents: [],
-        newAchievements: [],
-        levelUp: false,
-        previousLevel: gamificationState?.currentLevel ?? 1,
-        newLevel: gamificationState?.currentLevel ?? 1,
-        dailyGoalsCompleted: [],
-        allDailyGoalsComplete: false,
-      };
-      return emptyResult;
+      return runGamification((state, progress) =>
+        processExamComplete(state, progress, attempt, timeRemaining)
+      );
     },
-    [progressData, gamificationState]
+    [progressData, runGamification]
+  );
+
+  // Record a single answered question (Browse / Flash) with gamification
+  const recordQuestionWithGamification = useCallback(
+    async (attempt: QuestionAttempt): Promise<GamificationResult> => {
+      // Persist the raw attempt first (question stats + study streak), then
+      // award XP / advance daily goals against the fresh progress.
+      await progressData.recordQuestion(attempt);
+      return runGamification((state, progress) =>
+        processQuestionAnswered(state, attempt.correct, progress)
+      );
+    },
+    [progressData, runGamification]
   );
 
   // Record smart practice session completion
   const recordSmartPracticeSession = useCallback(
     async (questionsCompleted: number): Promise<GamificationResult> => {
-      if (gamificationState && gamificationState.settings.enabled) {
-        const { newState, result } = processSmartPracticeSession(
-          gamificationState,
-          questionsCompleted
-        );
-
-        await progressData.updateGamificationState(newState);
-        setLastGamificationResult(result);
-        return result;
-      }
-
-      const emptyResult: GamificationResult = {
-        xpGained: 0,
-        xpEvents: [],
-        newAchievements: [],
-        levelUp: false,
-        previousLevel: gamificationState?.currentLevel ?? 1,
-        newLevel: gamificationState?.currentLevel ?? 1,
-        dailyGoalsCompleted: [],
-        allDailyGoalsComplete: false,
-      };
-      return emptyResult;
+      return runGamification((state, progress) =>
+        processSmartPracticeSession(state, questionsCompleted, progress)
+      );
     },
-    [progressData, gamificationState]
+    [runGamification]
   );
 
   // Record drill completion
   const recordDrillComplete = useCallback(
     async (correctAnswers: number, totalQuestions: number): Promise<GamificationResult> => {
-      if (gamificationState && gamificationState.settings.enabled) {
-        const { newState, result } = processDrillComplete(
-          gamificationState,
-          correctAnswers,
-          totalQuestions
-        );
-
-        await progressData.updateGamificationState(newState);
-        setLastGamificationResult(result);
-        return result;
-      }
-
-      const emptyResult: GamificationResult = {
-        xpGained: 0,
-        xpEvents: [],
-        newAchievements: [],
-        levelUp: false,
-        previousLevel: gamificationState?.currentLevel ?? 1,
-        newLevel: gamificationState?.currentLevel ?? 1,
-        dailyGoalsCompleted: [],
-        allDailyGoalsComplete: false,
-      };
-      return emptyResult;
+      return runGamification((state, progress) =>
+        processDrillComplete(state, correctAnswers, totalQuestions, progress)
+      );
     },
-    [progressData, gamificationState]
+    [runGamification]
   );
 
   // Toggle gamification enabled/disabled
@@ -212,6 +207,7 @@ export default function ProgressProvider({
     gamification,
     lastGamificationResult,
     recordExamWithGamification,
+    recordQuestionWithGamification,
     recordSmartPracticeSession,
     recordDrillComplete,
     setGamificationEnabled,

--- a/hooks/useGamification.ts
+++ b/hooks/useGamification.ts
@@ -10,6 +10,7 @@ import type {
   UnlockedAchievement,
 } from "@/lib/types/gamification";
 import { createInitialGamificationState } from "@/lib/types/gamification";
+import type { UserProgress } from "@/lib/types/progress";
 import { getLevelForXP, getXPProgress, getXPToNextLevel, LEVELS } from "@/lib/gamification/levels";
 import { ACHIEVEMENTS, getAchievementById, getVisibleAchievements, getAchievementProgress } from "@/lib/gamification/achievements";
 import { ensureTodayProgress } from "@/lib/gamification/daily-goals";
@@ -54,7 +55,8 @@ export interface UseGamificationReturn {
 }
 
 export function useGamification(
-  gamificationState: GamificationState | undefined | null
+  gamificationState: GamificationState | undefined | null,
+  progressStats?: UserProgress["stats"] | null
 ): UseGamificationReturn {
   const state = gamificationState ?? createInitialGamificationState();
 
@@ -112,19 +114,20 @@ export function useGamification(
       if (!achievement) return null;
 
       return getAchievementProgress(achievement, {
-        totalExams: 0, // These will be filled from progress context
-        totalPassed: 0,
+        totalExams: progressStats?.totalExams ?? 0,
+        totalPassed: progressStats?.totalPassed ?? 0,
         perfectScores: state.lifetimeStats.perfectScores,
         questionsAnswered: state.lifetimeStats.questionsAnswered,
         questionsCorrect: state.lifetimeStats.questionsCorrect,
-        longestStreak: 0,
+        longestStreak: progressStats?.longestStreak ?? 0,
         dailyGoalsCompleted: state.lifetimeStats.dailyGoalsCompleted,
+        dailyGoalSetsCompleted: state.lifetimeStats.dailyGoalSetsCompleted,
         smartPracticeSessions: state.lifetimeStats.smartPracticeSessions,
         currentLevel: state.currentLevel,
         categoriesAttempted: state.lifetimeStats.categoriesAttempted,
       });
     },
-    [state]
+    [state, progressStats]
   );
 
   const isAchievementUnlocked = useCallback(

--- a/hooks/useProgress.ts
+++ b/hooks/useProgress.ts
@@ -22,7 +22,7 @@ import {
 interface UseProgressReturn {
   progress: UserProgress | null;
   isLoading: boolean;
-  recordExam: (attempt: ExamAttempt) => Promise<void>;
+  recordExam: (attempt: ExamAttempt) => Promise<UserProgress | null>;
   recordQuestion: (attempt: QuestionAttempt) => Promise<void>;
   recordQuestionBatch: (attempts: QuestionAttempt[]) => Promise<void>;
   recordQuestionWithSR: (
@@ -69,12 +69,18 @@ export function useProgress(): UseProgressReturn {
     loadProgress();
   }, [loadProgress]);
 
-  const recordExam = useCallback(async (attempt: ExamAttempt) => {
-    await storageProvider.recordExamAttempt(attempt);
-    // Reload progress to get updated state
-    const updated = await storageProvider.getProgress();
-    setProgress(updated);
-  }, []);
+  const recordExam = useCallback(
+    async (attempt: ExamAttempt): Promise<UserProgress | null> => {
+      await storageProvider.recordExamAttempt(attempt);
+      // Reload progress to get updated state, and hand the fresh copy back so
+      // callers can process gamification against post-exam stats without racing
+      // the async React state update.
+      const updated = await storageProvider.getProgress();
+      setProgress(updated);
+      return updated;
+    },
+    []
+  );
 
   const recordQuestion = useCallback(async (attempt: QuestionAttempt) => {
     await storageProvider.recordQuestionAttempt(attempt);
@@ -163,16 +169,13 @@ export function useProgress(): UseProgressReturn {
 
   const updateGamificationState = useCallback(
     async (newState: GamificationState) => {
-      if (!progress) return;
-      const updated: UserProgress = {
-        ...progress,
-        gamification: newState,
-        lastUpdated: Date.now(),
-      };
-      await storageProvider.saveProgress(updated);
-      setProgress(updated);
+      // Merge atomically against the latest stored progress rather than the
+      // (possibly stale) in-memory snapshot, so we never clobber exam/question
+      // writes that landed after this hook last rendered.
+      const updated = await storageProvider.updateGamification(newState);
+      if (updated) setProgress(updated);
     },
-    [progress]
+    []
   );
 
   return {

--- a/lib/backup/import.ts
+++ b/lib/backup/import.ts
@@ -168,6 +168,10 @@ function mergeGamification(
           existing.lifetimeStats?.dailyGoalsCompleted || 0,
           imported.lifetimeStats?.dailyGoalsCompleted || 0
         ),
+        dailyGoalSetsCompleted: Math.max(
+          existing.lifetimeStats?.dailyGoalSetsCompleted || 0,
+          imported.lifetimeStats?.dailyGoalSetsCompleted || 0
+        ),
         fastFinishes: Math.max(
           existing.lifetimeStats?.fastFinishes || 0,
           imported.lifetimeStats?.fastFinishes || 0

--- a/lib/gamification/achievements.ts
+++ b/lib/gamification/achievements.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Achievement, AchievementCategory } from "@/lib/types/gamification";
-import { ACHIEVEMENT_XP } from "./xp";
+import { ACHIEVEMENT_XP, FAST_FINISH_SECONDS_REMAINING } from "./xp";
 
 export const ACHIEVEMENTS: Achievement[] = [
   // ===== MILESTONE (5) =====
@@ -97,7 +97,7 @@ export const ACHIEVEMENTS: Achievement[] = [
     category: "excellence",
     rarity: "uncommon",
     xpReward: ACHIEVEMENT_XP.uncommon,
-    condition: { type: "fast_finish", secondsRemaining: 1800 },
+    condition: { type: "fast_finish", secondsRemaining: FAST_FINISH_SECONDS_REMAINING },
   },
   {
     id: "comeback_kid",
@@ -140,7 +140,7 @@ export const ACHIEVEMENTS: Achievement[] = [
     category: "dedication",
     rarity: "uncommon",
     xpReward: ACHIEVEMENT_XP.uncommon,
-    condition: { type: "daily_goals_completed", count: 7 },
+    condition: { type: "daily_goal_sets_completed", count: 7 },
   },
   {
     id: "smart_learner",
@@ -219,6 +219,7 @@ export function getAchievementProgress(
     questionsCorrect: number;
     longestStreak: number;
     dailyGoalsCompleted: number;
+    dailyGoalSetsCompleted: number;
     smartPracticeSessions: number;
     currentLevel: number;
     categoriesAttempted: string[];
@@ -255,6 +256,10 @@ export function getAchievementProgress(
       break;
     case "daily_goals_completed":
       current = stats.dailyGoalsCompleted;
+      target = condition.count;
+      break;
+    case "daily_goal_sets_completed":
+      current = stats.dailyGoalSetsCompleted;
       target = condition.count;
       break;
     case "smart_practice_sessions":

--- a/lib/gamification/daily-goals.ts
+++ b/lib/gamification/daily-goals.ts
@@ -68,10 +68,35 @@ export function createDailyProgress(date: string): DailyProgress {
 }
 
 /**
- * Get today's date as YYYY-MM-DD string
+ * Format a Date as a YYYY-MM-DD string using the LOCAL calendar day.
+ *
+ * We deliberately avoid `toISOString()` here: that returns the UTC date, which
+ * shifts to the previous/next day for users at nonzero UTC offsets (including
+ * Portugal/WEST, the primary audience) and desynchronizes streaks, daily-goal
+ * rollover and the streak calendar from what the user perceives as "today".
+ */
+export function toLocalDateString(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Get today's date as YYYY-MM-DD string (local calendar day)
  */
 export function getTodayDateString(): string {
-  return new Date().toISOString().split("T")[0] ?? "";
+  return toLocalDateString(new Date());
+}
+
+/**
+ * Get the day before the given YYYY-MM-DD date, as a YYYY-MM-DD string.
+ */
+export function getYesterdayDateString(fromDate: string): string {
+  // Parse at local midnight so the -1 day arithmetic stays in the local calendar.
+  const d = new Date(`${fromDate}T00:00:00`);
+  d.setDate(d.getDate() - 1);
+  return toLocalDateString(d);
 }
 
 /**

--- a/lib/gamification/engine.ts
+++ b/lib/gamification/engine.ts
@@ -13,7 +13,7 @@ import type {
 } from "@/lib/types/gamification";
 import type { ExamAttempt, UserProgress } from "@/lib/types/progress";
 import { createInitialGamificationState } from "@/lib/types/gamification";
-import { XP_VALUES, calculateExamXP, calculateDailyStreakBonus, ACHIEVEMENT_XP } from "./xp";
+import { XP_VALUES, calculateExamXP, calculateDailyStreakBonus, ACHIEVEMENT_XP, FAST_FINISH_SECONDS_REMAINING } from "./xp";
 import { getLevelForXP } from "./levels";
 
 // Maximum XP allowed (safety cap to prevent corruption from bugs)
@@ -30,6 +30,7 @@ import {
   updateDailyGoalProgress,
   areAllDailyGoalsComplete,
   getTodayDateString,
+  getYesterdayDateString,
 } from "./daily-goals";
 
 /**
@@ -46,6 +47,69 @@ function createEmptyResult(state: GamificationState): GamificationResult {
     dailyGoalsCompleted: [],
     allDailyGoalsComplete: false,
   };
+}
+
+/**
+ * Evaluate achievements and fold any newly-unlocked ones into the state.
+ *
+ * Shared by every activity processor so achievements unlock as soon as their
+ * underlying stat advances — not only after the next exam. Pushes an
+ * `achievement_unlocked` XP event per unlock (into the caller's `events` array),
+ * adds the reward XP (capped) and rechecks the level. When `progress` is absent
+ * (e.g. pure unit tests) it is a no-op.
+ */
+function applyAchievements(
+  state: GamificationState,
+  progress: UserProgress | undefined,
+  events: XPEvent[],
+  timeRemaining: number,
+  now: number
+): { newState: GamificationState; unlocked: Achievement[] } {
+  if (!progress) {
+    return { newState: state, unlocked: [] };
+  }
+
+  const achievementResult = checkAchievements(state, progress, timeRemaining);
+  const newState = achievementResult.newState;
+
+  for (const achievement of achievementResult.unlocked) {
+    events.push({
+      type: "achievement_unlocked",
+      amount: achievement.xpReward,
+      timestamp: now,
+      metadata: { achievementId: achievement.id },
+    });
+    newState.totalXP = addXPSafely(newState.totalXP, achievement.xpReward);
+  }
+
+  newState.currentLevel = getLevelForXP(newState.totalXP).level;
+
+  return { newState, unlocked: achievementResult.unlocked };
+}
+
+/**
+ * Advance the consecutive-day daily-goal streak.
+ *
+ * Increments only when the previous all-goals-complete day was *yesterday*;
+ * resets to 1 after any gap (or on the very first completion). Without this the
+ * value was a lifetime count of all-goals days, inflating the streak-bonus XP
+ * and the number shown in the daily-goals card.
+ */
+function bumpDailyGoalStreak(
+  state: GamificationState,
+  today: string
+): GamificationState {
+  const yesterday = getYesterdayDateString(today);
+  let streak: number;
+  if (state.lastGoalCompletionDate === today) {
+    // Already counted today (guarded by bonusClaimed, but stay idempotent).
+    streak = state.dailyGoalStreak;
+  } else if (state.lastGoalCompletionDate === yesterday) {
+    streak = state.dailyGoalStreak + 1;
+  } else {
+    streak = 1;
+  }
+  return { ...state, dailyGoalStreak: streak, lastGoalCompletionDate: today };
 }
 
 /**
@@ -107,7 +171,7 @@ export function processExamComplete(
   }
 
   // Track fast finish (30+ min remaining)
-  if (timeRemaining >= 1800) {
+  if (timeRemaining >= FAST_FINISH_SECONDS_REMAINING) {
     newState.lifetimeStats = {
       ...newState.lifetimeStats,
       fastFinishes: newState.lifetimeStats.fastFinishes + 1,
@@ -163,10 +227,16 @@ export function processExamComplete(
 
   // Check for all daily goals complete bonus
   const allDailyComplete = areAllDailyGoalsComplete(newState.dailyProgress);
+  let bonusJustClaimed = false;
   if (allDailyComplete && !newState.dailyProgress.bonusClaimed) {
     events.push({ type: "daily_goals_all_bonus", amount: XP_VALUES.DAILY_GOALS_ALL_BONUS, timestamp: now });
     newState.dailyProgress = { ...newState.dailyProgress, bonusClaimed: true };
-    newState.dailyGoalStreak += 1;
+    bonusJustClaimed = true;
+    newState.lifetimeStats = {
+      ...newState.lifetimeStats,
+      dailyGoalSetsCompleted: newState.lifetimeStats.dailyGoalSetsCompleted + 1,
+    };
+    newState = bumpDailyGoalStreak(newState, today);
 
     // Daily streak bonus
     const streakBonus = calculateDailyStreakBonus(newState.dailyGoalStreak);
@@ -183,24 +253,10 @@ export function processExamComplete(
   newState.totalXP = addXPSafely(newState.totalXP, totalXP);
   newState.currentLevel = getLevelForXP(newState.totalXP).level;
 
-  // Check achievements
-  const achievementResult = checkAchievements(newState, progress, timeRemaining);
-  newState = achievementResult.newState;
-  newAchievements.push(...achievementResult.unlocked);
-
-  // Add achievement XP
-  for (const achievement of achievementResult.unlocked) {
-    events.push({
-      type: "achievement_unlocked",
-      amount: achievement.xpReward,
-      timestamp: now,
-      metadata: { achievementId: achievement.id },
-    });
-    newState.totalXP = addXPSafely(newState.totalXP, achievement.xpReward);
-  }
-
-  // Recheck level after achievement XP
-  newState.currentLevel = getLevelForXP(newState.totalXP).level;
+  // Check achievements (also adds their XP + rechecks level)
+  const achResult = applyAchievements(newState, progress, events, timeRemaining, now);
+  newState = achResult.newState;
+  newAchievements.push(...achResult.unlocked);
 
   // Update XP history (keep last 100)
   newState.xpHistory = [...events, ...newState.xpHistory].slice(0, 100);
@@ -208,14 +264,14 @@ export function processExamComplete(
   return {
     newState,
     result: {
-      xpGained: totalXP + achievementResult.unlocked.reduce((sum, a) => sum + a.xpReward, 0),
+      xpGained: totalXP + achResult.unlocked.reduce((sum, a) => sum + a.xpReward, 0),
       xpEvents: events,
       newAchievements,
       levelUp: newState.currentLevel > previousLevel,
       previousLevel,
       newLevel: newState.currentLevel,
       dailyGoalsCompleted: dailyResult.newlyCompleted,
-      allDailyGoalsComplete: allDailyComplete && !state.dailyProgress?.bonusClaimed,
+      allDailyGoalsComplete: bonusJustClaimed,
     },
   };
 }
@@ -226,6 +282,7 @@ export function processExamComplete(
 export function processQuestionAnswered(
   state: GamificationState,
   correct: boolean,
+  progress?: UserProgress,
   goalType: DailyGoalType = "questions_answered"
 ): { newState: GamificationState; result: GamificationResult } {
   if (!state.settings.enabled) {
@@ -275,10 +332,16 @@ export function processQuestionAnswered(
 
   // Check for all daily goals complete
   const allDailyComplete = areAllDailyGoalsComplete(newState.dailyProgress);
+  let bonusJustClaimed = false;
   if (allDailyComplete && !newState.dailyProgress.bonusClaimed) {
     events.push({ type: "daily_goals_all_bonus", amount: XP_VALUES.DAILY_GOALS_ALL_BONUS, timestamp: now });
     newState.dailyProgress = { ...newState.dailyProgress, bonusClaimed: true };
-    newState.dailyGoalStreak += 1;
+    bonusJustClaimed = true;
+    newState.lifetimeStats = {
+      ...newState.lifetimeStats,
+      dailyGoalSetsCompleted: newState.lifetimeStats.dailyGoalSetsCompleted + 1,
+    };
+    newState = bumpDailyGoalStreak(newState, today);
   }
 
   // Calculate total XP (questions don't earn XP directly outside exams, only through goals)
@@ -287,19 +350,23 @@ export function processQuestionAnswered(
 
   newState.totalXP = addXPSafely(newState.totalXP, totalXP);
   newState.currentLevel = getLevelForXP(newState.totalXP).level;
+
+  // Check achievements (streak/level/question milestones can unlock here too)
+  const ach = applyAchievements(newState, progress, events, 0, now);
+  newState = ach.newState;
   newState.xpHistory = [...events, ...newState.xpHistory].slice(0, 100);
 
   return {
     newState,
     result: {
-      xpGained: totalXP,
+      xpGained: totalXP + ach.unlocked.reduce((sum, a) => sum + a.xpReward, 0),
       xpEvents: events,
-      newAchievements: [],
+      newAchievements: ach.unlocked,
       levelUp: newState.currentLevel > previousLevel,
       previousLevel,
       newLevel: newState.currentLevel,
       dailyGoalsCompleted: dailyResult.newlyCompleted,
-      allDailyGoalsComplete: allDailyComplete && !state.dailyProgress?.bonusClaimed,
+      allDailyGoalsComplete: bonusJustClaimed,
     },
   };
 }
@@ -309,7 +376,8 @@ export function processQuestionAnswered(
  */
 export function processSmartPracticeSession(
   state: GamificationState,
-  questionsCompleted: number
+  questionsCompleted: number,
+  progress?: UserProgress
 ): { newState: GamificationState; result: GamificationResult } {
   if (!state.settings.enabled) {
     return { newState: state, result: createEmptyResult(state) };
@@ -350,14 +418,18 @@ export function processSmartPracticeSession(
 
   newState.totalXP = addXPSafely(newState.totalXP, totalXP);
   newState.currentLevel = getLevelForXP(newState.totalXP).level;
+
+  // Check achievements (smart_learner and level/xp milestones can unlock here)
+  const ach = applyAchievements(newState, progress, events, 0, now);
+  newState = ach.newState;
   newState.xpHistory = [...events, ...newState.xpHistory].slice(0, 100);
 
   return {
     newState,
     result: {
-      xpGained: totalXP,
+      xpGained: totalXP + ach.unlocked.reduce((sum, a) => sum + a.xpReward, 0),
       xpEvents: events,
-      newAchievements: [],
+      newAchievements: ach.unlocked,
       levelUp: newState.currentLevel > previousLevel,
       previousLevel,
       newLevel: newState.currentLevel,
@@ -373,7 +445,8 @@ export function processSmartPracticeSession(
 export function processDrillComplete(
   state: GamificationState,
   correctAnswers: number,
-  totalQuestions: number
+  totalQuestions: number,
+  progress?: UserProgress
 ): { newState: GamificationState; result: GamificationResult } {
   if (!state.settings.enabled) {
     return { newState: state, result: createEmptyResult(state) };
@@ -438,10 +511,16 @@ export function processDrillComplete(
 
   // Check for all daily goals complete
   const allDailyComplete = areAllDailyGoalsComplete(newState.dailyProgress);
+  let bonusJustClaimed = false;
   if (allDailyComplete && !newState.dailyProgress.bonusClaimed) {
     events.push({ type: "daily_goals_all_bonus", amount: XP_VALUES.DAILY_GOALS_ALL_BONUS, timestamp: now });
     newState.dailyProgress = { ...newState.dailyProgress, bonusClaimed: true };
-    newState.dailyGoalStreak += 1;
+    bonusJustClaimed = true;
+    newState.lifetimeStats = {
+      ...newState.lifetimeStats,
+      dailyGoalSetsCompleted: newState.lifetimeStats.dailyGoalSetsCompleted + 1,
+    };
+    newState = bumpDailyGoalStreak(newState, today);
 
     const streakBonus = calculateDailyStreakBonus(newState.dailyGoalStreak);
     if (streakBonus > 0) {
@@ -454,19 +533,23 @@ export function processDrillComplete(
 
   newState.totalXP = addXPSafely(newState.totalXP, totalXP);
   newState.currentLevel = getLevelForXP(newState.totalXP).level;
+
+  // Check achievements (drill milestones, streak/level/xp can unlock here)
+  const ach = applyAchievements(newState, progress, events, 0, now);
+  newState = ach.newState;
   newState.xpHistory = [...events, ...newState.xpHistory].slice(0, 100);
 
   return {
     newState,
     result: {
-      xpGained: totalXP,
+      xpGained: totalXP + ach.unlocked.reduce((sum, a) => sum + a.xpReward, 0),
       xpEvents: events,
-      newAchievements: [],
+      newAchievements: ach.unlocked,
       levelUp: newState.currentLevel > previousLevel,
       previousLevel,
       newLevel: newState.currentLevel,
       dailyGoalsCompleted: dailyResult.newlyCompleted,
-      allDailyGoalsComplete: allDailyComplete && !state.dailyProgress?.bonusClaimed,
+      allDailyGoalsComplete: bonusJustClaimed,
     },
   };
 }
@@ -542,6 +625,8 @@ function evaluateCondition(
       return progress.stats.longestStreak >= condition.count;
     case "daily_goals_completed":
       return state.lifetimeStats.dailyGoalsCompleted >= condition.count;
+    case "daily_goal_sets_completed":
+      return state.lifetimeStats.dailyGoalSetsCompleted >= condition.count;
     case "smart_practice_sessions":
       return state.lifetimeStats.smartPracticeSessions >= condition.count;
     case "level_reached":
@@ -645,8 +730,22 @@ export function migrateToGamification(
 
   // Award XP for past activity (simplified: 5 XP per correct answer)
   const retroactiveXP = questionsCorrect * 5 + progress.stats.totalPassed * 50;
-  state.totalXP = retroactiveXP;
-  state.currentLevel = getLevelForXP(retroactiveXP).level;
+  state.totalXP = addXPSafely(0, retroactiveXP);
+  state.currentLevel = getLevelForXP(state.totalXP).level;
 
-  return state;
+  // Retroactively unlock achievements the user already earned. Mark them as
+  // already notified so returning users are not flooded with toasts on the
+  // first load after this migration.
+  const { newState: withAchievements, unlocked } = checkAchievements(state, progress, 0);
+  const finalState = withAchievements;
+  for (const achievement of unlocked) {
+    finalState.totalXP = addXPSafely(finalState.totalXP, achievement.xpReward);
+  }
+  finalState.currentLevel = getLevelForXP(finalState.totalXP).level;
+  finalState.unlockedAchievements = finalState.unlockedAchievements.map((ua) => ({
+    ...ua,
+    notified: true,
+  }));
+
+  return finalState;
 }

--- a/lib/gamification/xp.ts
+++ b/lib/gamification/xp.ts
@@ -21,6 +21,13 @@ export const XP_VALUES = {
   DRILL_PERFECT: 25,
 } as const;
 
+/**
+ * Seconds remaining on the exam clock that qualifies as a "fast finish"
+ * (30+ minutes). Single source of truth shared by the engine (which counts
+ * fast finishes) and the speed_demon achievement definition.
+ */
+export const FAST_FINISH_SECONDS_REMAINING = 1800;
+
 export const ACHIEVEMENT_XP: Record<AchievementRarity, number> = {
   common: 25,
   uncommon: 50,

--- a/lib/storage/localStorage.ts
+++ b/lib/storage/localStorage.ts
@@ -15,6 +15,8 @@ import {
 } from "@/lib/types/progress";
 import { migrateToGamification } from "@/lib/gamification/engine";
 import { createInitialGamificationState } from "@/lib/types/gamification";
+import type { GamificationState } from "@/lib/types/gamification";
+import { getTodayDateString } from "@/lib/gamification/daily-goals";
 import { convertLegacyExport } from "@/lib/backup/legacy-import";
 
 const STORAGE_KEY = "hamradio_progress";
@@ -149,12 +151,20 @@ export function migrateProgress(progress: UserProgress): UserProgress {
     migrated.gamification = createInitialGamificationState();
   }
 
+  // V3 -> V4: Added lastGoalCompletionDate (consecutive-day daily-goal streak)
+  // and lifetimeStats.dailyGoalSetsCompleted (days with all goals complete).
+  // Backfill both for states that predate the fields.
+  if (migrated.version < 4) {
+    if (migrated.gamification.lastGoalCompletionDate === undefined) {
+      migrated.gamification.lastGoalCompletionDate = null;
+    }
+    if (migrated.gamification.lifetimeStats.dailyGoalSetsCompleted === undefined) {
+      migrated.gamification.lifetimeStats.dailyGoalSetsCompleted = 0;
+    }
+  }
+
   migrated.version = PROGRESS_VERSION;
   return migrated;
-}
-
-function getTodayDateString(): string {
-  return new Date().toISOString().split("T")[0] ?? "";
 }
 
 function updateStreak(stats: UserProgress["stats"]): void {
@@ -252,6 +262,17 @@ async function clearProgress(): Promise<void> {
   localStorage.removeItem(STORAGE_KEY);
 }
 
+async function updateGamification(
+  newState: GamificationState
+): Promise<UserProgress | null> {
+  const progress = await getProgress();
+  if (!progress) return null;
+
+  progress.gamification = newState;
+  await saveProgress(progress);
+  return progress;
+}
+
 /**
  * Update spaced repetition stats for a specific question
  * Used by Smart Practice mode to track review intervals
@@ -301,6 +322,7 @@ export const localStorageProvider: StorageProvider = {
   recordExamAttempt,
   recordQuestionAttempt,
   clearProgress,
+  updateGamification,
 };
 
 // Utility functions for accessing specific stats

--- a/lib/types/gamification.ts
+++ b/lib/types/gamification.ts
@@ -64,6 +64,7 @@ export type AchievementCondition =
   | { type: "xp_total"; amount: number }
   | { type: "level_reached"; level: number }
   | { type: "daily_goals_completed"; count: number }
+  | { type: "daily_goal_sets_completed"; count: number }
   | { type: "fast_finish"; secondsRemaining: number }
   | { type: "comeback" };
 
@@ -117,7 +118,10 @@ export interface LifetimeStats {
   smartPracticeSessions: number;
   drillsCompleted: number;
   drillsPerfect: number;
+  /** Count of individual daily goals completed (multiple per day). */
   dailyGoalsCompleted: number;
+  /** Count of days where ALL daily goals were completed (one "set" per day). */
+  dailyGoalSetsCompleted: number;
   fastFinishes: number;
   comebacks: number;
   categoriesAttempted: string[];
@@ -138,6 +142,9 @@ export interface GamificationState {
   achievementProgress: Record<string, number>;
   dailyProgress: DailyProgress | null;
   dailyGoalStreak: number;
+  /** YYYY-MM-DD of the last day all daily goals were completed (drives the
+   *  consecutive-day streak reset). Null until the first all-goals-complete day. */
+  lastGoalCompletionDate: string | null;
   lifetimeStats: LifetimeStats;
   lastActivityDate: string | null;
 }
@@ -166,6 +173,7 @@ export function createInitialLifetimeStats(): LifetimeStats {
     drillsCompleted: 0,
     drillsPerfect: 0,
     dailyGoalsCompleted: 0,
+    dailyGoalSetsCompleted: 0,
     fastFinishes: 0,
     comebacks: 0,
     categoriesAttempted: [],
@@ -188,6 +196,7 @@ export function createInitialGamificationState(): GamificationState {
     achievementProgress: {},
     dailyProgress: null,
     dailyGoalStreak: 0,
+    lastGoalCompletionDate: null,
     lifetimeStats: createInitialLifetimeStats(),
     lastActivityDate: null,
   };

--- a/lib/types/progress.ts
+++ b/lib/types/progress.ts
@@ -71,9 +71,17 @@ export interface StorageProvider {
   recordExamAttempt(attempt: ExamAttempt): Promise<void>;
   recordQuestionAttempt(attempt: QuestionAttempt): Promise<void>;
   clearProgress(): Promise<void>;
+  /**
+   * Atomically merge a new gamification state into the persisted progress:
+   * re-reads the latest stored progress, replaces only `gamification`, and
+   * saves. Prevents a stale in-memory snapshot from clobbering exam/question
+   * writes that landed after it was read. Returns the merged progress (or null
+   * if there is nothing stored to merge into).
+   */
+  updateGamification(newState: GamificationState): Promise<UserProgress | null>;
 }
 
-export const PROGRESS_VERSION = 3;
+export const PROGRESS_VERSION = 4;
 
 // SM-2 Algorithm Constants
 export const SM2_CONFIG = {


### PR DESCRIPTION
## Summary

A multi-agent review of the gamification system surfaced a data-safety flaw plus a cluster of correctness and wiring gaps. This PR resolves the full set (1 HIGH, 5 MEDIUM, 6 LOW).

The two most serious issues share one root cause: **stale React-state closures in `ProgressProvider`/`useProgress` combined with full-object `saveProgress` overwrites.** An atomic storage-layer merge + returning fresh progress from `recordExam` neutralizes both.

## HIGH
- **Enabling gamification silently clobbered just-saved exam/question data.** Added an atomic `storageProvider.updateGamification()` (re-read latest → merge only `gamification` → save) and routed `updateGamificationState` through it. `recordExam` now returns fresh post-exam progress. The exam page sequences the exam+gamification write before the per-question batch so they no longer race on localStorage.

## MEDIUM
- Achievements now evaluate on **every** activity (drill / smart-practice / browse / flash), not just after an exam, via a shared `applyAchievements()` helper; `migrateToGamification` also runs a retroactive pass (marked notified to avoid toast spam).
- Exam/pass/streak achievements no longer unlock **one exam late** (evaluated against fresh post-exam stats).
- `dailyGoalStreak` is now a real **consecutive-day** streak (`lastGoalCompletionDate` + reset-on-gap) instead of a lifetime count.
- `StreakCalendar` and `getTodayDateString` use the **local calendar day** (`toLocalDateString`) instead of UTC, fixing streak/goal rollover for nonzero UTC offsets (incl. Portugal/WEST). Consolidated the duplicated date helper.
- **Browse and Flash** answers now award XP / advance daily goals via `recordQuestionWithGamification` (`processQuestionAnswered` was imported but never called).

## LOW
- `daily_champion` counts completed goal **sets** (`dailyGoalSetsCompleted`), matching its "7 sets" copy, instead of individual goals (was firing ~3× early).
- `useGamification` threads real `progress.stats` into `getAchievementProgress` (was hardcoded to 0).
- Extracted `FAST_FINISH_SECONDS_REMAINING` as the single source of truth for the fast-finish threshold.
- `allDailyGoalsComplete` result flag reflects the bonus **just claimed** this call (fixes stale read on day rollover).
- `AchievementToast` keeps `onDismiss` in a ref so the 5s auto-hide timer no longer restarts on parent re-render.

## Migration
Bumped `PROGRESS_VERSION` 3 → 4 with backfill for the new `lastGoalCompletionDate` and `dailyGoalSetsCompleted` fields (import-merge handles them too).

## Testing
Added engine unit tests (streak reset, cross-activity achievements, goal-sets/bonus flag) and browse/flash wiring contract tests.

- `bun run type-check` ✅
- `bun run test` — 190 passed ✅
- `bun run lint` ✅
- `bun run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)