### PR TITLE
Add a manually runnable Deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,115 @@
+name: Deploy
+
+# Rolls an already-built image out to the VPS. Two ways in:
+#
+#   - workflow_call  — release.yml calls this after it pushes a new image
+#   - workflow_dispatch — the "Run workflow" button, for redeploying or rolling
+#     back to any tag that is already in GHCR, without rebuilding anything
+#
+# Rolling back through this workflow is preferable to running release.sh over
+# SSH by hand: the box holds no registry credentials of its own, so a manual
+# pull of an image it has already pruned would fail. Here CI supplies them.
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        description: Image tag to deploy
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to deploy, e.g. 2.0.0 — no leading v (see Packages for what exists)"
+        required: true
+        type: string
+
+# Shared with release.yml, so a manual deploy and a tag release can never roll
+# out over each other.
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    # Scopes the SSH secrets to this job and gives you somewhere to add a
+    # manual approval later (Settings → Environments → production).
+    environment:
+      name: production
+      url: https://${{ vars.DEPLOY_HOST }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Configure SSH
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          printf '%s\n' "$DEPLOY_KNOWN_HOSTS" > ~/.ssh/known_hosts
+
+      # The compose stack is versioned in the repo, so every deploy ships the
+      # current definition rather than trusting whatever is on the box.
+      - name: Ship stack definition
+        env:
+          TARGET: ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }}
+        run: scp deploy/compose.yaml deploy/Caddyfile deploy/release.sh "$TARGET:app/"
+
+      # The image is private, so the box needs registry credentials — but only
+      # for the length of this job. GITHUB_TOKEN dies with the run, so no
+      # long-lived credential is ever parked on the server.
+      - name: Log the server into GHCR
+        env:
+          TARGET: ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+        run: ssh "$TARGET" "docker login ghcr.io -u '$ACTOR' --password-stdin" <<< "$GHCR_TOKEN"
+
+      - name: Roll out
+        env:
+          TARGET: ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }}
+          TAG: ${{ inputs.image_tag }}
+        run: ssh "$TARGET" "bash ~/app/release.sh '$TAG'"
+
+      # Runs even if the rollout failed — never leave credentials behind.
+      - name: Log the server out of GHCR
+        if: always()
+        env:
+          TARGET: ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }}
+        run: ssh "$TARGET" 'docker logout ghcr.io'
+
+      # --retry-all-errors matters: plain --retry ignores TLS handshake failures
+      # (curl exit 35), which is exactly what you get while Caddy is still
+      # obtaining the certificate on a first deploy to a new host.
+      - name: Smoke test
+        env:
+          HOST: ${{ vars.DEPLOY_HOST }}
+        run: |
+          curl --fail --silent --show-error \
+               --retry 12 --retry-delay 5 --retry-all-errors \
+               --max-time 120 \
+               "https://$HOST/api/health"
+
+      - name: Summary
+        if: always()
+        env:
+          TAG: ${{ inputs.image_tag }}
+          HOST: ${{ vars.DEPLOY_HOST }}
+        run: |
+          {
+            echo "### Deploy"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Image tag | \`$TAG\` |"
+            echo "| Host | https://$HOST |"
+            echo "| Triggered by | ${{ github.event_name }} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,61 +59,11 @@ jobs:
           build-args: |
             NEXT_PUBLIC_GAMIFICATION=${{ vars.NEXT_PUBLIC_GAMIFICATION }}
 
+  # The rollout itself lives in deploy.yml so the same steps back both a tag
+  # release and the manual "Run workflow" button (redeploys and rollbacks).
   deploy:
     needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
-    # Scopes the SSH secrets to this job and gives you somewhere to add a
-    # manual approval later (Settings → Environments → production).
-    environment:
-      name: production
-      url: https://${{ vars.DEPLOY_HOST }}
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Configure SSH
-        env:
-          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
-          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
-        run: |
-          install -m 700 -d ~/.ssh
-          printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          printf '%s\n' "$DEPLOY_KNOWN_HOSTS" > ~/.ssh/known_hosts
-
-      # The compose stack is versioned in the repo, so every deploy ships the
-      # current definition rather than trusting whatever is on the box.
-      - name: Ship stack definition
-        env:
-          TARGET: ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }}
-        run: scp deploy/compose.yaml deploy/Caddyfile deploy/release.sh "$TARGET:app/"
-
-      # The image is private, so the box needs registry credentials — but only
-      # for the length of this job. GITHUB_TOKEN dies with the run, so no
-      # long-lived credential is ever parked on the server.
-      - name: Log the server into GHCR
-        env:
-          TARGET: ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }}
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACTOR: ${{ github.actor }}
-        run: ssh "$TARGET" "docker login ghcr.io -u '$ACTOR' --password-stdin" <<< "$GHCR_TOKEN"
-
-      - name: Roll out
-        env:
-          TARGET: ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }}
-          TAG: ${{ needs.build.outputs.image_tag }}
-        run: ssh "$TARGET" "bash ~/app/release.sh '$TAG'"
-
-      # Runs even if the rollout failed — never leave credentials behind.
-      - name: Log the server out of GHCR
-        if: always()
-        env:
-          TARGET: ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }}
-        run: ssh "$TARGET" 'docker logout ghcr.io'
-
-      - name: Smoke test
-        env:
-          HOST: ${{ vars.DEPLOY_HOST }}
-        run: curl --fail --silent --show-error --retry 5 --retry-delay 5 "https://$HOST/api/health"
+    uses: ./.github/workflows/deploy.yml
+    with:
+      image_tag: ${{ needs.build.outputs.image_tag }}
+    secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,12 @@ git tag -a v2.0.0 -m "Release 2.0.0" && git push origin v2.0.0
 ```
 
 `.github/workflows/release.yml` runs the checks, builds `Dockerfile`, pushes
-`ghcr.io/radioescola-pt/site:2.0.0`, then rolls it out with `deploy/release.sh`.
-Rollback is that script with an older tag. Full runbook and server setup in
-`docs/deployment.md`.
+`ghcr.io/radioescola-pt/site:2.0.0`, then calls `deploy.yml` to roll it out.
+
+`deploy.yml` also runs on its own from **Actions → Deploy → Run workflow**,
+taking an image tag — that is how you redeploy or roll back, and it beats
+running `release.sh` over SSH because CI supplies the registry credentials the
+box deliberately does not keep. Full runbook in `docs/deployment.md`.
 
 - **The image tag has no leading `v`** — `docker/metadata-action` strips it, so
   the tag `v2.0.0` publishes `2.0.0`

--- a/deploy/release.sh
+++ b/deploy/release.sh
@@ -1,23 +1,40 @@
 #!/usr/bin/env bash
-# Points the stack at an image tag and rolls it out. Run by the release
-# workflow, and by hand to roll back:
+# Points the stack at an image tag and rolls it out. Run by the Deploy
+# workflow. To roll back, prefer that workflow's "Run workflow" button over
+# running this by hand: CI supplies registry credentials, which the box
+# deliberately does not keep.
+#
+# By hand, if the image is still cached locally:
 #
 #   ssh deploy@server.radioescola.pt 'bash ~/app/release.sh 1.9.0'
 #
 # The tag has no leading v — metadata-action publishes the bare semver.
-#
 set -euo pipefail
 
 TAG="${1:?usage: release.sh <image-tag>}"
 cd "$(dirname "$0")"
 
+# Resolve the image the compose file would use for this tag, without touching
+# the live .env yet — so a typo'd or never-built tag cannot leave the recorded
+# tag out of step with what is actually running.
+# Name the service: `config --images` lists every service alphabetically, so an
+# unqualified `head -1` returns caddy.
+IMAGE=$(IMAGE_TAG="$TAG" docker compose config --images app)
+echo "==> $IMAGE"
+
+if ! docker pull "$IMAGE"; then
+  # A manual rollback runs without registry credentials. That is fine as long
+  # as the image is still cached locally.
+  echo "==> pull failed; looking for a local copy"
+  docker image inspect "$IMAGE" > /dev/null 2>&1 || {
+    echo "!!! $IMAGE is neither pullable nor cached locally — nothing changed." >&2
+    exit 1
+  }
+  echo "==> using the cached copy"
+fi
+
 printf 'IMAGE_TAG=%s\n' "$TAG" > .env
 
-# A manual rollback runs without registry credentials (CI logs the box out
-# again after every deploy). That is fine as long as the image is still cached
-# locally, so a failed pull is a warning, not the end — `up --wait` below is
-# what actually decides whether the release is viable.
-docker compose pull || echo "==> pull failed; falling back to a locally cached image"
 # --wait makes an unhealthy new container a failed deploy instead of a
 # silently broken site.
 docker compose up -d --remove-orphans --wait

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,7 +10,10 @@ git tag v2.0.0  ──▶  .github/workflows/release.yml
                         │
                         ├─ check    type-check, lint, test, content:check
                         ├─ build    Dockerfile ──▶ ghcr.io/radioescola-pt/site:2.0.0
-                        └─ deploy   scp deploy/* ──▶ ~/app  ──▶ release.sh 2.0.0
+                        └─ deploy ──▶ deploy.yml (also runnable on its own,
+                                      for a redeploy or a rollback)
+                                        │
+                                        scp deploy/* ──▶ ~/app ──▶ release.sh 2.0.0
                                                                 │
                                     VPS: caddy (TLS) ──▶ app container :3000
 ```
@@ -25,7 +28,8 @@ git tag v2.0.0  ──▶  .github/workflows/release.yml
 | `deploy/Caddyfile` | Reverse proxy and automatic TLS |
 | `deploy/release.sh` | Pins an image tag and rolls it out. Also the rollback tool |
 | `.github/workflows/ci.yml` | Checks. Runs on PRs, and is reused by the release |
-| `.github/workflows/release.yml` | Tag → build → push → deploy |
+| `.github/workflows/release.yml` | Tag → build → push → calls the deploy workflow |
+| `.github/workflows/deploy.yml` | The rollout. Called by a release, or run by hand for a redeploy or rollback |
 
 Edit the `deploy/` files here, never on the server — the next deploy overwrites
 whatever is in `~/app`.
@@ -198,17 +202,29 @@ Caddy.
 
 Only `v*.*.*` tags trigger a release. Pushes to `main` run the checks only.
 
-## Rolling back
+## Deploying by hand, and rolling back
 
-Images are never overwritten, so rollback is just pointing at an older one:
+Images are never overwritten, so both are the same operation: point the stack at
+a tag that already exists.
+
+**Actions → Deploy → Run workflow**, and give it an image tag. That is the way to
+do it. The workflow supplies registry credentials, so it works for any tag still
+in GHCR, whether or not the box has it cached — and it is the same code path a
+tag release takes, because `release.yml` calls this workflow too.
+
+Note the tag has **no leading `v`**: published tags are the bare semver
+(`2.0.0`, `2.0`) plus a `sha-` tag. Check the repo's Packages page for what
+exists.
+
+Over SSH also works, but only for an image the box still has cached — it holds
+no registry credentials of its own by design:
 
 ```bash
-ssh deploy@server.radioescola.pt 'bash ~/app/release.sh 1.9.0'
+ssh deploy@server.radioescola.pt 'bash ~/app/release.sh 2.0.0'
 ```
 
-Note the tag has no leading `v` — the published image tags are the semver
-version (`2.0.0`, `2.0`) plus a `sha-` tag. `docker image ls` on the server
-shows what is still cached locally; anything else pulls from GHCR.
+Either way, a tag that can be neither pulled nor found locally aborts before
+`.env` is rewritten, so a typo leaves the running site alone.
 
 ## Operating it
 


### PR DESCRIPTION
Adds a **Deploy** workflow you can run from the Actions tab, so a redeploy or rollback no longer needs a terminal.

## Shape

The rollout moves out of `release.yml` into `deploy.yml`, which takes an `image_tag` and is reachable two ways:

- `workflow_call` — `release.yml` calls it after pushing a new image
- `workflow_dispatch` — the **Run workflow** button, for any tag already in GHCR

One code path, so the manual button and a tag release cannot drift apart. Both share a `deploy` concurrency group, so a manual rollout and a release can never roll out over each other.

This is now the *preferred* way to roll back. `release.sh` over SSH only works for an image the box still has cached, because it holds no registry credentials by design — the workflow supplies them for the length of the run.

## Bug found while testing

`release.sh` rewrote `.env` *before* fetching the image, so a typo'd or never-built tag left the recorded tag out of step with what was actually running. It now resolves and fetches first, and aborts with everything untouched. Verified against a nonexistent tag: exit 1, `.env` still on the previous tag.

While fixing that I hit a second one — `docker compose config --images` lists services **alphabetically**, so the obvious `head -1` returns `caddy:2-alpine`, not the app image. The check would have validated the wrong image entirely. Now names the service explicitly.

## Using it

Actions → **Deploy** → Run workflow → image tag, e.g. `2.0.0`. Note **no leading `v`** — published tags are the bare semver, since `metadata-action` strips it. The repo's Packages page lists what exists. The run writes a summary showing the tag, host and trigger.

The button only appears once this is on `main`, which is how `workflow_dispatch` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UzGA67sTRrKNPNKFjBhUv