### PR TITLE
Serve www.radioescola.pt as the canonical origin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,8 +41,11 @@ jobs:
     # Scopes the SSH secrets to this job and gives you somewhere to add a
     # manual approval later (Settings → Environments → production).
     environment:
+      # SITE_URL is the public site; DEPLOY_HOST is the box we SSH to. They were
+      # the same name until www became canonical — keep them apart so a DNS
+      # change to the public name can never redirect a deploy.
       name: production
-      url: https://${{ vars.DEPLOY_HOST }}
+      url: ${{ vars.SITE_URL || format('https://{0}', vars.DEPLOY_HOST) }}
     steps:
       - uses: actions/checkout@v7
 
@@ -91,18 +94,22 @@ jobs:
       # obtaining the certificate on a first deploy to a new host.
       - name: Smoke test
         env:
-          HOST: ${{ vars.DEPLOY_HOST }}
+          # Checks the site the public actually reaches, through whatever DNS
+          # and redirects are in front of it. --location so an apex-to-www
+          # redirect is followed rather than counted as a pass.
+          SITE_URL: ${{ vars.SITE_URL || format('https://{0}', vars.DEPLOY_HOST) }}
         run: |
-          curl --fail --silent --show-error \
+          curl --fail --silent --show-error --location \
                --retry 12 --retry-delay 5 --retry-all-errors \
                --max-time 120 \
-               "https://$HOST/api/health"
+               "$SITE_URL/api/health"
 
       - name: Summary
         if: always()
         env:
           TAG: ${{ inputs.image_tag }}
