### PR TITLE
Let the smoke test outlast a first certificate issuance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,14 @@ jobs:
           TARGET: ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }}
         run: ssh "$TARGET" 'docker logout ghcr.io'
 
+      # --retry-all-errors matters: plain --retry ignores TLS handshake failures
+      # (curl exit 35), which is exactly what you get while Caddy is still
+      # obtaining the certificate on a first deploy to a new host.
       - name: Smoke test
         env:
           HOST: ${{ vars.DEPLOY_HOST }}
-        run: curl --fail --silent --show-error --retry 5 --retry-delay 5 "https://$HOST/api/health"
+        run: |
+          curl --fail --silent --show-error \
+               --retry 12 --retry-delay 5 --retry-all-errors \
+               --max-time 120 \
+               "https://$HOST/api/health"


### PR DESCRIPTION
The `v2.0.0` deploy worked — image built, pushed, rolled out, container healthy, site live at https://server.radioescola.pt with a valid certificate. But the job went red on the final smoke test with curl exit 35.

That is a TLS handshake error: Caddy was still solving the ACME http-01 challenge when curl ran. `--retry` on its own does not treat handshake failures as retriable, so all five attempts failed back-to-back instead of waiting it out.

`--retry-all-errors` fixes it. Bumped to 12 attempts with a 120s ceiling — issuance actually took ~8s, so that is a wide margin.

Only affects the first deploy to a host without a certificate, but that is precisely the run you least want to see fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UzGA67sTRrKNPNKFjBhUv