### PR TITLE
Replace the placeholder testimonials with a real one

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,24 +8,15 @@ import { Testimonials, type Testimonial } from "@/components/Testimonials";
 
 type RawTestimonial = Omit<Testimonial, "categoryLabel">;
 
+// Real operators only — a callsign is publicly registered to a named person,
+// so a made-up one puts words in a real amateur's mouth.
 const TESTIMONIALS: RawTestimonial[] = [
   {
-    quote: "Usei o Rádio Escola desde a Categoria 3 até à 1. Os simuladores de exame são iguais ao exame real da ANACOM.",
-    name: "Carlos",
-    callsign: "CT7XRQ",
-    category: "1",
-  },
-  {
-    quote: "A prática inteligente foca nas perguntas que erro mais. Em duas semanas senti-me preparado.",
-    name: "Ana",
-    callsign: "CS7BVF",
+    quote:
+      "Comecei com o RadioEscola para tirar a Categoria 3 e voltei sempre que subi de categoria. É o único sítio onde encontrei a matéria toda organizada em português e com perguntas reais de exames, fez toda a diferença.",
+    name: "Joel",
+    callsign: "CS7BLE",
     category: "2",
-  },
-  {
-    quote: "Estudei tudo no telemóvel, no comboio para o trabalho. Muito prático.",
-    name: "Miguel",
-    callsign: "CR7KJD",
-    category: "3",
   },
 ];
 


### PR DESCRIPTION
The three testimonials on the landing page were placeholders, but they carried valid-format Portuguese callsigns — `CT7XRQ`, `CS7BVF`, `CR7KJD` — under the heading *"O que dizem os utilizadores"*, complete with an animated on-air indicator. Callsigns are publicly registered to named individuals in the ANACOM registry, so those read as endorsements from identifiable licensed amateurs who never gave one. Now that the site is deployed, that seemed worth fixing before the domain cutover.

Replaced with a single real testimonial from Joel, `CS7BLE`.

## Category

Set to `2`, from the site's own explanation in `content/questions/cat3/0153.mdx`: the letters encode the category (`CT` = 1, `CS` = 2, `CR` = 3) and the digit the area (`7` = Portugal continental). So `CS7BLE` is categoria 2 — consistent with the quote, which describes starting at Categoria 3 and coming back on the way up. It is also the convention the placeholders themselves followed.

## Layout

`Testimonials` does `const [featured, ...rest] = items`, so one entry renders as the wide featured card spanning both grid columns with an empty supporting row — no gap, no orphaned half-row. Verified against the server-rendered HTML: one `<blockquote>`, `CS7BLE · Joel · Categoria 2`, no trace of the old callsigns.

Also added a comment above the array noting why entries must stay real, so this doesn't quietly regrow placeholders.

## Note

The quote is a Portuguese string literal in `app/page.tsx`, outside next-intl — same as the placeholders were. Only `testimonialsHeading` is translated, so an English visitor gets an English heading over a Portuguese quote. Pre-existing, not addressed here; moving the quotes into `messages/*.json` would fix it without touching the component.

Type-check, lint and 223 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UzGA67sTRrKNPNKFjBhUv