### PR TITLE
Disable gamification behind a build flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,15 @@
 # cp .env.example .env.local
 
 # ===========================================
+# Feature Flags (build time)
+# ===========================================
+# Gamification: XP, levels, achievements, daily goals, streak calendar.
+# Disabled unless set to exactly "true". Read at BUILD time and inlined into
+# the bundle, so changing it requires a rebuild — restarting is not enough.
+# Saved XP/achievements in localStorage are untouched while it is off.
+# NEXT_PUBLIC_GAMIFICATION=true
+
+# ===========================================
 # Exam Submission (Resend Email)
 # ===========================================
 # Get your API key from https://resend.com/api-keys

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,3 +93,24 @@ RESEND_FROM_EMAIL=        # Sender email (default: onboarding@resend.dev)
 ```
 
 Only needed for the `/submit-exam` feature. The app runs fully without them.
+
+### Feature flags
+
+```
+NEXT_PUBLIC_GAMIFICATION=  # "true" enables gamification; anything else disables it
+```
+
+Build-time flags live in `lib/config/features.ts`. Next inlines `NEXT_PUBLIC_*`
+at build time, so the constants collapse to literals — **changing a flag needs a
+rebuild, not just a restart**. Keep the `process.env.X` access written out
+literally; destructuring defeats the inlining. The flags gate behaviour, not
+bundle size: disabling gamification does not measurably shrink the client
+bundle, since `useGamification` runs on every page and imports the achievement
+data unconditionally.
+
+Gamification is **off by default**. It is gated at two choke points —
+`isEnabled` in `hooks/useGamification.ts` (drives all UI) and `runGamification`
+in `ProgressProvider` (drives all XP/achievement writes) — plus the dashboard
+blocks. `lib/gamification/engine.ts` is deliberately not gated, so its tests run
+independently of the flag. Existing localStorage progress is preserved while
+off.

--- a/__tests__/unit/test-gamification-feature-flag.test.ts
+++ b/__tests__/unit/test-gamification-feature-flag.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests: gamification build flag
+ *
+ * `GAMIFICATION_ENABLED` is inlined at build time, so these tests stub the
+ * config module and re-import the consumers to exercise both builds.
+ *
+ * The invariant that matters: the build flag must win over the user's stored
+ * `settings.enabled`. A disabled build has no UI to turn gamification back on,
+ * so saved state saying "enabled" must not resurrect it.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import {
+  createInitialGamificationState,
+  type GamificationState,
+} from "@/lib/types/gamification";
+
+/** Re-imports the hook with the build flag stubbed, and returns `isEnabled`. */
+async function isEnabledWithFlag(
+  flag: boolean,
+  state: GamificationState | null
+): Promise<boolean> {
+  vi.resetModules();
+  vi.doMock("@/lib/config/features", () => ({ GAMIFICATION_ENABLED: flag }));
+  const { useGamification } = await import("@/hooks/useGamification");
+  const { result } = renderHook(() => useGamification(state));
+  return result.current.isEnabled;
+}
+
+afterEach(() => {
+  vi.doUnmock("@/lib/config/features");
+  vi.resetModules();
+});
+
+describe("Gamification build flag", () => {
+  it("reports disabled when the build flag is off, even if stored state is enabled", async () => {
+    const state = createInitialGamificationState();
+    expect(state.settings.enabled).toBe(true); // stored state says on
+
+    expect(await isEnabledWithFlag(false, state)).toBe(false);
+  });
+
+  it("respects stored state when the build flag is on", async () => {
+    const state = createInitialGamificationState();
+
+    expect(await isEnabledWithFlag(true, state)).toBe(true);
+  });
+
+  it("stays disabled when the build flag is on but the user turned it off", async () => {
+    const state = createInitialGamificationState();
+    state.settings.enabled = false;
+
+    expect(await isEnabledWithFlag(true, state)).toBe(false);
+  });
+
+  it("defaults to disabled for missing state when the build flag is off", async () => {
+    expect(await isEnabledWithFlag(false, null)).toBe(false);
+  });
+});

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,7 +3,7 @@
 import { useTranslations } from "next-intl";
 import { useProgressContext } from "@/components/providers/ProgressProvider";
 import { PageLoading } from "@/components/shared/Loading";
-import { CATEGORIES, CATEGORY_CONFIG } from "@/lib/config";
+import { CATEGORIES, CATEGORY_CONFIG, GAMIFICATION_ENABLED } from "@/lib/config";
 import type { CategoryId } from "@/lib/config/categories";
 import { loadData } from "@/lib/data";
 import { useEffect, useMemo, useState } from "react";
@@ -123,7 +123,10 @@ export default function DashboardPage() {
     .map(ua => ACHIEVEMENTS.find(a => a.id === ua.achievementId))
     .filter((a): a is typeof ACHIEVEMENTS[number] => a !== undefined) ?? [];
 
-  const gamificationEnabled = gamification?.isEnabled ?? true;
+  // `?? true` keeps the pre-existing default-on behaviour while progress is
+  // still loading, so the build flag has to be applied on top of it here.
+  const gamificationEnabled =
+    GAMIFICATION_ENABLED && (gamification?.isEnabled ?? true);
   const hasActivity = stats.totalExams > 0 || (gamification?.totalXP ?? 0) > 0;
 
   // New user — show onboarding instead of empty data grids
@@ -207,10 +210,12 @@ export default function DashboardPage() {
 
   return (
     <section className="-mx-4 sm:mx-0 pb-8">
-      <AchievementToastContainer
-        achievements={pendingAchievements}
-        onDismiss={handleDismissAchievement}
-      />
+      {GAMIFICATION_ENABLED && (
+        <AchievementToastContainer
+          achievements={pendingAchievements}
+          onDismiss={handleDismissAchievement}
+        />
+      )}
 
       {/* Header */}
       <div className="px-4 sm:px-0 py-4">
@@ -289,8 +294,9 @@ export default function DashboardPage() {
         </div>
       )}
 
-      {/* Gamification Disabled Banner */}
-      {!gamificationEnabled && (
+      {/* Gamification Disabled Banner — only when the user turned it off; a
+          build without gamification has no way to act on the Enable button. */}
+      {GAMIFICATION_ENABLED && !gamificationEnabled && (
         <div className="mx-4 sm:mx-0 mb-6 p-4 bg-slate-100 dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700">
           <div className="flex items-center justify-between">
             <div>

--- a/components/providers/ProgressProvider.tsx
+++ b/components/providers/ProgressProvider.tsx
@@ -24,6 +24,7 @@ import {
   markAchievementsNotified,
 } from "@/lib/gamification/engine";
 import { useGamification, type UseGamificationReturn } from "@/hooks/useGamification";
+import { GAMIFICATION_ENABLED } from "@/lib/config/features";
 
 type ProgressContextType = {
   progress: UserProgress | null;
@@ -119,6 +120,13 @@ export default function ProgressProvider({
         progress: UserProgress
       ) => { newState: GamificationState; result: GamificationResult }
     ): Promise<GamificationResult> => {
+      // Bail before touching storage when gamification is compiled out, so a
+      // disabled build never writes XP or achievements — existing saved
+      // progress stays exactly as it was and returns intact if the flag flips.
+      if (!GAMIFICATION_ENABLED) {
+        return makeEmptyResult(1);
+      }
+
       const fresh = await storageProvider.getProgress();
       const state = fresh?.gamification ?? null;
 

--- a/hooks/useGamification.ts
+++ b/hooks/useGamification.ts
@@ -11,6 +11,7 @@ import type {
 } from "@/lib/types/gamification";
 import { createInitialGamificationState } from "@/lib/types/gamification";
 import type { UserProgress } from "@/lib/types/progress";
+import { GAMIFICATION_ENABLED } from "@/lib/config/features";
 import { getLevelForXP, getXPProgress, getXPToNextLevel, LEVELS } from "@/lib/gamification/levels";
 import { ACHIEVEMENTS, getAchievementById, getVisibleAchievements, getAchievementProgress } from "@/lib/gamification/achievements";
 import { ensureTodayProgress } from "@/lib/gamification/daily-goals";
@@ -60,7 +61,10 @@ export function useGamification(
 ): UseGamificationReturn {
   const state = gamificationState ?? createInitialGamificationState();
 
-  const isEnabled = state.settings.enabled;
+  // The build flag wins over the user's stored setting: when gamification is
+  // compiled out there is no way to turn it back on, so every consumer of
+  // `isEnabled` must see false regardless of what localStorage says.
+  const isEnabled = GAMIFICATION_ENABLED && state.settings.enabled;
   // Apply sanity check to prevent displaying corrupted XP values
   // This can happen if a bug causes XP to be added repeatedly
   const totalXP = Math.min(state.totalXP, MAX_REASONABLE_XP);

--- a/lib/config/features.ts
+++ b/lib/config/features.ts
@@ -1,0 +1,28 @@
+/**
+ * Build-time feature flags
+ *
+ * Next.js inlines `process.env.NEXT_PUBLIC_*` at build time, so each constant
+ * below collapses to a literal `true`/`false` and the guarded branches are
+ * decided at compile time rather than per render. Flipping a flag therefore
+ * requires a rebuild, not just a restart.
+ *
+ * The `process.env.X` access must stay written out literally for the inlining
+ * to happen — destructuring or dynamic lookup silently defeats it.
+ *
+ * NOTE: this does *not* currently shrink the bundle. Measured builds differ by
+ * ~100 bytes with gamification off, because `useGamification` runs on every
+ * page via ProgressProvider and statically imports the achievement/level data,
+ * so nothing becomes unreachable enough to tree-shake. The flags are a
+ * behavioural kill switch, not a code-splitting mechanism.
+ */
+
+/**
+ * Gamification (XP, levels, achievements, daily goals, streak calendar).
+ * Disabled unless `NEXT_PUBLIC_GAMIFICATION=true` at build time.
+ *
+ * When off, no XP or achievements are awarded and none of the gamification UI
+ * renders. Any progress already in localStorage is left untouched, so turning
+ * the flag back on restores it.
+ */
+export const GAMIFICATION_ENABLED =
+  process.env.NEXT_PUBLIC_GAMIFICATION === "true";

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -2,6 +2,7 @@
  * Config module barrel export
  */
 export * from './exam';
+export * from './features';
 export * from './categories';
 export * from './external-links';
 export * from './calculators';


### PR DESCRIPTION
## Summary

Puts gamification (XP, levels, achievements, daily goals, streak calendar) behind a build-time flag, **off by default**. Set `NEXT_PUBLIC_GAMIFICATION=true` at build time to turn it back on.

New `lib/config/features.ts` holds build-time flags, following the existing `lib/config/` pattern. Next inlines `NEXT_PUBLIC_*` env vars, so the constant resolves at compile time — **flipping it requires a rebuild, not just a restart**.

## Approach

The codebase already had a single runtime kill switch (`gamification.settings.enabled`) that everything funnels through, so this gates the two existing choke points rather than every call site:

- **`hooks/useGamification.ts`** — the build flag now wins over the stored `settings.enabled`, so every consumer of `isEnabled` (dashboard, exam results via `ExamResults`) turns off together. A disabled build offers no way to re-enable, so saved state saying "enabled" must not resurrect it.
- **`ProgressProvider.runGamification`** — returns early *before* reading storage, so a disabled build never writes XP or achievements. All four processors (exam, question, smart practice, drill) route through it.

`app/dashboard/page.tsx` additionally hides the XP bar, streak calendar, daily goals, achievements grid, toasts and the ⚙ settings toggle. The "gamification disabled" banner is kept only for the *runtime* toggle, since its **Enable** button cannot work in a disabled build. Its `?? true` fallback defaulted to on while progress loads, so the flag is applied there explicitly.

`lib/gamification/engine.ts` and the types are deliberately untouched, so the existing engine and wiring test files pass unchanged.

Saved progress in localStorage is left intact and returns if the flag is turned back on.

## Not a bundle-size win

Worth being explicit, since it's the natural assumption about a `NEXT_PUBLIC_*` flag: this is a **behavioural kill switch, not code splitting**. Measured client bundles:

| Build | `.next/static` |
| --- | --- |
| flag off | 3,877,765 bytes |
| flag on | 3,877,664 bytes |

~100 bytes, i.e. the inlined literal. Gamification code is not tree-shaken because `useGamification` runs on every page via `ProgressProvider` and imports the achievement/level data unconditionally (and there's no `sideEffects: false` in `package.json`). Getting actual elimination would need a deeper refactor — restructuring the hook and lazy-loading the dashboard section. Noted in `lib/config/features.ts` and `CLAUDE.md` so the assumption isn't made later.

## Verification

- `bun run type-check` ✓
- `bun run lint` ✓
- `bun run test` → 196 passed ✓ (4 new: stub the flag module and assert both build states, including that stored `enabled: true` cannot override a disabled build)
- `bun run build` ✓ with the flag both **off** and **on**

Docs updated: `.env.example` and a feature-flags section in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)