### PR TITLE
Fix nav wrapping between md and lg, drop Estado da Escola from the bar

### DIFF
--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Link from "next/link";
-import { Home, BookOpen, FileText, Upload, Menu, GraduationCap, BarChart3, Settings, Globe, Zap, Radio, TrendingUp, School } from "lucide-react";
+import { Home, BookOpen, FileText, Upload, Menu, GraduationCap, BarChart3, Settings, Globe, Zap, Radio, TrendingUp } from "lucide-react";
 import {
   Sheet,
   SheetContent,
@@ -223,15 +223,6 @@ export default function MobileNav({ open, onOpenChange }: MobileNavProps) {
             {t("nationStatus")}
           </Link>
 
-          {/* Estado da Escola */}
-          <Link
-            href="/estado-da-escola"
-            onClick={closeMenu}
-            className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
-          >
-            <School className="h-4 w-4" />
-            {t("schoolStatus")}
-          </Link>
 
           {/* Become Ham Link */}
           <Link

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -43,7 +43,7 @@ export default function MobileNav({ open, onOpenChange }: MobileNavProps) {
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetTrigger asChild className="md:hidden">
+      <SheetTrigger asChild className="lg:hidden">
         <button
           type="button"
           className="inline-flex h-9 w-9 items-center justify-center rounded-md text-slate-700 transition-colors hover:bg-slate-200 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-slate-100"

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -21,7 +21,7 @@ import { useCalculators } from "@/components/providers/CalculatorProvider";
 import { CATEGORIES, CATEGORY_CONFIG } from "@/lib/config/categories";
 import type { CalculatorCode } from "@/lib/types";
 
-const triggerClasses = "inline-flex h-9 items-center justify-center rounded-md px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-200 hover:text-slate-900 focus:bg-slate-200 focus:text-slate-900 focus:outline-none data-[state=open]:bg-slate-200 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-slate-100 dark:focus:bg-slate-700 dark:focus:text-slate-100 dark:data-[state=open]:bg-slate-700";
+const triggerClasses = "inline-flex h-9 whitespace-nowrap items-center justify-center rounded-md px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-200 hover:text-slate-900 focus:bg-slate-200 focus:text-slate-900 focus:outline-none data-[state=open]:bg-slate-200 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-slate-100 dark:focus:bg-slate-700 dark:focus:text-slate-100 dark:data-[state=open]:bg-slate-700";
 
 export default function NavBar() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -38,16 +38,16 @@ export default function NavBar() {
   return (
     <header className="sticky top-0 z-50 border-b border-slate-200/50 bg-slate-50/70 backdrop-blur-xl dark:border-slate-700/50 dark:bg-slate-900/70">
       <div className="container mx-auto flex h-14 items-center justify-between px-4">
-        <Link href="/" className="logo-link flex items-center gap-2 font-bold text-lg text-slate-800 transition-colors hover:text-amber-700 dark:text-slate-100 dark:hover:text-amber-300">
+        <Link href="/" className="logo-link flex shrink-0 items-center gap-2 whitespace-nowrap font-bold text-lg text-slate-800 transition-colors hover:text-amber-700 dark:text-slate-100 dark:hover:text-amber-300">
           <Radio className="logo-radio-icon h-5 w-5 text-amber-600 dark:text-amber-400" />
           <span className="tracking-tight">Rádio Escola</span>
         </Link>
 
         {/* Desktop Navigation */}
-        <nav className="hidden md:flex items-center gap-1">
+        <nav className="hidden lg:flex items-center gap-1">
           <Link
             href="/"
-            className="inline-flex h-9 items-center justify-center rounded-md px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-200 hover:text-slate-900 focus:bg-slate-200 focus:text-slate-900 focus:outline-none dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-slate-100 dark:focus:bg-slate-700 dark:focus:text-slate-100"
+            className="inline-flex h-9 whitespace-nowrap items-center justify-center rounded-md px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-200 hover:text-slate-900 focus:bg-slate-200 focus:text-slate-900 focus:outline-none dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-slate-100 dark:focus:bg-slate-700 dark:focus:text-slate-100"
           >
             <Home className="mr-2 h-4 w-4" />
             {t("home")}
@@ -181,7 +181,7 @@ export default function NavBar() {
 
           <Link
             href="/estado-da-nacao"
-            className="inline-flex h-9 items-center justify-center rounded-md px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-200 hover:text-slate-900 focus:bg-slate-200 focus:text-slate-900 focus:outline-none dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-slate-100 dark:focus:bg-slate-700 dark:focus:text-slate-100"
+            className="inline-flex h-9 whitespace-nowrap items-center justify-center rounded-md px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-200 hover:text-slate-900 focus:bg-slate-200 focus:text-slate-900 focus:outline-none dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-slate-100 dark:focus:bg-slate-700 dark:focus:text-slate-100"
           >
             <TrendingUp className="mr-2 h-4 w-4" />
             {t("nationStatus")}
@@ -190,7 +190,7 @@ export default function NavBar() {
 
           <Link
             href="/ser-radioamador"
-            className="inline-flex h-9 items-center justify-center rounded-md px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-200 hover:text-slate-900 focus:bg-slate-200 focus:text-slate-900 focus:outline-none dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-slate-100 dark:focus:bg-slate-700 dark:focus:text-slate-100"
+            className="inline-flex h-9 whitespace-nowrap items-center justify-center rounded-md px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-200 hover:text-slate-900 focus:bg-slate-200 focus:text-slate-900 focus:outline-none dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-slate-100 dark:focus:bg-slate-700 dark:focus:text-slate-100"
           >
             <GraduationCap className="mr-2 h-4 w-4" />
             {t("becomeHam")}
@@ -202,7 +202,7 @@ export default function NavBar() {
           <ThemeToggle />
 
           {/* Desktop Profile Dropdown */}
-          <div className="hidden md:flex items-center">
+          <div className="hidden lg:flex items-center">
             <DropdownMenu>
               <DropdownMenuTrigger className="inline-flex h-9 w-9 items-center justify-center rounded-md text-slate-700 transition-colors hover:bg-slate-200 hover:text-slate-900 focus:bg-slate-200 focus:text-slate-900 focus:outline-none dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-slate-100 dark:focus:bg-slate-700 dark:focus:text-slate-100">
                 <UserCircle className="h-5 w-5" />

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useState } from "react";
 import Link from "next/link";
-import { Home, BookOpen, FileText, Calculator, ChevronDown, Upload, GraduationCap, BarChart3, UserCircle, Globe, Zap, Radio, TrendingUp, School } from "lucide-react";
+import { Home, BookOpen, FileText, Calculator, ChevronDown, Upload, GraduationCap, BarChart3, UserCircle, Globe, Zap, Radio, TrendingUp } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -187,13 +187,6 @@ export default function NavBar() {
             {t("nationStatus")}
           </Link>
 
-          <Link
-            href="/estado-da-escola"
-            className="inline-flex h-9 items-center justify-center rounded-md px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-200 hover:text-slate-900 focus:bg-slate-200 focus:text-slate-900 focus:outline-none dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-slate-100 dark:focus:bg-slate-700 dark:focus:text-slate-100"
-          >
-            <School className="mr-2 h-4 w-4" />
-            {t("schoolStatus")}
-          </Link>
 
           <Link
             href="/ser-radioamador"


### PR DESCRIPTION
## Summary

Two navigation changes.

**Estado da Escola is removed from the main nav**, and stays in the footer. Removed from both the desktop bar and the mobile drawer — they're the same navigation at different breakpoints, so leaving it in the drawer would have kept it on phones. The page itself is unchanged and still reachable.

**The horizontal nav now switches to the drawer at `lg` rather than `md`.** Between 768px and ~940px it didn't fit, so "Rádio Escola", "Estado da Nação" and "Ser Radioamador" each wrapped to two lines inside a fixed `h-14` bar.

## Why the breakpoint, and not spacing

Measured in **Portuguese**, which is what the default locale renders — English is ~30% narrower (37 characters of label vs 49), so measuring in English would have understated it:

| viewport | needed | available | shortfall |
|---|---|---|---|
| 820px | 892px | 768px | **124px** |
| 768px (`md`) | ~892px | ~736px | **~156px** |

That size of gap rules out the tempting fixes:

- `px-4` → `px-2` across five items recovers ~80px, icon margins another ~10 — short of 124px, and fragile: one longer translation or a sixth item brings the wrap back.
- `whitespace-nowrap` alone converts wrapping into overflow.
- Icon-only labels would fit, but "Estado da Nação" and "Ser Radioamador" as bare icons aren't guessable.

Raising the breakpoint is the one fix that can't regress: the nav is shown only where it demonstrably fits (**120px spare at 1024px**), and nothing is lost because the drawer already carries every link.

**Trade-off:** 940–1024px now gets the drawer despite having room. Worth it for a rule that survives translation; the alternative — moving the two long items into a "Mais" overflow menu below `lg` — keeps the bar at that width but costs complexity.

The desktop profile dropdown moves to `lg` alongside the nav; left at `md` it would have shown a profile menu and a hamburger side by side. `whitespace-nowrap` on the items and `shrink-0` on the logo are belt and braces, so a future squeeze overflows rather than grows the bar taller.

## Verification

Checked in Portuguese at **768, 820, 1023 and 1024px**: bar stays 56px, nothing wraps, no horizontal overflow, and the handover is exactly at 1024 — no width shows both navs or neither.

`type-check` ✓ · `lint` ✓ · 223 tests ✓ · production build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)