### PR TITLE
Cut release time by dropping a cache that never hits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,11 @@ jobs:
   check:
     uses: ./.github/workflows/ci.yml
 
+  # Deliberately NOT gated on `check`: it publishes an image, it does not deploy
+  # one. Running it alongside the checks halves the wall clock, and the worst
+  # case is an unused image in GHCR for a commit whose tests then failed —
+  # `deploy` needs both, so nothing unverified can reach the server.
   build:
-    needs: check
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -54,21 +57,25 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
 
+      # No build cache on purpose. Measured on v2.0.3: exporting to the GitHub
+      # Actions cache took 250s of a 351s build and produced *zero* cache hits,
+      # because that cache is scoped by ref and tag builds cannot read each
+      # other's entries. Nothing here is worth caching anyway — `COPY . .`
+      # invalidates every layer after the deps stage on every commit, and that
+      # stage is only ~15s of `bun install`.
       - uses: docker/build-push-action@v7
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           build-args: |
             NEXT_PUBLIC_GAMIFICATION=${{ vars.NEXT_PUBLIC_GAMIFICATION }}
 
   # The rollout itself lives in deploy.yml so the same steps back both a tag
   # release and the manual "Run workflow" button (redeploys and rollbacks).
   deploy:
-    needs: build
+    needs: [check, build]
     uses: ./.github/workflows/deploy.yml
     with:
       image_tag: ${{ needs.build.outputs.image_tag }}


### PR DESCRIPTION
The `v2.0.3` release took **13.2 minutes**. Measured where it went rather than guessing:

| | |
|---|---|
| `check` | 4.9 min |
| `build` | 6.5 min |
| `deploy` | 1.7 min |

And inside the 351s build step:

| | |
|---|---|
| **cache export to GHA** | **250.2s** |
| `next build` | 40.9s |
| image push to GHCR | 18.9s |
| `bun install` | 15.4s |
| context upload (188 MB) | 2.9s |

## The cache was pure cost

71% of the build was exporting to the GitHub Actions cache — and the build log shows **zero `CACHED` layers**. It was written on every release and never once read.

The reason is that GHA cache is **scoped by ref**. A cache written during the `v2.0.2` tag run is not readable from the `v2.0.3` tag run, because tags do not inherit from one another. So a tag-triggered pipeline can never hit it, by construction.

Nothing here is worth caching anyway: `COPY . .` invalidates every layer after the deps stage on each commit, and that stage is ~15s of `bun install`. Spending 250s to maybe save 15s would be a bad trade even if it worked.

Removed rather than switched to registry cache: with only ~15s of cacheable work, any export mechanism costing more than that is a net loss.

## Serialisation

`build` was gated on `check`, so ~5 min of checks and ~6.5 min of build ran back to back. But `build` only *publishes* an image — it does not deploy one. It now runs alongside `check`, and `deploy` needs **both**, which is what actually keeps unverified code off the server.

Worst case is an unused image in GHCR for a commit whose tests then failed. That is a registry blob nobody pulls.

## Expected

**~13 min → ~4 min.** Build drops to roughly 100s and overlaps the checks; deploy stays ~1.7 min. I will confirm against the next release rather than assert it.

## Not a problem, despite appearances

That run's `actions/checkout` took 245s, which looks like the 169 MB of exam PDFs. Across the last ten runs it is 4–12s, so that was an outlier and there is nothing to fix. Worth stating explicitly since it is the obvious thing to blame.