### PR TITLE
Deploy from tags via GitHub Actions, GHCR and Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Everything the image build does not need. Keeping this tight matters: the
+# build context carries ~170 MB of exam PDFs in public/ as it is.
+.git
+.github
+.claude
+.vscode
+.idea
+
+node_modules
+.next
+out
+dist
+build
+coverage
+
+# Secrets never belong in an image — runtime config comes from the server's
+# app.env (see docs/deployment.md).
+.env
+.env.*
+!.env.example
+
+__tests__
+docs
+deploy
+deploy.sh
+deploy-remote.sh
+Dockerfile
+.dockerignore
+
+.ocr-cache
+.impeccable
+.playwright-mcp
+screenshots
+*.log
+tsconfig.tsbuildinfo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  # Called by release.yml so a tag runs exactly the same checks a PR does.
+  workflow_call:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.4.0"
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run type-check
+      - run: bun run lint
+      - run: bun run test
+
+      # Fails if public/data or content/notes drifted from content/questions.
+      - run: bun run content:check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     # Scopes the SSH secrets to this job and gives you somewhere to add a
     # manual approval later (Settings → Environments → production).
     environment:
@@ -87,11 +90,28 @@ jobs:
           TARGET: ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }}
         run: scp deploy/compose.yaml deploy/Caddyfile deploy/release.sh "$TARGET:app/"
 
+      # The image is private, so the box needs registry credentials — but only
+      # for the length of this job. GITHUB_TOKEN dies with the run, so no
+      # long-lived credential is ever parked on the server.
+      - name: Log the server into GHCR
+        env:
+          TARGET: ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+        run: ssh "$TARGET" "docker login ghcr.io -u '$ACTOR' --password-stdin" <<< "$GHCR_TOKEN"
+
       - name: Roll out
         env:
           TARGET: ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }}
           TAG: ${{ needs.build.outputs.image_tag }}
         run: ssh "$TARGET" "bash ~/app/release.sh '$TAG'"
+
+      # Runs even if the rollout failed — never leave credentials behind.
+      - name: Log the server out of GHCR
+        if: always()
+        env:
+          TARGET: ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }}
+        run: ssh "$TARGET" 'docker logout ghcr.io'
 
       - name: Smoke test
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release
+
+# Tagging is the release trigger: `git tag v2.0.0 && git push origin v2.0.0`
+# builds an image, pushes it to GHCR and rolls it out to the VPS.
+on:
+  push:
+    tags: ["v*.*.*"]
+
+# Never let two releases roll out at once, and never cancel one mid-deploy.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    uses: ./.github/workflows/ci.yml
+
+  build:
+    needs: check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      # The tag metadata-action actually pushed (semver strips the leading v,
+      # so `v2.0.0` becomes `2.0.0`). Deploy must pull exactly this.
+      image_tag: ${{ steps.meta.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            NEXT_PUBLIC_GAMIFICATION=${{ vars.NEXT_PUBLIC_GAMIFICATION }}
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    # Scopes the SSH secrets to this job and gives you somewhere to add a
+    # manual approval later (Settings → Environments → production).
+    environment:
+      name: production
+      url: https://${{ vars.DEPLOY_HOST }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Configure SSH
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          printf '%s\n' "$DEPLOY_KNOWN_HOSTS" > ~/.ssh/known_hosts
+
+      # The compose stack is versioned in the repo, so every deploy ships the
+      # current definition rather than trusting whatever is on the box.
+      - name: Ship stack definition
+        env:
+          TARGET: ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }}
+        run: scp deploy/compose.yaml deploy/Caddyfile deploy/release.sh "$TARGET:app/"
+
+      - name: Roll out
+        env:
+          TARGET: ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }}
+          TAG: ${{ needs.build.outputs.image_tag }}
+        run: ssh "$TARGET" "bash ~/app/release.sh '$TAG'"
+
+      - name: Smoke test
+        env:
+          HOST: ${{ vars.DEPLOY_HOST }}
+        run: curl --fail --silent --show-error --retry 5 --retry-delay 5 "https://$HOST/api/health"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,33 @@ bun run test:coverage # Vitest with V8 coverage
 bun run type-check   # tsc --noEmit
 bun run content:build # Compile content/questions/** into shipped artifacts
 bun run content:check # Verify artifacts match their source (writes nothing)
