### PR TITLE
Update the cat3 licensing questions to Lei 22/2026

### DIFF
--- a/content/notes/cat3/160.mdx
+++ b/content/notes/cat3/160.mdx
@@ -2,7 +2,7 @@
 
 A categoria 3 é a porta de entrada no radioamadorismo em Portugal, e o acesso ao exame não tem idade mínima. O que a lei exige, quando o candidato é menor, é o consentimento formal de quem responde por ele: uma autorização escrita de quem exerça a responsabilidade parental ou a tutela, nos termos da lei civil. Sem essa autorização o pedido não pode ser aceite; com ela, não há limite inferior de idade.
 
-Convém não confundir o acesso ao exame com o que se pode fazer depois de o passar. Um titular de CAN menor de 16 anos só pode utilizar estações de amador em modo de emissão se for supervisionado por um amador com idade igual ou superior a 16 anos e com privilégios de acesso às faixas de frequências iguais ou superiores aos seus. A idade não trava a certificação, mas condiciona a operação.
+Convém não confundir o acesso ao exame com o que se pode fazer depois de o passar. Um titular de CAN da categoria 3 com menos de 16 anos só pode utilizar estações de amador sob a supervisão de um amador com idade igual ou superior a 16 anos e com privilégios de acesso às faixas de frequências iguais ou superiores aos seus. A idade não trava a certificação, mas condiciona a operação.
 
 As restantes opções fixam limiares de idade que a lei não impõe. É a palavra "apenas" que as torna erradas: qualquer uma delas excluiria candidatos que a lei admite.
 

--- a/content/notes/cat3/160.mdx
+++ b/content/notes/cat3/160.mdx
@@ -1,5 +1,9 @@
-**Podem requerer o exame de categoria 3 os maiores de 12 anos.**
+**Podem requerer o exame de categoria 3 os indivíduos de qualquer idade. Sendo o candidato menor, é necessária autorização escrita de quem exerça o poder paternal ou a tutela.**
 
-A categoria 3 é a porta de entrada no radioamadorismo em Portugal, e por isso a idade mínima exigida é propositadamente baixa. A ideia é permitir que jovens interessados comecem cedo, ainda em idade escolar, a aprender e a praticar radiocomunicações de forma legal e acompanhada. Basta ter mais de 12 anos para pedir à ANACOM a realização do exame.
+A categoria 3 é a porta de entrada no radioamadorismo em Portugal, e o acesso ao exame não tem idade mínima. O que a lei exige, quando o candidato é menor, é o consentimento formal de quem responde por ele: uma autorização escrita de quem exerça a responsabilidade parental ou a tutela, nos termos da lei civil. Sem essa autorização o pedido não pode ser aceite; com ela, não há limite inferior de idade.
 
-As restantes opções (16, 18 ou 21 anos) indicam idades superiores à que a regulamentação define para esta categoria. Convém fixar o valor: para a categoria de iniciação, bastam os 12 anos, sem necessidade de esperar pela maioridade.
+Convém não confundir o acesso ao exame com o que se pode fazer depois de o passar. Um titular de CAN menor de 16 anos só pode utilizar estações de amador em modo de emissão se for supervisionado por um amador com idade igual ou superior a 16 anos e com privilégios de acesso às faixas de frequências iguais ou superiores aos seus. A idade não trava a certificação, mas condiciona a operação.
+
+As restantes opções fixam limiares de idade que a lei não impõe. É a palavra "apenas" que as torna erradas: qualquer uma delas excluiria candidatos que a lei admite.
+
+**Nota sobre a alteração da lei.** Até 24 de agosto de 2026 a resposta certa era "maiores de 12 anos", e é essa a formulação que consta das provas anteriores a essa data, como a pergunta 7 da prova de 18-08-2023. A Lei n.º 22/2026, de 27 de maio, que alterou o Decreto-Lei n.º 53/2009 e entrou em vigor a 25 de agosto de 2026, eliminou a idade mínima e passou a exigir autorização escrita no caso de candidatos menores.

