### PR TITLE
Reload Caddy on deploy so Caddyfile changes take effect

### DIFF
--- a/deploy/release.sh
+++ b/deploy/release.sh
@@ -38,6 +38,30 @@ printf 'IMAGE_TAG=%s\n' "$TAG" > .env
 # --wait makes an unhealthy new container a failed deploy instead of a
 # silently broken site.
 docker compose up -d --remove-orphans --wait
+
+# `up -d` only recreates a container whose *configuration* changed. The
+# Caddyfile is a bind-mounted file, so editing its contents is invisible to
+# compose and Caddy keeps serving the config it started with — a new hostname
+# added here would never take effect, with nothing reporting an error. Reload it
+# explicitly. This is graceful: connections are not dropped and certificates
+# already held are kept.
+# Retried because on a cold start Caddy's admin API may not be listening yet,
+# and failing the deploy over that would be a false alarm — it started with the
+# new config in that case anyway.
+reloaded=""
+for attempt in 1 2 3; do
+  if docker compose exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile; then
+    reloaded=yes
+    break
+  fi
+  echo "==> caddy reload attempt $attempt failed; retrying"
+  sleep 3
+done
+if [ -z "$reloaded" ]; then
+  echo "!!! Caddy would not accept the new config; it is still serving the previous one." >&2
+  exit 1
+fi
+
 docker image prune -f
 
 docker compose ps

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,6 +34,12 @@ git tag v2.0.0  ──▶  .github/workflows/release.yml
 Edit the `deploy/` files here, never on the server — the next deploy overwrites
 whatever is in `~/app`.
 
+`release.sh` reloads Caddy explicitly after copying the stack across. It has to:
+`docker compose up -d` only recreates a container whose *configuration* changed,
+and the Caddyfile is a bind-mounted file, so editing its contents is invisible
+to compose. Without the reload, a hostname added to the Caddyfile silently never
+takes effect — the deploy reports success and the new name serves nothing.
+
 ## One-time server setup
 
 Everything below runs on the VPS as `root` unless noted.


### PR DESCRIPTION
The `v2.0.3` deploy shipped a Caddyfile adding `www.radioescola.pt`, reported success, and left Caddy serving the **old** config. `docker compose ps` showed it as `Up 4 hours` — it was never recreated. `www` stayed unreachable until I reloaded Caddy by hand.

## Why

`docker compose up -d` only recreates a container whose *configuration* changed. The app container cycled because its image tag changed. The Caddyfile is a **bind-mounted file**, so editing its contents changes nothing compose can see — Caddy carried on with the config it had at startup.

Nothing errored. The rollout step passed, the container was healthy, and only the smoke test caught it — and only because it now checks `SITE_URL` rather than the box's own name. Had I not split that variable in #24, this would have gone entirely unnoticed until someone visited `www`.

## Fix

`release.sh` now reloads Caddy explicitly after shipping the stack, and fails the deploy if the config is rejected. The reload is graceful — connections are kept and certificates already held are not re-fetched.

Retried three times: on a cold start Caddy's admin API may not be listening yet, and failing a deploy over that would be a false alarm, since Caddy started with the new config in that case anyway.

## Current production state

Already reconciled by hand, so this changes nothing about what is live now — it makes the *next* Caddyfile change work without intervention.

- `www.radioescola.pt` — serving, valid Let's Encrypt cert (`CN=www.radioescola.pt`, expires 22 Nov 2026)
- `server.radioescola.pt` — serving, unchanged
- `radioescola.pt` — still on GitHub Pages, which redirects to www of its own accord, so the apex behaves correctly by accident. Once its A record moves to `178.159.34.183`, Caddy's own redirect takes over and it will need a cert — which is exactly the case this fix covers.