-./deploy.sh          # Pull, install, build, PM2 restart (app name: radioescola)
 ```
+
+## Deployment
+
+Tag-triggered, via GitHub Actions → GHCR → the VPS at `server.radioescola.pt`:
+
+```bash
+git tag -a v2.0.0 -m "Release 2.0.0" && git push origin v2.0.0
+```
+
+`.github/workflows/release.yml` runs the checks, builds `Dockerfile`, pushes
+`ghcr.io/radioescola-pt/site:2.0.0`, then rolls it out with `deploy/release.sh`.
+Rollback is that script with an older tag. Full runbook and server setup in
+`docs/deployment.md`.
+
+- **The image tag has no leading `v`** — `docker/metadata-action` strips it, so
+  the tag `v2.0.0` publishes `2.0.0`
+- **`NEXT_PUBLIC_*` is baked into the image**, so a feature-flag change needs a
+  new tag, not an edit to the server's `app.env`
+- **Two API routes read source files at request time** (`/api/notes/*` from
+  `content/notes/`, `/api/study-items` from `app/study/`) using paths built from
+  `process.cwd()`, which file tracing cannot follow. They are kept in the
+  standalone output by `outputFileTracingIncludes` in `next.config.js` — a new
+  route that reads from disk needs an entry there or it will answer empty in
+  production only
+- `deploy.sh` (builds on the box, PM2) and `deploy-remote.sh` (builds on your
+  laptop, rsync) are the superseded predecessors
 
 ## Architecture
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,59 @@
+# syntax=docker/dockerfile:1
+
+# Bun builds (the content pipeline scripts are run by bun), Node serves — the
+# standalone server is a plain Node program and Node is what Next supports for
+# it. Both stages are glibc/Debian so the traced native binaries (sharp) that
+# get copied across match the runner's libc.
+
+FROM oven/bun:1.4 AS deps
+WORKDIR /app
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile
+
+
+FROM oven/bun:1.4 AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# NEXT_PUBLIC_* is inlined by next build, so feature flags are baked into the
+# image here — the server's app.env cannot change them afterwards.
+ARG NEXT_PUBLIC_GAMIFICATION
+ENV NEXT_PUBLIC_GAMIFICATION=$NEXT_PUBLIC_GAMIFICATION
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# `bun run build` gates on content:check, so a stale generated artifact fails
+# the image build rather than shipping.
+RUN bun run build
+
+# Next traces sharp's musl binaries alongside the glibc ones. The runner is
+# Debian, so the musl copies are ~19 MB of dead weight — drop them here, before
+# the runner stage copies the tree (deleting them later would not shrink the
+# image, only add a whiteout layer).
+RUN rm -rf .next/standalone/node_modules/@img/sharp-libvips-linuxmusl-x64 \
+           .next/standalone/node_modules/@img/sharp-linuxmusl-x64
+
+
+FROM node:24-bookworm-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+
+RUN groupadd --system --gid 1001 nodejs \
+ && useradd --system --uid 1001 --gid nodejs nextjs
+
+# standalone carries the server plus its traced dependencies; static assets and
+# public/ are never traced and have to come across on their own.
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+USER nextjs
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:3000/api/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+CMD ["node", "server.js"]

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Container health probe.
+ *
+ * Deliberately does no work beyond proving the server is up and answering:
+ * Docker polls it every 30s, and Caddy waits on it before accepting traffic
+ * for a freshly rolled-out container.
+ */
+export const dynamic = 'force-dynamic';
+
+export function GET() {
+  return NextResponse.json({ status: 'ok' });
+}

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,12 @@
+# Terminates TLS (certificates issued and renewed automatically) and proxies to
+# the app container. Next sets its own Cache-Control headers, so nothing here
+# second-guesses them.
+server.radioescola.pt {
+	encode zstd gzip
+	reverse_proxy app:3000
+}
+
+# To also serve the apex domain, point its DNS at this host and add:
+# radioescola.pt {
+# 	redir https://server.radioescola.pt{uri}
+# }

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -1,0 +1,47 @@
+# Lives in the repo, copied to ~/app on the server by the release workflow.
+# Edit it here, never on the box — the next deploy overwrites it.
+name: radioescola
+
+services:
+  app:
+    # IMAGE_TAG comes from ~/app/.env, which release.sh rewrites on every
+    # deploy. Rolling back is therefore just release.sh with an older tag.
+    image: ghcr.io/radioescola-pt/site:${IMAGE_TAG:?set IMAGE_TAG in .env}
+    restart: unless-stopped
+    # Runtime secrets only (RESEND_*). Build-time NEXT_PUBLIC_* flags are
+    # already baked into the image and cannot be changed from here.
+    env_file:
+      - app.env
+    expose:
+      - "3000"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      app:
+        condition: service_healthy
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+volumes:
+  # Holds the ACME account and issued certificates. Losing it means re-issuing
+  # from Let's Encrypt, which is rate limited — do not prune it.
+  caddy_data:
+  caddy_config:

--- a/deploy/release.sh
+++ b/deploy/release.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Points the stack at an image tag and rolls it out. Run by the release
+# workflow, and by hand to roll back:
+#
+#   ssh deploy@server.radioescola.pt 'bash ~/app/release.sh v1.9.0'
+#
+set -euo pipefail
+
+TAG="${1:?usage: release.sh <image-tag>}"
+cd "$(dirname "$0")"
+
+printf 'IMAGE_TAG=%s\n' "$TAG" > .env
+
+docker compose pull
+# --wait makes an unhealthy new container a failed deploy instead of a
+# silently broken site.
+docker compose up -d --remove-orphans --wait
+docker image prune -f
+
+docker compose ps

--- a/deploy/release.sh
+++ b/deploy/release.sh
@@ -2,7 +2,9 @@
 # Points the stack at an image tag and rolls it out. Run by the release
 # workflow, and by hand to roll back:
 #
-#   ssh deploy@server.radioescola.pt 'bash ~/app/release.sh v1.9.0'
+#   ssh deploy@server.radioescola.pt 'bash ~/app/release.sh 1.9.0'
+#
+# The tag has no leading v — metadata-action publishes the bare semver.
 #
 set -euo pipefail
 
@@ -11,7 +13,11 @@ cd "$(dirname "$0")"
 
 printf 'IMAGE_TAG=%s\n' "$TAG" > .env
 