--- a/content/notes/cat3/162.mdx
+++ b/content/notes/cat3/162.mdx
@@ -1,5 +1,9 @@
-**O acesso à categoria 1 faz-se mediante exame, ao qual podem candidatar-se amadores com pelo menos 1 ano de permanência na categoria 2, bem como os amadores das antigas categorias A e B.**
+**O acesso à categoria 1 faz-se mediante exame, ao qual podem candidatar-se os amadores da categoria 2 e os amadores das antigas categorias A e B.**
 
-A ideia por trás desta regra é simples: a categoria 1 é a mais avançada e exige mais conhecimentos, por isso não se entra nela diretamente. Primeiro é preciso ganhar experiência na categoria 2 durante um período mínimo, e só depois prestar o exame de acesso. As categorias A e B são designações do sistema antigo de classificação de amadores, e quem as detém pode também candidatar-se a este exame.
+Não existe qualquer período mínimo de permanência na categoria 2: basta ser amador dessa categoria para se poder candidatar ao exame de acesso à categoria 1. As categorias A e B pertencem ao sistema de classificação anterior, e quem as detém pode candidatar-se diretamente, sem ter de passar pela categoria 2.
 
-As restantes opções falham porque endurecem ou alargam a regra de forma errada: a regulamentação não exige 18 anos de idade nem 5 anos de permanência na categoria 2, e também não admite ao exame os amadores da categoria 3 (ou da antiga categoria C), que teriam primeiro de subir à categoria 2.
+O enunciado refere a outra via de acesso para a excluir da pergunta: o reconhecimento de títulos habilitantes válidos emitidos por outras Administrações. São dois caminhos distintos para o mesmo fim, e a pergunta incide sobre o segundo.
+
+As restantes opções acrescentam condições que a lei não prevê ou alargam indevidamente o universo de candidatos. Não é exigida idade mínima de 18 anos nem permanência de 5 anos na categoria 2. E os amadores da categoria 3, ou da antiga categoria C, não se podem candidatar diretamente ao exame de categoria 1: têm primeiro de aceder à categoria 2.
+
+**Nota sobre a alteração da lei.** Até 24 de agosto de 2026 exigia-se pelo menos 1 ano de permanência na categoria 2, e é essa a formulação que consta das provas anteriores, como a pergunta 8 da prova de 18-08-2023. A Lei n.º 22/2026, de 27 de maio, em vigor desde 25 de agosto de 2026, eliminou esse requisito.

--- a/content/questions/cat3/0160.mdx
+++ b/content/questions/cat3/0160.mdx
@@ -1,21 +1,22 @@
 ---
 id: 160
-question: >-
-  Podem requerer à ANACOM a realização de exame para a categoria 3, os
-  indivíduos
+question: Podem requerer à ANACOM a realização de exame para a categoria 3
 answers:
-  - text: maiores de 12 anos
+  - text: >-
+      os indivíduos de qualquer idade, com autorização escrita de quem exerça o
+      respetivo poder paternal ou tutela, nos termos da lei civil, no caso de se
+      tratar de candidato menor
     correct: true
-  - text: maiores de 16 anos
-  - text: maiores de 18 anos
-  - text: maiores de 21 anos
-sources:
-  - pdf: cat3/2023_08_18
-    question: 7
-    page: 2
+  - text: apenas maiores de 12 anos
+  - text: apenas maiores de 16 anos
+  - text: apenas maiores de 18 anos
 ---
-**Podem requerer o exame de categoria 3 os maiores de 12 anos.**
+**Podem requerer o exame de categoria 3 os indivíduos de qualquer idade. Sendo o candidato menor, é necessária autorização escrita de quem exerça o poder paternal ou a tutela.**
 
-A categoria 3 é a porta de entrada no radioamadorismo em Portugal, e por isso a idade mínima exigida é propositadamente baixa. A ideia é permitir que jovens interessados comecem cedo, ainda em idade escolar, a aprender e a praticar radiocomunicações de forma legal e acompanhada. Basta ter mais de 12 anos para pedir à ANACOM a realização do exame.
+A categoria 3 é a porta de entrada no radioamadorismo em Portugal, e o acesso ao exame não tem idade mínima. O que a lei exige, quando o candidato é menor, é o consentimento formal de quem responde por ele: uma autorização escrita de quem exerça a responsabilidade parental ou a tutela, nos termos da lei civil. Sem essa autorização o pedido não pode ser aceite; com ela, não há limite inferior de idade.
 
