### PR TITLE
Render maths in explanations, and rewrite question 33 to use it

### DIFF
--- a/__tests__/unit/render-note.test.ts
+++ b/__tests__/unit/render-note.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { renderNoteToHtml } from "@/lib/content/render-note";
+
+describe("renderNoteToHtml", () => {
+  it("renders inline maths as KaTeX rather than literal dollar signs", async () => {
+    const html = await renderNoteToHtml("A reactância é $X_C$ em ohms.");
+
+    expect(html).toContain("katex");
+    expect(html).not.toContain("$X_C$");
+  });
+
+  it("renders display maths", async () => {
+    const html = await renderNoteToHtml(
+      "$$\nX_C = \\frac{1}{2\\pi f C}\n$$"
+    );
+
+    expect(html).toContain("katex-display");
+    // The fraction survives as MathML, which is what screen readers announce.
+    expect(html).toContain("<mfrac");
+  });
+
+  it("still renders GFM tables", async () => {
+    const html = await renderNoteToHtml(
+      "| Frequência | $X_C$ |\n| --- | --- |\n| 1 kHz | 1,6 kΩ |"
+    );
+
+    expect(html).toContain("<table");
+    expect(html).toContain("katex");
+  });
+
+  it("leaves ordinary prose and emphasis alone", async () => {
+    const html = await renderNoteToHtml("Um **condensador** simples.");
+
+    expect(html).toContain("<strong>condensador</strong>");
+  });
+});

--- a/app/api/notes/[category]/[id]/route.ts
+++ b/app/api/notes/[category]/[id]/route.ts
@@ -1,11 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import React from 'react';
-import { compile, run } from '@mdx-js/mdx';
-import * as runtime from 'react/jsx-runtime';
-import remarkGfm from 'remark-gfm';
-import remarkFrontmatter from 'remark-frontmatter';
-import remarkMdxFrontmatter from 'remark-mdx-frontmatter';
+import { renderNoteToHtml } from '@/lib/content/render-note';
 
 const NOTES_ROOT = path.join(process.cwd(), 'content', 'notes');
 const VALID_CATEGORIES = new Set(['1', '2', '3']);
