### PR TITLE
Check out only deploy/ in the deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,13 @@ jobs:
       name: production
       url: ${{ vars.SITE_URL || format('https://{0}', vars.DEPLOY_HOST) }}
     steps:
+      # Only the stack definition is needed here — the three files scp'd below.
+      # A full checkout drags in ~180 MB of exam PDFs, which is normally 4-12s
+      # but has twice taken over three minutes (191s on v2.0.4, 245s on v2.0.3),
+      # dwarfing the 21s rollout it exists to serve.
       - uses: actions/checkout@v7
+        with:
+          sparse-checkout: deploy
 
       - name: Configure SSH
         env:


### PR DESCRIPTION
The deploy job needs exactly three files — `deploy/compose.yaml`, `deploy/Caddyfile`, `deploy/release.sh` — but was cloning the whole repository, including ~180 MB of exam PDFs.

## Correcting something I got wrong

In #27 I wrote that the 245s checkout on `v2.0.3` was an outlier and there was nothing to fix, because it is 4–12s across most runs. `v2.0.4` took **191s**. Two out of two releases, so it is a recurring cost, not noise.

The damage on `v2.0.4`:

| Deploy step | |
|---|---|
| **`actions/checkout`** | **191s** |
| Roll out | 21s |
| Ship stack definition | 3s |
| everything else | ~4s |

The checkout was 191s of a 221s job, to fetch three small files.

`sparse-checkout: deploy` removes the variance rather than hoping for the fast case.

## Result of #27, for the record

The cache removal landed as predicted — the build step went **351s → 106s**, and `check` now overlaps `build`. Total release time went **13.2 min → 6 min**. With this change the remainder should drop to roughly 4 min, which is what #27 originally estimated before this checkout cost showed up in a different job.

The `check` and `build` jobs still need a full checkout, so they keep one.