-As restantes opções (16, 18 ou 21 anos) indicam idades superiores à que a regulamentação define para esta categoria. Convém fixar o valor: para a categoria de iniciação, bastam os 12 anos, sem necessidade de esperar pela maioridade.
+Convém não confundir o acesso ao exame com o que se pode fazer depois de o passar. Um titular de CAN menor de 16 anos só pode utilizar estações de amador em modo de emissão se for supervisionado por um amador com idade igual ou superior a 16 anos e com privilégios de acesso às faixas de frequências iguais ou superiores aos seus. A idade não trava a certificação, mas condiciona a operação.
+
+As restantes opções fixam limiares de idade que a lei não impõe. É a palavra "apenas" que as torna erradas: qualquer uma delas excluiria candidatos que a lei admite.
+
+**Nota sobre a alteração da lei.** Até 24 de agosto de 2026 a resposta certa era "maiores de 12 anos", e é essa a formulação que consta das provas anteriores a essa data, como a pergunta 7 da prova de 18-08-2023. A Lei n.º 22/2026, de 27 de maio, que alterou o Decreto-Lei n.º 53/2009 e entrou em vigor a 25 de agosto de 2026, eliminou a idade mínima e passou a exigir autorização escrita no caso de candidatos menores.

--- a/content/questions/cat3/0160.mdx
+++ b/content/questions/cat3/0160.mdx
@@ -15,7 +15,7 @@ answers:
 
 A categoria 3 é a porta de entrada no radioamadorismo em Portugal, e o acesso ao exame não tem idade mínima. O que a lei exige, quando o candidato é menor, é o consentimento formal de quem responde por ele: uma autorização escrita de quem exerça a responsabilidade parental ou a tutela, nos termos da lei civil. Sem essa autorização o pedido não pode ser aceite; com ela, não há limite inferior de idade.
 
-Convém não confundir o acesso ao exame com o que se pode fazer depois de o passar. Um titular de CAN menor de 16 anos só pode utilizar estações de amador em modo de emissão se for supervisionado por um amador com idade igual ou superior a 16 anos e com privilégios de acesso às faixas de frequências iguais ou superiores aos seus. A idade não trava a certificação, mas condiciona a operação.
+Convém não confundir o acesso ao exame com o que se pode fazer depois de o passar. Um titular de CAN da categoria 3 com menos de 16 anos só pode utilizar estações de amador sob a supervisão de um amador com idade igual ou superior a 16 anos e com privilégios de acesso às faixas de frequências iguais ou superiores aos seus. A idade não trava a certificação, mas condiciona a operação.
 
 As restantes opções fixam limiares de idade que a lei não impõe. É a palavra "apenas" que as torna erradas: qualquer uma delas excluiria candidatos que a lei admite.
 

--- a/content/questions/cat3/0162.mdx
+++ b/content/questions/cat3/0162.mdx
@@ -5,23 +5,23 @@ question: >-
   outras Administrações, como é feito o acesso à categoria 1?
 answers:
   - text: >-
-      Mediante exame ao qual podem candidatar-se amadores maiores de 18 anos,
+      Mediante exame, ao qual podem candidatar-se amadores maiores de 18 anos,
       com pelo menos 5 anos de permanência na categoria 2
   - text: >-
-      Mediante exame ao qual podem candidatar-se amadores com pelo menos 1 ano
-      de permanência na categoria 2 e os amadores das categorias A e B
+      Mediante exame, ao qual podem candidatar-se os amadores da categoria 2 e os
+      amadores das categorias A e B
     correct: true
-  - text: Mediante exame ao qual podem candidatar-se amadores das categorias 2 e 3
+  - text: Mediante exame, ao qual podem candidatar-se amadores das categorias 2 ou 3
   - text: >-
-      Mediante exame ao qual podem candidatar-se amadores das categorias 2, 3, B
+      Mediante exame, ao qual podem candidatar-se amadores das categorias 2, 3, B
       ou C