@@ -23,14 +18,7 @@ function buildCacheKey(category: string, id: string) {
 
 async function compileMdxToHtml(filePath: string) {
   const source = await fs.readFile(filePath, 'utf8');
-  const compiled = await compile(source, {
-    remarkPlugins: [remarkFrontmatter, remarkMdxFrontmatter, remarkGfm],
-    outputFormat: 'function-body',
-  });
-  const { default: Content } = await run(compiled, runtime);
-  const { renderToStaticMarkup } = await import('react-dom/server');
-  const html = renderToStaticMarkup(React.createElement(Content));
-  return html;
+  return renderNoteToHtml(source);
 }
 
 export async function GET(

--- a/content/notes/cat1/33.mdx
+++ b/content/notes/cat1/33.mdx
@@ -1,9 +1,55 @@
-A28  Exames:(<a target='_blank' href='exams/cat1/2014_05_23.pdf'>2014_05_23p16</a>)
-
 Num condensador, **à medida que a frequência da corrente alternada aumenta, a reactância diminui**.
 
-A reactância capacitiva é dada por X<sub>C</sub> = 1 / (2πfC), com f em hertz e C em farads. A frequência aparece no denominador, pelo que a relação é inversa: duplicar a frequência reduz a reactância para metade. Por exemplo, um condensador de 100 nF apresenta X<sub>C</sub> = 1 / (2π × 1000 × 100×10<sup>-9</sup>) ≈ 1,6 kΩ a 1 kHz, mas apenas cerca de 160 Ω a 10 kHz.
+## A fórmula
 
-Fisicamente, o condensador opõe-se à variação da tensão aos seus terminais: a corrente que o atravessa é a corrente de carga e descarga das armaduras. A frequências mais altas, a tensão inverte-se mais vezes por segundo, o condensador carrega e descarrega mais frequentemente e circula por isso mais corrente para a mesma tensão aplicada, o que equivale a uma oposição menor. Nos casos extremos: em corrente contínua (f = 0) a reactância é infinita e o condensador bloqueia a corrente; a frequências muito altas comporta-se quase como um curto-circuito. É este comportamento que o torna útil como condensador de acoplamento (deixa passar o sinal e bloqueia a componente contínua) e em filtros passa-alto.
+A reactância capacitiva é dada por
 
-As restantes opções estão erradas: dizer que a reactância aumenta com a frequência descreve uma bobina (X<sub>L</sub> = 2πfL), não um condensador; e a amplitude da corrente não entra na fórmula, porque a reactância é uma propriedade do componente à frequência de trabalho, não do nível do sinal aplicado.
+$$
+X_C = \frac{1}{2\pi f C}
+$$
+
+com $f$ em hertz, $C$ em farads e $X_C$ em ohms. A frequência está no
+**denominador**, pelo que a relação é inversa: duplicar $f$ reduz $X_C$ para
+metade.
+
+Para um condensador de $100\ \text{nF}$:
+
+| Frequência | $X_C$ |
+| --- | --- |
+| $100\ \text{Hz}$ | $\approx 15{,}9\ \text{k}\Omega$ |
+| $1\ \text{kHz}$ | $\approx 1{,}6\ \text{k}\Omega$ |
+| $10\ \text{kHz}$ | $\approx 159\ \Omega$ |
+| $100\ \text{kHz}$ | $\approx 15{,}9\ \Omega$ |
+
+Cada salto de dez vezes na frequência divide a reactância por dez. A conta para
+$1\ \text{kHz}$, por exemplo:
+
+$$
+X_C = \frac{1}{2\pi \times 10^{3} \times 100 \times 10^{-9}} \approx 1592\ \Omega
+$$
+
+## Porque é que isto acontece
+
+O condensador opõe-se à **variação da tensão** aos seus terminais: a corrente que
+o atravessa é a corrente de carga e descarga das armaduras. A frequências mais
+altas a tensão inverte-se mais vezes por segundo, o condensador carrega e
+descarrega mais frequentemente, e circula mais corrente para a mesma tensão
+aplicada — o que equivale a uma oposição menor.
+
+Os casos extremos confirmam a fórmula:
+
+- Em corrente contínua, $f = 0$, logo $X_C \to \infty$: o condensador **bloqueia**
+  a corrente.
+- A frequências muito altas, $X_C \to 0$: comporta-se quase como um
+  **curto-circuito**.
+
+É este comportamento que o torna útil como condensador de acoplamento (deixa
+passar o sinal e bloqueia a componente contínua) e em filtros passa-alto.
+
+## Porque falham as outras opções
+
+- **A reactância aumenta com a frequência** — descreve uma *bobina*, não um
+  condensador. Na bobina a frequência está no numerador: $X_L = 2\pi f L$.
+- **As duas opções sobre a amplitude** — a amplitude não aparece na fórmula. A
+  reactância é uma propriedade do componente à frequência de trabalho, não do
+  nível do sinal aplicado.

--- a/content/questions/cat1/0033.mdx
+++ b/content/questions/cat1/0033.mdx
@@ -20,12 +20,58 @@ sources:
     question: 16
     page: 4
 ---
-A28  Exames:(<a target='_blank' href='exams/cat1/2014_05_23.pdf'>2014_05_23p16</a>)
-
 Num condensador, **à medida que a frequência da corrente alternada aumenta, a reactância diminui**.
 
-A reactância capacitiva é dada por X<sub>C</sub> = 1 / (2πfC), com f em hertz e C em farads. A frequência aparece no denominador, pelo que a relação é inversa: duplicar a frequência reduz a reactância para metade. Por exemplo, um condensador de 100 nF apresenta X<sub>C</sub> = 1 / (2π × 1000 × 100×10<sup>-9</sup>) ≈ 1,6 kΩ a 1 kHz, mas apenas cerca de 160 Ω a 10 kHz.
+## A fórmula
 
-Fisicamente, o condensador opõe-se à variação da tensão aos seus terminais: a corrente que o atravessa é a corrente de carga e descarga das armaduras. A frequências mais altas, a tensão inverte-se mais vezes por segundo, o condensador carrega e descarrega mais frequentemente e circula por isso mais corrente para a mesma tensão aplicada, o que equivale a uma oposição menor. Nos casos extremos: em corrente contínua (f = 0) a reactância é infinita e o condensador bloqueia a corrente; a frequências muito altas comporta-se quase como um curto-circuito. É este comportamento que o torna útil como condensador de acoplamento (deixa passar o sinal e bloqueia a componente contínua) e em filtros passa-alto.
+A reactância capacitiva é dada por
 
-As restantes opções estão erradas: dizer que a reactância aumenta com a frequência descreve uma bobina (X<sub>L</sub> = 2πfL), não um condensador; e a amplitude da corrente não entra na fórmula, porque a reactância é uma propriedade do componente à frequência de trabalho, não do nível do sinal aplicado.
+$$
+X_C = \frac{1}{2\pi f C}
+$$
+
+com $f$ em hertz, $C$ em farads e $X_C$ em ohms. A frequência está no
+**denominador**, pelo que a relação é inversa: duplicar $f$ reduz $X_C$ para
+metade.
+
+Para um condensador de $100\ \text{nF}$:
+
+| Frequência | $X_C$ |
+| --- | --- |
+| $100\ \text{Hz}$ | $\approx 15{,}9\ \text{k}\Omega$ |
+| $1\ \text{kHz}$ | $\approx 1{,}6\ \text{k}\Omega$ |
+| $10\ \text{kHz}$ | $\approx 159\ \Omega$ |
+| $100\ \text{kHz}$ | $\approx 15{,}9\ \Omega$ |
+
+Cada salto de dez vezes na frequência divide a reactância por dez. A conta para
+$1\ \text{kHz}$, por exemplo:
+
+$$
+X_C = \frac{1}{2\pi \times 10^{3} \times 100 \times 10^{-9}} \approx 1592\ \Omega
+$$
+
+## Porque é que isto acontece
+
+O condensador opõe-se à **variação da tensão** aos seus terminais: a corrente que
+o atravessa é a corrente de carga e descarga das armaduras. A frequências mais
+altas a tensão inverte-se mais vezes por segundo, o condensador carrega e
+descarrega mais frequentemente, e circula mais corrente para a mesma tensão
+aplicada — o que equivale a uma oposição menor.
+
+Os casos extremos confirmam a fórmula:
+
+- Em corrente contínua, $f = 0$, logo $X_C \to \infty$: o condensador **bloqueia**
+  a corrente.
+- A frequências muito altas, $X_C \to 0$: comporta-se quase como um
+  **curto-circuito**.
+
+É este comportamento que o torna útil como condensador de acoplamento (deixa
+passar o sinal e bloqueia a componente contínua) e em filtros passa-alto.
+
+## Porque falham as outras opções
+
+- **A reactância aumenta com a frequência** — descreve uma *bobina*, não um
+  condensador. Na bobina a frequência está no numerador: $X_L = 2\pi f L$.
+- **As duas opções sobre a amplitude** — a amplitude não aparece na fórmula. A
+  reactância é uma propriedade do componente à frequência de trabalho, não do
+  nível do sinal aplicado.

--- a/lib/content/render-note.ts
+++ b/lib/content/render-note.ts
@@ -1,0 +1,31 @@
+import React from 'react';
+import { compile, run } from '@mdx-js/mdx';
+import * as runtime from 'react/jsx-runtime';
+import remarkGfm from 'remark-gfm';
+import remarkFrontmatter from 'remark-frontmatter';
+import remarkMdxFrontmatter from 'remark-mdx-frontmatter';
+import remarkMath from 'remark-math';
+import rehypeKatex from 'rehype-katex';
+
+/**
+ * Compiles one explanation's MDX to static HTML.
+ *
+ * Lives here rather than inline in the route so the plugin list is covered by
+ * tests. Dropping a plugin fails silently and only in production — maths would
+ * come out as literal `$` signs on the question card, with nothing erroring.
+ *
+ * Note that `next.config.js` configures the same plugins for MDX *pages*; that
+ * has no effect here, because explanations are compiled at request time rather
+ * than at build time. Both lists have to be kept in step.
+ * `katex.min.css` is loaded globally in `app/layout.tsx`.
+ */
+export async function renderNoteToHtml(source: string): Promise<string> {
+  const compiled = await compile(source, {
+    remarkPlugins: [remarkFrontmatter, remarkMdxFrontmatter, remarkGfm, remarkMath],
+    rehypePlugins: [rehypeKatex],
+    outputFormat: 'function-body',
+  });
+  const { default: Content } = await run(compiled, runtime);
+  const { renderToStaticMarkup } = await import('react-dom/server');
+  return renderToStaticMarkup(React.createElement(Content));
+}


### PR DESCRIPTION
Question 33's explanation wrote its formulas as `X<sub>C</sub> = 1 / (2πfC)`. It now uses real typeset maths — but that needed a fix first.

## Maths did not render at all

`/api/notes` compiled MDX with `remarkFrontmatter`, `remarkMdxFrontmatter` and `remarkGfm` — **no `remark-math`, no `rehype-katex`**. So `$X_C$` in an explanation would have come out as literal dollar signs on the question card.

`next.config.js` *does* wire both plugins, which is why this looks configured — but that covers MDX **pages**, and explanations are compiled at request time by this route, which keeps its own plugin list. `katex.min.css` was already imported globally in `app/layout.tsx`, so only the plugins were missing. No note in the corpus used maths, so nothing had ever exercised the path.

## Verified through the whole pipeline

The risky step is `QuestionCard`, which runs the compiled HTML through `DOMPurify.sanitize()` before `dangerouslySetInnerHTML`. KaTeX emits MathML plus heavily style-attributed spans, so it was worth checking rather than assuming:

| | before | after sanitize |
|---|---|---|
| `<math>` elements | 22 | 22 |
| `katex-mathml` / `katex-html` spans | 22 / 22 | 22 / 22 |
| `<mfrac>` | 2 | 2 |
| inline `style` attributes | 138 | 138 |
| `aria-hidden` | 22 | 22 |

The only thing stripped is `encoding="application/x-tex"` from the MathML `<annotation>` elements — metadata that does not affect rendering. Text content is identical.

## The explanation itself

- Formulas as display maths instead of `<sub>`/`<sup>`: $X_C = \frac{1}{2\pi f C}$
- A table of $X_C$ against frequency for a 100 nF capacitor (100 Hz → 100 kHz), so "each ten-fold rise in frequency divides reactance by ten" is *visible* rather than asserted
- Headings, so the formula, the physical intuition and the wrong-answer analysis are separable
- The $X_L = 2\pi f L$ contrast made explicit where the distractor is addressed
- Worked arithmetic kept, corrected to 159 Ω (was "cerca de 160 Ω"; 1592/10 = 159.2, and question 34 already says 159)

## Made testable

Compilation moves to `lib/content/render-note.ts` so the plugin list is covered by tests. Losing a plugin fails silently and only in production — precisely the bug being fixed here. Four tests cover inline maths, display maths, GFM tables alongside maths, and plain emphasis.

## Found while doing this — not fixed here

The explanation began with a legacy line duplicating the `sources` frontmatter:

```
A28  Exames:(<a target='_blank' href='exams/cat1/2014_05_23.pdf'>2014_05_23p16</a>)
```

Its `href` is **relative**, so from `/browse/1` it resolves to `/browse/exams/cat1/2014_05_23.pdf` → **404** (confirmed against production; `/exams/...` returns 200).

This is not isolated: **396 questions** carry that line, and **all 901** such hrefs in the corpus are relative. None use an absolute path. I removed it from question 33 only, since `sources` already drives the UI's PDF link. Happy to sweep the other 395 — say the word.

Type-check, lint and 231 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UzGA67sTRrKNPNKFjBhUv