-docker compose pull
+# A manual rollback runs without registry credentials (CI logs the box out
+# again after every deploy). That is fine as long as the image is still cached
+# locally, so a failed pull is a warning, not the end — `up --wait` below is
+# what actually decides whether the release is viable.
+docker compose pull || echo "==> pull failed; falling back to a locally cached image"
 # --wait makes an unhealthy new container a failed deploy instead of a
 # silently broken site.
 docker compose up -d --remove-orphans --wait

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,225 @@
+# Deployment
+
+Releases are cut by tagging. `git push origin v2.0.0` makes GitHub Actions run
+the test suite, build a Docker image, push it to GHCR, and roll it out to
+`server.radioescola.pt`. Nothing is built on the production box, and every
+release is an immutable image you can roll back to by name.
+
+```
+git tag v2.0.0  ──▶  .github/workflows/release.yml
+                        │
+                        ├─ check    type-check, lint, test, content:check
+                        ├─ build    Dockerfile ──▶ ghcr.io/radioescola-pt/site:2.0.0
+                        └─ deploy   scp deploy/* ──▶ ~/app  ──▶ release.sh 2.0.0
+                                                                │
+                                    VPS: caddy (TLS) ──▶ app container :3000
+```
+
+## Files
+
+| Path | What it is |
+| --- | --- |
+| `Dockerfile` | Bun builds, Node serves the standalone output |
+| `.dockerignore` | Keeps the build context down (`public/` alone is ~170 MB) |
+| `deploy/compose.yaml` | The stack: app + Caddy. Copied to the server on every deploy |
+| `deploy/Caddyfile` | Reverse proxy and automatic TLS |
+| `deploy/release.sh` | Pins an image tag and rolls it out. Also the rollback tool |
+| `.github/workflows/ci.yml` | Checks. Runs on PRs, and is reused by the release |
+| `.github/workflows/release.yml` | Tag → build → push → deploy |
+
+Edit the `deploy/` files here, never on the server — the next deploy overwrites
+whatever is in `~/app`.
+
+## One-time server setup
+
+Everything below runs on the VPS as `root` unless noted.
+
+### 1. DNS
+
+Point `server.radioescola.pt` at the VPS (`A`, plus `AAAA` if it has IPv6)
+*before* the first deploy. Caddy issues the certificate on startup and needs the
+name to resolve to itself.
+
+### 2. Base system
+
+```bash
+apt update && apt full-upgrade -y
+apt install -y ca-certificates curl ufw unattended-upgrades
+
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow OpenSSH
+ufw allow 80/tcp
+ufw allow 443
+ufw --force enable
+```
+
+Lock down SSH in `/etc/ssh/sshd_config` — `PasswordAuthentication no`,
+`PermitRootLogin prohibit-password` — then `systemctl restart ssh`.
+
+### 3. Docker
+
+```bash
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+
+. /etc/os-release
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+  https://download.docker.com/linux/debian $VERSION_CODENAME stable" \
+  > /etc/apt/sources.list.d/docker.list
+
+apt update
+apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+systemctl enable --now docker
+```
+
+> Docker publishes per-release suites. If `apt update` 404s on the Debian 14
+> codename, the repo has not caught up yet — substitute the previous stable
+> codename (`trixie`) in the `sources.list.d` line. The packages are compatible.
+
+### 4. Deploy user
+
+```bash
+adduser --disabled-password --gecos "" deploy
+usermod -aG docker deploy
+install -o deploy -g deploy -m 700 -d /home/deploy/app
+```
+
+`docker` group membership is root-equivalent. That is why this user exists and
+why it does nothing else.
+
+### 5. SSH key for GitHub Actions
+
+On your machine:
+
+```bash
+ssh-keygen -t ed25519 -f /tmp/radioescola_deploy -N "" -C "github-actions"
+ssh-copy-id -i /tmp/radioescola_deploy.pub deploy@server.radioescola.pt
+ssh-keyscan -t ed25519 server.radioescola.pt   # → DEPLOY_KNOWN_HOSTS
+```
+
+Keep the private key for the `DEPLOY_SSH_KEY` secret below, then delete it
+locally. Pinning `known_hosts` rather than disabling host-key checking is what
+stops a deploy from being redirected to another host.
+
+### 6. Registry access
+
+The repo is private, so the image is too, and the server has to authenticate to
+pull it. Create a **classic** personal access token with only the
+`read:packages` scope, then, as `deploy`:
+
+```bash
+echo "<token>" | docker login ghcr.io -u <github-username> --password-stdin
+```
+
+This writes `~/.docker/config.json` and persists across reboots. (Making the
+GHCR package public instead removes this step — but the image contains the full
+site build, so only do that if the site's content is public anyway.)
+
+### 7. Runtime secrets
+
+As `deploy`, create `~/app/app.env` — this is the only configuration that lives
+on the server:
+
+```bash
+cat > ~/app/app.env <<'EOF'
+RESEND_API_KEY=re_xxxxxxxxxxxx
+EXAM_SUBMISSION_EMAIL=you@example.com
+RESEND_FROM_EMAIL=onboarding@resend.dev
+EOF
+chmod 600 ~/app/app.env
+```
+
+The app runs fine without these; only `/submit-exam` needs them.
+
+`~/app/.env` is a *different* file, written by `release.sh` on every deploy to
+record which image tag is live. Do not put secrets in it.
+
+Build-time flags (`NEXT_PUBLIC_GAMIFICATION`) are **not** here. Next inlines
+them at build time, so they are baked into the image — changing one means a new
+tag, not an edit on the server.
+
+## One-time GitHub setup
+
+**Settings → Secrets and variables → Actions → Variables** (repository):
+
+| Variable | Value |
+| --- | --- |
+| `DEPLOY_HOST` | `server.radioescola.pt` |
+| `DEPLOY_USER` | `deploy` |
+| `NEXT_PUBLIC_GAMIFICATION` | `true` to ship gamification, otherwise leave unset |
+
+**Settings → Environments → New environment → `production`**, then add its
+secrets:
+
+| Secret | Value |
+| --- | --- |
+| `DEPLOY_SSH_KEY` | the private key from step 5 |
+| `DEPLOY_KNOWN_HOSTS` | the `ssh-keyscan` output from step 5 |
+
+Scoping them to the environment means only the `deploy` job can read them. Add
+required reviewers to that environment if you ever want releases to pause for
+approval.
+
+Nothing needs configuring for GHCR on the CI side — `GITHUB_TOKEN` with
+`packages: write` covers the push.
+
+## Releasing
+
+```bash
+git tag -a v2.0.0 -m "Release 2.0.0"
+git push origin v2.0.0
+```
+
+Watch it in the Actions tab. The deploy step fails loudly if the new container
+does not come up healthy, and a final smoke test hits `/api/health` through
+Caddy.
+
+Only `v*.*.*` tags trigger a release. Pushes to `main` run the checks only.
+
+## Rolling back
+
+Images are never overwritten, so rollback is just pointing at an older one:
+
+```bash
+ssh deploy@server.radioescola.pt 'bash ~/app/release.sh 1.9.0'
+```
+
+Note the tag has no leading `v` — the published image tags are the semver
+version (`2.0.0`, `2.0`) plus a `sha-` tag. `docker image ls` on the server
+shows what is still cached locally; anything else pulls from GHCR.
+
+## Operating it
+
+```bash
+cd ~/app
+docker compose ps                 # what is running, and its health
+docker compose logs -f app        # app logs (rotated, 10 MB × 5)
+docker compose logs -f caddy      # TLS issuance and access problems
+cat .env                          # which tag is live
+```
+
+The stack has `restart: unless-stopped` and Docker is enabled at boot, so a
+reboot brings the site back on its own.
+
+Never `docker volume prune` — the `caddy_data` volume holds the ACME account
+and issued certificates, and re-issuing runs into Let's Encrypt rate limits.
+`release.sh` only prunes dangling *images*, which is safe.
+
+## Known trade-offs
+
+- **A deploy has a few seconds of downtime.** The app container is replaced in
+  place. Zero-downtime would need two app containers and a proxy that drains
+  the old one (blue/green, or a tool like Kamal). Not worth it for a site with
+  no server-side session state.
+- **The image unpacks to ~436 MB**: ~245 MB Debian + Node runtime, 185 MB
+  `public/` (169 MB of it exam PDFs), 52 MB traced `node_modules`, 4 MB static
+  assets. (`docker images` reports ~770 MB under the containerd image store —
+  it counts the compressed blobs *and* the unpacked snapshot.) Only the ~56 MB
+  of app layers change between releases; the PDF layer is content-addressed and
+  is reused, so it is pushed and pulled exactly once. Verified by rebuilding
+  after a code change and comparing layer digests.
+- **`deploy.sh` and `deploy-remote.sh` are superseded.** The first builds on the
+  production box, the second builds on your laptop; both fight with the
+  container for the port. Delete them once this flow is live.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -54,8 +54,25 @@ ufw allow 443
 ufw --force enable
 ```
 
-Lock down SSH in `/etc/ssh/sshd_config` — `PasswordAuthentication no`,
-`PermitRootLogin prohibit-password` — then `systemctl restart ssh`.
+Then lock down SSH. **Do not edit `/etc/ssh/sshd_config` directly** — it already
+says `PasswordAuthentication no`, but it `Include`s `sshd_config.d/*.conf` above
+that line, and cloud-init and the provider both drop files in there turning it
+back on. sshd keeps the *first* value it obtains, so the drop-ins win. Add one
+that sorts ahead of them:
+
+```bash
+cat > /etc/ssh/sshd_config.d/00-hardening.conf <<'EOF'
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PermitRootLogin prohibit-password
+EOF
+
+sshd -t && sshd -T | grep -E 'passwordauth|permitroot'   # confirm before reloading
+systemctl reload ssh
+```
+
+Verify from a *second* terminal that your key still works before you close the
+first one.
 
 ### 3. Docker
 
@@ -64,9 +81,11 @@ install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
 chmod a+r /etc/apt/keyrings/docker.asc
 
-. /etc/os-release
+# Debian 14 is "forky", and Docker publishes no forky suite — pin trixie, whose
+# packages work fine. Check before changing this:
+#   curl -sI https://download.docker.com/linux/debian/dists/forky/Release
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
-  https://download.docker.com/linux/debian $VERSION_CODENAME stable" \
+  https://download.docker.com/linux/debian trixie stable" \
   > /etc/apt/sources.list.d/docker.list
 
 apt update
@@ -74,17 +93,18 @@ apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker
 systemctl enable --now docker
 ```
 
-> Docker publishes per-release suites. If `apt update` 404s on the Debian 14
-> codename, the repo has not caught up yet — substitute the previous stable
-> codename (`trixie`) in the `sources.list.d` line. The packages are compatible.
+> Once Docker ships a `forky` suite, switch the line to `$VERSION_CODENAME`.
 
 ### 4. Deploy user
 
 ```bash
-adduser --disabled-password --gecos "" deploy
+useradd --create-home --shell /bin/bash --password '!' deploy
 usermod -aG docker deploy
 install -o deploy -g deploy -m 700 -d /home/deploy/app
 ```
+
+(`useradd`, not `adduser`: `/usr/sbin` is off `PATH` for a non-interactive SSH
+command, so scripted setup fails on `adduser: command not found`.)
 
 `docker` group membership is root-equivalent. That is why this user exists and
 why it does nothing else.
@@ -103,19 +123,19 @@ Keep the private key for the `DEPLOY_SSH_KEY` secret below, then delete it
 locally. Pinning `known_hosts` rather than disabling host-key checking is what
 stops a deploy from being redirected to another host.
 
-### 6. Registry access
+### 6. Registry access — nothing to do
 
 The repo is private, so the image is too, and the server has to authenticate to
-pull it. Create a **classic** personal access token with only the
-`read:packages` scope, then, as `deploy`:
+pull it. Rather than parking a long-lived token on the box, the release workflow
+logs the server in with its own `GITHUB_TOKEN` just before pulling and logs it
+out again afterwards (`if: always()`, so a failed rollout still cleans up). That
+token dies with the workflow run, so no registry credential outlives a deploy.
 
-```bash
-echo "<token>" | docker login ghcr.io -u <github-username> --password-stdin
-```
-
-This writes `~/.docker/config.json` and persists across reboots. (Making the
-GHCR package public instead removes this step — but the image contains the full
-site build, so only do that if the site's content is public anyway.)
+The one consequence: **a manual rollback runs without credentials.** That is
+fine when the image is still cached on the box, which it is for anything recent
+— `release.sh` treats a failed `pull` as a warning and lets `up --wait` decide.
+To roll back to something already pruned, either re-run the release workflow for
+that tag, or log in by hand first with a `read:packages` token.
 
 ### 7. Runtime secrets
 

--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,13 @@ const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
 const nextConfig = {
   pageExtensions: ["ts", "tsx", "md", "mdx"],
   output: "standalone",
+  // Two API routes read source files off disk at request time with paths built
+  // from process.cwd(), which file tracing cannot follow. Without these the
+  // standalone bundle ships without them and both routes answer empty.
+  outputFileTracingIncludes: {
+    "/api/notes/\\[category\\]/\\[id\\]": ["content/notes/**/*.mdx"],
+    "/api/study-items": ["app/study/**/page.mdx"],
+  },
   // Ephemeral Cloudflare tunnels (bun run tunnel) serve the dev server from a
   // random *.trycloudflare.com host; Next blocks cross-origin dev assets otherwise.
   allowedDevOrigins: ["*.trycloudflare.com"],


