### PR TITLE
Raise release.yml's permission ceiling for the called deploy workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,14 @@ concurrency:
   group: release
   cancel-in-progress: false
 
+# A called workflow can only DOWNGRADE the caller's GITHUB_TOKEN permissions,
+# never elevate them — so this ceiling must already cover everything deploy.yml
+# asks for. With `contents: read` alone here, deploy.yml requesting
+# `packages: read` is an elevation and the whole run dies with a
+# startup_failure before a single job begins.
 permissions:
   contents: read
+  packages: write
 
 jobs:
   check:


### PR DESCRIPTION
The `v2.0.1` tag failed with `startup_failure` — no jobs ran at all.

Cause: **a called workflow can only downgrade the caller's `GITHUB_TOKEN` permissions, never elevate them.** `release.yml` set `contents: read` at workflow level; `deploy.yml`'s job asks for `packages: read`, which it needs to pull the private image. That is an elevation, so the run is rejected before any job starts.

The subtlety is that job-level permissions *within* a single workflow do not behave this way — which is exactly why the identical block ran fine as an inline `deploy` job in `v2.0.0` and only broke once #19 moved it behind `uses:`.

Fix: raise the ceiling to `packages: write`, which the `build` job needs anyway. `deploy.yml` asking for `packages: read` is then a downgrade, as required.

## Verification

Before changing anything, I dispatched `deploy.yml` standalone with a deliberately nonexistent tag (`9.9.9`) to isolate whether the file itself was at fault. It started cleanly, connected over SSH, shipped the stack definition, logged into GHCR, and failed precisely where it should:

```
Error response from daemon: failed to resolve reference "ghcr.io/radioescola-pt/site:9.9.9": not found
!!! ghcr.io/radioescola-pt/site:9.9.9 is neither pullable nor cached locally — nothing changed.
```

...then logged the server back out and skipped the smoke test. Production was untouched: `.env` still recorded `2.0.0` and the container was still `Up 2 hours (healthy)`, never restarted. So the guard added in #19 does what it claims, under real conditions.

That confirmed `deploy.yml` is sound and the fault is purely in the call relationship.

## After merging

`v2.0.1` never produced an image, so I'll delete and re-push the tag rather than burn a version number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UzGA67sTRrKNPNKFjBhUv