### PR TITLE
Point the deployment at the renamed repository

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ git tag -a v2.0.0 -m "Release 2.0.0" && git push origin v2.0.0
 ```
 
 `.github/workflows/release.yml` runs the checks, builds `Dockerfile`, pushes
-`ghcr.io/radioescola-pt/site:2.0.0`, then calls `deploy.yml` to roll it out.
+`ghcr.io/radioescola-pt/radioescola:2.0.0`, then calls `deploy.yml` to roll it out.
 
 `deploy.yml` also runs on its own from **Actions → Deploy → Run workflow**,
 taking an image tag — that is how you redeploy or roll back, and it beats

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Built with Next.js 16, React 19, TypeScript, and Tailwind CSS v4.
 ### Setup
 
 ```bash
-git clone https://github.com/jcalado/hamradiostudy.git
-cd hamradiostudy
+git clone https://github.com/RadioEscola-pt/radioescola.git
+cd radioescola
 bun install
 bun run dev
 ```

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -6,7 +6,7 @@ services:
   app:
     # IMAGE_TAG comes from ~/app/.env, which release.sh rewrites on every
     # deploy. Rolling back is therefore just release.sh with an older tag.
-    image: ghcr.io/radioescola-pt/site:${IMAGE_TAG:?set IMAGE_TAG in .env}
+    image: ghcr.io/radioescola-pt/radioescola:${IMAGE_TAG:?set IMAGE_TAG in .env}
     restart: unless-stopped
     # Runtime secrets only (RESEND_*). Build-time NEXT_PUBLIC_* flags are
     # already baked into the image and cannot be changed from here.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -9,7 +9,7 @@ release is an immutable image you can roll back to by name.
 git tag v2.0.0  ──▶  .github/workflows/release.yml
                         │
                         ├─ check    type-check, lint, test, content:check
-                        ├─ build    Dockerfile ──▶ ghcr.io/radioescola-pt/site:2.0.0
+                        ├─ build    Dockerfile ──▶ ghcr.io/radioescola-pt/radioescola:2.0.0
                         └─ deploy ──▶ deploy.yml (also runnable on its own,
                                       for a redeploy or a rollback)
                                         │
@@ -217,6 +217,19 @@ does not come up healthy, and a final smoke test hits `/api/health` through
 Caddy.
 
 Only `v*.*.*` tags trigger a release. Pushes to `main` run the checks only.
+
+## The repository rename
+
+The image name comes from `ghcr.io/${{ github.repository }}`, so it follows a
+repository rename automatically — but `deploy/compose.yaml` names it literally
+and does not. Both have to move together, or the workflow publishes to one
+package while the server pulls from another and `release.sh` aborts with
+"neither pullable nor cached".
+
+**Packages do not rename with the repository.** Tags published before a rename
+stay under the old package name, so a rollback across a rename cannot reach
+them. Do not delete the old package, and cut a fresh tag straight after
+renaming so the new one has something to roll back to.
 
 ## Deploying by hand, and rolling back
 


### PR DESCRIPTION
Prepares for renaming `site` → `radioescola`. **Do not merge until the rename has happened** — merging first would point compose at a package that does not exist yet.

## The one thing that actually breaks

`release.yml` builds `ghcr.io/${{ github.repository }}`, so it follows a rename on its own. `deploy/compose.yaml` names the image literally and does not:

```yaml
image: ghcr.io/radioescola-pt/site:${IMAGE_TAG:?...}
```

After a rename the workflow would publish to `…/radioescola` while the server pulls from `…/site`, so the new tag would not exist where compose looks. `release.sh` aborts on that ("neither pullable nor cached") rather than deploying, so the failure is clean and the running site is untouched — but it is a failed release.

## Rollback across the rename is one-way

Packages do not rename with their repository. Tags `2.0.0`–`2.0.3` stay under the old package name, so once compose points at the new one, `release.sh 2.0.3` cannot find them. Documented in the runbook, with two consequences:

- **Do not delete the old package.**
- Cut a fresh tag straight after renaming, so the new package has something to roll back to.

## Also included

The README clone URL, which was still on the pre-org name (`RadioEscola-pt/site`) — that is the one-line change that has been sitting uncommitted in the working tree all session, now updated to the post-rename name.

## Sequence

1. You rename `site` → `radioescola` (the name is free — you already renamed the old repo to `radioescola-v1`)
2. Merge this, and #25
3. Tag `v2.0.4` — publishes the first image under the new name and proves the pipeline end to end

Nothing deploys between 1 and 3, so there is no window where the pipeline is broken.

## Not affected by the rename

Secrets, repo variables, the `production` environment, Actions history, branch protections, and the running container — its `.env` pins `2.0.3`, already pulled. Old GitHub URLs and PR links redirect; local git remotes keep working, though worth updating.