### PR DESCRIPTION
Replaces the build-on-the-box (`deploy.sh`) and build-on-your-laptop (`deploy-remote.sh`) flows with a tag-triggered pipeline.

`git push origin v2.0.0` → checks → image → GHCR → rolled out to `server.radioescola.pt`. Rollback is `release.sh <older-tag>`; images are never overwritten.

## What's here

- `Dockerfile` — bun builds, Node 24 serves the standalone output. Non-root, healthchecked.
- `deploy/` — the compose stack (app + Caddy for TLS) and `release.sh`. Copied to the server on every deploy, so the repo stays the source of truth.
- `.github/workflows/ci.yml` — type-check, lint, test, `content:check`. Runs on PRs and is reused by the release.
- `.github/workflows/release.yml` — tag → build → push → deploy → smoke test.
- `app/api/health/route.ts` — container health probe.
- `docs/deployment.md` — server provisioning runbook and operating notes.

## Two bugs this turned up

**`/api/notes/*` and `/api/study-items` were shipping broken to any standalone deploy.** Both read source files at request time from paths built with `process.cwd()`, which Next's file tracing can't follow, so `content/notes/` and `app/study/` never made it into the output and both routes answered empty. `outputFileTracingIncludes` now keeps them. This affected `deploy-remote.sh` too.

**19 MB of dead sharp binaries.** Next traces sharp's musl build alongside the glibc one; the runner is Debian, so the musl copies can never execute. Stripped in the builder stage — deleting them in the runner would only add a whiteout layer.

## Verified

Built and ran the image locally: `/`, `/browse/3`, `/api/health`, `/api/data`, `/api/study-items`, `/api/notes/3/1` and `/_next/image` all serve real content, container reports healthy. Rebuilt after a code change and compared layer digests to confirm the 185 MB `public/` layer is reused, so releases transfer ~56 MB, not the whole image.

Image unpacks to ~436 MB — ~245 MB of that is the Debian + Node runtime and 169 MB is the exam PDFs.

## Before merging

The server side isn't set up yet — `docs/deployment.md` has the runbook. Merging this is safe on its own; nothing deploys until a `v*.*.*` tag is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UzGA67sTRrKNPNKFjBhUv