-sources:
-  - pdf: cat3/2023_08_18
-    question: 8
-    page: 2
 ---
-**O acesso à categoria 1 faz-se mediante exame, ao qual podem candidatar-se amadores com pelo menos 1 ano de permanência na categoria 2, bem como os amadores das antigas categorias A e B.**
+**O acesso à categoria 1 faz-se mediante exame, ao qual podem candidatar-se os amadores da categoria 2 e os amadores das antigas categorias A e B.**
 
-A ideia por trás desta regra é simples: a categoria 1 é a mais avançada e exige mais conhecimentos, por isso não se entra nela diretamente. Primeiro é preciso ganhar experiência na categoria 2 durante um período mínimo, e só depois prestar o exame de acesso. As categorias A e B são designações do sistema antigo de classificação de amadores, e quem as detém pode também candidatar-se a este exame.
+Não existe qualquer período mínimo de permanência na categoria 2: basta ser amador dessa categoria para se poder candidatar ao exame de acesso à categoria 1. As categorias A e B pertencem ao sistema de classificação anterior, e quem as detém pode candidatar-se diretamente, sem ter de passar pela categoria 2.
 
-As restantes opções falham porque endurecem ou alargam a regra de forma errada: a regulamentação não exige 18 anos de idade nem 5 anos de permanência na categoria 2, e também não admite ao exame os amadores da categoria 3 (ou da antiga categoria C), que teriam primeiro de subir à categoria 2.
+O enunciado refere a outra via de acesso para a excluir da pergunta: o reconhecimento de títulos habilitantes válidos emitidos por outras Administrações. São dois caminhos distintos para o mesmo fim, e a pergunta incide sobre o segundo.
+
+As restantes opções acrescentam condições que a lei não prevê ou alargam indevidamente o universo de candidatos. Não é exigida idade mínima de 18 anos nem permanência de 5 anos na categoria 2. E os amadores da categoria 3, ou da antiga categoria C, não se podem candidatar diretamente ao exame de categoria 1: têm primeiro de aceder à categoria 2.
+
+**Nota sobre a alteração da lei.** Até 24 de agosto de 2026 exigia-se pelo menos 1 ano de permanência na categoria 2, e é essa a formulação que consta das provas anteriores, como a pergunta 8 da prova de 18-08-2023. A Lei n.º 22/2026, de 27 de maio, em vigor desde 25 de agosto de 2026, eliminou esse requisito.