-          HOST: ${{ vars.DEPLOY_HOST }}
+          SITE_URL: ${{ vars.SITE_URL || format('https://{0}', vars.DEPLOY_HOST) }}
+          DEPLOY_HOST: ${{ vars.DEPLOY_HOST }}
         run: |
           {
             echo "### Deploy"
@@ -110,6 +117,7 @@ jobs:
             echo "| | |"
             echo "|---|---|"
             echo "| Image tag | \`$TAG\` |"
-            echo "| Host | https://$HOST |"
+            echo "| Site | $SITE_URL |"
+            echo "| Deployed to | $DEPLOY_HOST |"
             echo "| Triggered by | ${{ github.event_name }} |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,12 +1,26 @@
 # Terminates TLS (certificates issued and renewed automatically) and proxies to
 # the app container. Next sets its own Cache-Control headers, so nothing here
 # second-guesses them.
-server.radioescola.pt {
+#
+# Certificates are issued on demand over HTTP-01, so a name must already resolve
+# to this host before it is added here — otherwise the challenge fails and Let's
+# Encrypt counts it against the failed-validation limit (5 per hostname/hour).
+
+# The canonical public site.
+www.radioescola.pt {
 	encode zstd gzip
 	reverse_proxy app:3000
 }
 
-# To also serve the apex domain, point its DNS at this host and add:
-# radioescola.pt {
-# 	redir https://server.radioescola.pt{uri}
-# }
+# Apex redirects to www rather than serving a second copy, so there is one
+# canonical origin and no duplicate-content split.
+radioescola.pt {
+	redir https://www.radioescola.pt{uri} permanent
+}
+
+# Kept as an alias so deploys and health checks never depend on the public name
+# — if a DNS change breaks www, this still reaches the box.
+server.radioescola.pt {
+	encode zstd gzip
+	reverse_proxy app:3000
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -40,9 +40,24 @@ Everything below runs on the VPS as `root` unless noted.
 
 ### 1. DNS
 
-Point `server.radioescola.pt` at the VPS (`A`, plus `AAAA` if it has IPv6)
-*before* the first deploy. Caddy issues the certificate on startup and needs the
-name to resolve to itself.
+Point every name Caddy serves at the VPS (`A`, plus `AAAA` if it has IPv6)
+*before* deploying a Caddyfile that mentions it. Certificates are issued on
+demand over HTTP-01, so a name that does not yet resolve here fails the
+challenge — and Let's Encrypt allows only **5 failed validations per hostname
+per hour**.
+
+The names currently served, from `deploy/Caddyfile`:
+
+| Name | Role |
+| --- | --- |
+| `www.radioescola.pt` | canonical public site |
+| `radioescola.pt` | permanent redirect to www |
+| `server.radioescola.pt` | alias, kept so deploys never depend on the public name |
+
+When moving a live name across (as `www` was, from GitHub Pages): lower its TTL
+first, flip the DNS, confirm it resolves to this host, and only then deploy the
+Caddyfile that claims it. Doing it the other way round burns failed validations
+while the old host still answers the challenge.
 
 ### 2. Base system
 
@@ -170,8 +185,9 @@ tag, not an edit on the server.
 
 | Variable | Value |
 | --- | --- |
-| `DEPLOY_HOST` | `server.radioescola.pt` |
+| `DEPLOY_HOST` | `server.radioescola.pt` — the box to SSH to |
 | `DEPLOY_USER` | `deploy` |
+| `SITE_URL` | `https://www.radioescola.pt` — the public site, used for the smoke test and the environment link. Falls back to `https://$DEPLOY_HOST` if unset |
 | `NEXT_PUBLIC_GAMIFICATION` | `true` to ship gamification, otherwise leave unset |
 
 **Settings → Environments → New environment → `production`**, then add its

--- a/lib/share/templates.ts
+++ b/lib/share/templates.ts
@@ -1,6 +1,8 @@
 import type { ShareContent } from "./share-service";
 
-const APP_URL = "https://radioescola.pt";
+// The canonical origin. Shared links point straight at it rather than at the
+// apex, which redirects — a shared result should not cost the recipient a hop.
+const APP_URL = "https://www.radioescola.pt";
 const HASHTAGS = ["hamradio", "radioamador", "portugal"];
 
 interface ExamResultParams {


### PR DESCRIPTION
Prepares the deployment to answer on `www.radioescola.pt` instead of only `server.radioescola.pt`. **Merging this is safe; it changes nothing until the Caddyfile is deployed, which must happen after the DNS flip.**

## Caddyfile

| Name | Role |
|---|---|
| `www.radioescola.pt` | canonical public site |
| `radioescola.pt` | permanent redirect to www — one canonical origin, no duplicate-content split |
| `server.radioescola.pt` | kept as an alias, so deploys and health checks never depend on the public name |

Keeping `server.` matters: if a DNS change to `www` goes wrong, the deploy path still reaches the box.

Verified with `caddy validate` inside `caddy:2-alpine` — "Valid configuration".

## The workflow bug this exposed

`vars.DEPLOY_HOST` was doing three unrelated jobs: the scp/ssh target, the `environment.url`, and the smoke-test URL. They were the same string only by coincidence, and stop being so as soon as the public name isn't the box's own name. Simply repointing `DEPLOY_HOST` at `www` would have started routing SSH through the public DNS record.

Split out `SITE_URL`, with `${{ vars.SITE_URL || format('https://{0}', vars.DEPLOY_HOST) }}` so behaviour is unchanged until the variable is set.

The smoke test also gained `--location`. Without it, a request to a redirecting name returns 301 and `--fail` treats that as success — the check would pass without the site being up.

## Share links

`lib/share/templates.ts` hardcoded `https://radioescola.pt` (apex, no www), so every shared exam result, achievement and streak link would take a redirect hop once the apex redirects. Now points at `https://www.radioescola.pt` directly.

## Cutover order — this matters

Caddy issues certificates on demand over HTTP-01, and Let's Encrypt allows only **5 failed validations per hostname per hour**. If the Caddyfile claims `www` while DNS still points at GitHub Pages, the challenge is answered by Pages and fails.

So:

1. Lower the TTL on `www` and the apex
2. Flip DNS: `www` → `CNAME server.radioescola.pt`, apex → `A 178.159.34.183`
3. Confirm both resolve to `178.159.34.183`
4. Set the `SITE_URL` repo variable to `https://www.radioescola.pt`
5. Deploy — Actions → Deploy → Run workflow → current image tag
6. Remove the custom domain from the old repo's Pages settings and delete its `CNAME` file

Steps 1, 2 and 6 are yours; I can do 3, 4 and 5 on your signal.

Type-check, lint and 231 tests pass.