### PR TITLE
Add a `bun run tunnel` helper for sharing the dev server

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,9 @@ const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
 const nextConfig = {
   pageExtensions: ["ts", "tsx", "md", "mdx"],
   output: "standalone",
+  // Ephemeral Cloudflare tunnels (bun run tunnel) serve the dev server from a
+  // random *.trycloudflare.com host; Next blocks cross-origin dev assets otherwise.
+  allowedDevOrigins: ["*.trycloudflare.com"],
 };
 
 module.exports = withNextIntl(withMDX(nextConfig));

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--max-old-space-size=8192' next dev",
+    "tunnel": "bash scripts/tunnel.sh",
     "build": "bun run content:check && next build",
     "start": "next start",
     "lint": "eslint .",

--- a/scripts/tunnel.sh
+++ b/scripts/tunnel.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Expose the local dev server through an ephemeral Cloudflare tunnel.
+# Prints a fresh https://<random>.trycloudflare.com URL on every run.
+set -euo pipefail
+
+PORT="${PORT:-3000}"
+
+command -v cloudflared >/dev/null 2>&1 || {
+  echo "cloudflared not found. Install: https://developers.cloudflare.com/cloudflared" >&2
+  exit 1
+}
+
+DEV_PID=""
+cleanup() {
+  if [[ -n "$DEV_PID" ]] && kill -0 "$DEV_PID" 2>/dev/null; then
+    echo "Stopping dev server (pid $DEV_PID)"
+    kill "$DEV_PID" 2>/dev/null || true
+    wait "$DEV_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+cd "$(dirname "$0")/.."
+
+if ss -ltn "sport = :${PORT}" 2>/dev/null | grep -q LISTEN; then
+  echo "Detected existing listener on :${PORT}; skipping dev server start"
+else
+  echo "Starting dev server on :${PORT}"
+  bun run dev --port "${PORT}" &
+  DEV_PID=$!
+
+  for _ in $(seq 1 60); do
+    if ss -ltn "sport = :${PORT}" 2>/dev/null | grep -q LISTEN; then
+      break
+    fi
+    if ! kill -0 "$DEV_PID" 2>/dev/null; then
+      echo "Dev server exited before binding to :${PORT}" >&2
+      exit 1
+    fi
+    sleep 0.5
+  done
+fi
+
+echo "Starting ephemeral tunnel to http://localhost:${PORT}"
+cloudflared tunnel --url "http://localhost:${PORT}"


### PR DESCRIPTION
Dev-tooling only — no application code touched.

`bun run tunnel` wraps cloudflared's ephemeral tunnels so the local dev server can be handed to someone on another device (phone testing, a quick review link):

- Starts `bun run dev` only if nothing is already listening on `:$PORT`, waits for the bind, and kills the server it started on exit.
- Bails with an install hint if `cloudflared` isn't on PATH.
- Prints a fresh `https://<random>.trycloudflare.com` URL each run.

`allowedDevOrigins: ["*.trycloudflare.com"]` in `next.config.js` is required because Next otherwise blocks cross-origin dev asset requests from those random hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBrcm3pFcEaD6c1RTUxbtP