--- a/public/data/cat3.json
+++ b/public/data/cat3.json
@@ -2362,22 +2362,15 @@
     },
     {
       "id": 160,
-      "question": "Podem requerer à ANACOM a realização de exame para a categoria 3, os indivíduos",
+      "question": "Podem requerer à ANACOM a realização de exame para a categoria 3",
       "options": [
-        "maiores de 12 anos",
-        "maiores de 16 anos",
-        "maiores de 18 anos",
-        "maiores de 21 anos"
+        "os indivíduos de qualquer idade, com autorização escrita de quem exerça o respetivo poder paternal ou tutela, nos termos da lei civil, no caso de se tratar de candidato menor",
+        "apenas maiores de 12 anos",
+        "apenas maiores de 16 anos",
+        "apenas maiores de 18 anos"
       ],
       "correctIndex": 0,
-      "hasNotesMdx": true,
-      "sources": [
-        {
-          "pdf": "cat3/2023_08_18",
-          "question": 7,
-          "page": 2
-        }
-      ]
+      "hasNotesMdx": true
     },
     {
       "id": 161,
@@ -2395,20 +2388,13 @@
       "id": 162,
       "question": "Para além do reconhecimento de títulos habilitantes válidos emitidos por outras Administrações, como é feito o acesso à categoria 1?",
       "options": [
-        "Mediante exame ao qual podem candidatar-se amadores maiores de 18 anos, com pelo menos 5 anos de permanência na categoria 2",
-        "Mediante exame ao qual podem candidatar-se amadores com pelo menos 1 ano de permanência na categoria 2 e os amadores das categorias A e B",
-        "Mediante exame ao qual podem candidatar-se amadores das categorias 2 e 3",
-        "Mediante exame ao qual podem candidatar-se amadores das categorias 2, 3, B ou C"
+        "Mediante exame, ao qual podem candidatar-se amadores maiores de 18 anos, com pelo menos 5 anos de permanência na categoria 2",
+        "Mediante exame, ao qual podem candidatar-se os amadores da categoria 2 e os amadores das categorias A e B",
+        "Mediante exame, ao qual podem candidatar-se amadores das categorias 2 ou 3",
+        "Mediante exame, ao qual podem candidatar-se amadores das categorias 2, 3, B ou C"
       ],
       "correctIndex": 1,
-      "hasNotesMdx": true,
-      "sources": [
-        {
-          "pdf": "cat3/2023_08_18",
-          "question": 8,
-          "page": 2
-        }
-      ]
+      "hasNotesMdx": true
     },
     {
       "id": 163,


### PR DESCRIPTION
**Lei n.º 22/2026, de 27 de maio** amended Decreto-Lei n.º 53/2009 and **entered into force on 25 August 2026 — today**. Two cat3 questions taught rules it repealed, so as of this morning they mark the wrong answer correct.

I found this while comparing ANACOM's example-questions paper for categoria 3 against our bank. That file was reissued today (created 19 Aug, modified 25 Aug 08:18 WEST) and now carries 91 questions, up from the 90 recorded in `category.json`.

## What the law changed

| | Old rule (our bank) | Lei 22/2026 |
|---|---|---|
| **`0160`** cat 3 exam | `maiores de 12 anos` | **any age**; minors need written parental authorisation |
| **`0162`** cat 1 access | `pelo menos 1 ano de permanência na categoria 2` | `os amadores da categoria 2` — **no permanence period** |

Confirmed against two independent renderings of the law (the primary DRE page would not load), both agreeing with ANACOM's own updated file.

## What this PR does

**`0160`** — the stem drops `, os indivíduos`, which moves into the options; `maiores de 21 anos` is gone; the three surviving age options gain `apenas`; and the new correct answer is ANACOM's exact text. Note that their reissue turned our old correct answer into an explicit distractor — `apenas maiores de 12 anos` — which is about as unambiguous a signal as the regulator can give.

**`0162`** — stem unchanged. The correct option loses the permanence clause and option C shifts `categorias 2 e 3` → `2 ou 3`.

Both option sets are taken verbatim from ANACOM's paper. Their file prints `AeB`; written here as `A e B`. Their correct option for `0160` says `poder paternal`, a term Portuguese civil law replaced with `responsabilidades parentais` in 2008 — kept as-is, since that is what a candidate will see printed on the exam.

**Explanations rewritten.** Each now teaches the current rule and closes with a **Nota sobre a alteração da lei** giving the old answer, the paper it appears in, and the date it changed. `0160`'s also separates the exam having no age floor from a CAN holder under 16 still needing supervision to transmit — two rules that are easy to conflate now that one of them has no age limit.

## On the removed `sources`

Both cited `cat3/2023_08_18` perguntas 7 and 8. That paper predates the amendment and no longer contains these questions as stated, so keeping the reference would have made it false. The history it recorded now lives in the explanation prose instead, where it actually reaches the student — candidates practising with pre-2026 papers **will** meet the old answer and need to know which one counts.

## Not fixed here

**`0161`** teaches the repealed categoria 2 rules — a 16-year age floor and a minimum period in categoria 3, both of which the law removed. ANACOM **withdrew** that question rather than reissuing it, so there is no authoritative replacement text and any distractors would be invented. Deferred to the round that handles the Azores callsign questions, which face the same "law changed, regulator withdrew the question" problem: the new file contains **zero** `AZR` references and no `CU` prefixes yet, while we have 15 files teaching the superseded CS8/CT8/CR8 series.

Also deferred: the 6 genuinely new questions in the reissued file, and `anacomFile: 90` → `91`.

## Verification

`content:build` wrote 3 artifacts, `content:check` passes at 759, type-check and lint clean, 231 tests pass. Both notes render correctly through `renderNoteToHtml`.