### PR TITLE
Show each question's topic on the card

### DIFF
--- a/__tests__/unit/test-QuestionCard.test.tsx
+++ b/__tests__/unit/test-QuestionCard.test.tsx
@@ -58,6 +58,45 @@ describe("Unit: QuestionCard", () => {
     expect(onSelect).toHaveBeenCalledWith(1);
   });
 
+  it("shows the topic label when the question carries one", () => {
+    render(
+      <QuestionCard
+        question={{ ...mockQuestion, materia: "propagacao" }}
+        selectedOption={undefined}
+        onSelect={() => {}}
+        ended={false}
+      />
+    );
+    // Locale is mocked to pt, so the short Portuguese label is expected.
+    expect(screen.getByText("Propagação")).toBeInTheDocument();
+  });
+
+  it("omits the topic label for a slug outside the taxonomy", () => {
+    // `materia` was a freeform legacy field; a stale value must not render.
+    render(
+      <QuestionCard
+        question={{ ...mockQuestion, materia: "ohm" }}
+        selectedOption={undefined}
+        onSelect={() => {}}
+        ended={false}
+      />
+    );
+    expect(screen.queryByText("ohm")).not.toBeInTheDocument();
+  });
+
+  it("renders no meta row when there is no topic, difficulty or bookmark", () => {
+    const { container } = render(
+      <QuestionCard
+        question={mockQuestion}
+        selectedOption={undefined}
+        onSelect={() => {}}
+        ended={false}
+      />
+    );
+    // The question text must be the card's first content, not an empty row.
+    expect(container.querySelector(".justify-between")).toBeNull();
+  });
+
   it("shows correct answer styling when ended", () => {
     const { container } = render(
       <QuestionCard

--- a/components/QuestionCard.tsx
+++ b/components/QuestionCard.tsx
@@ -5,7 +5,7 @@ import DOMPurify from 'dompurify';
 import { Calculator, ChevronRight, FileText, FileX } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 import { Question, SourceRef } from '@/lib/types';
-import { getCalculatorMeta } from '@/lib/config';
+import { getCalculatorMeta, topicShortLabel } from '@/lib/config';
 import type { CalculatorCode } from '@/lib/types';
 import { AnswerOption, type AnswerOptionState } from '@/components/ui/answer-option';
 import BookmarkButton from '@/components/BookmarkButton';
@@ -181,6 +181,11 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
   }, [notesKey]);
 
   const resolvedNotes = remoteNotesHtml ?? question.notes ?? null;
+  // `materia` is the shipped name for the source's `topic` field.
+  const topicLabel = question.materia ? topicShortLabel(question.materia, locale) : null;
+  const showsDifficulty =
+    attemptCount !== undefined && attemptCount > 0 && successRate !== undefined;
+  const showsBookmark = Boolean(showBookmark && onToggleBookmark);
   const calcCodes = normalizeCalcCodes(question.calc);
 
   // Get color class for difficulty badge based on success rate
@@ -245,28 +250,39 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
         </div>
       )}
 
-      <div className="flex items-start gap-2 mb-3">
-        <p className="flex-1 text-slate-900 dark:text-slate-100">
-          {indexNumber && (
-            <span className="font-semibold text-amber-600 dark:text-amber-500 mr-2">{indexNumber}.</span>
-          )}
-          {question.question}
-        </p>
-        <div className="flex items-center gap-2 shrink-0">
-          {attemptCount !== undefined && attemptCount > 0 && successRate !== undefined && (
-            <span className={`text-xs px-2 py-0.5 rounded-full ${getDifficultyColorClass(successRate)}`}>
-              {t('successRate', { rate: Math.round(successRate) })}
+      {(topicLabel || showsDifficulty || showsBookmark) && (
+        <div className="flex items-center justify-between gap-3 mb-2">
+          {topicLabel ? (
+            <span className="min-w-0 truncate text-[10px] font-semibold uppercase tracking-widest text-slate-500 dark:text-slate-400">
+              <span className="sr-only">{t('topic')}: </span>
+              {topicLabel}
             </span>
+          ) : (
+            <span aria-hidden="true" />
           )}
-          {showBookmark && onToggleBookmark && (
-            <BookmarkButton
-              isBookmarked={isBookmarked}
-              onToggle={onToggleBookmark}
-              size="sm"
-            />
-          )}
+          <div className="flex items-center gap-2 shrink-0">
+            {attemptCount !== undefined && attemptCount > 0 && successRate !== undefined && (
+              <span className={`text-xs px-2 py-0.5 rounded-full ${getDifficultyColorClass(successRate)}`}>
+                {t('successRate', { rate: Math.round(successRate) })}
+              </span>
+            )}
+            {showBookmark && onToggleBookmark && (
+              <BookmarkButton
+                isBookmarked={isBookmarked}
+                onToggle={onToggleBookmark}
+                size="sm"
+              />
+            )}
+          </div>
         </div>
-      </div>
+      )}
+
+      <p className="mb-3 text-slate-900 dark:text-slate-100">
+        {indexNumber && (
+          <span className="font-semibold text-amber-600 dark:text-amber-500 mr-2">{indexNumber}.</span>
+        )}
+        {question.question}
+      </p>
 
       <div className={showImage && question.img ? "flex flex-col gap-4 sm:flex-row sm:items-start" : undefined}>
         <div className="space-y-2 sm:flex-[2] sm:min-w-0">

--- a/lib/config/topics.ts
+++ b/lib/config/topics.ts
@@ -53,8 +53,18 @@ export type Topic = {
    * Treat a mismatch as worth a second look, never as an error.
    */
   examinedFrom: CategoryId;
+  /** Full chapter title, as printed in Anexo 1. Reference-page length. */
   pt: string;
   en: string;
+  /**
+   * Card-sized label. The full titles do not fit on a question card —
+   * "Regulamentação nacional e internacional relevante para os serviços de
+   * amador e amador por satélite" is a heading, not a chip. Truncating with CSS
+   * would produce "Regulamentação nacional e intern…", so the short form is
+   * authored rather than derived.
+   */
+  shortPt: string;
+  shortEn: string;
   /** What belongs here. */
   scope: string;
   /** Tie-break against the neighbouring topic it is most often confused with. */
@@ -67,6 +77,7 @@ export const TOPICS: readonly Topic[] = [
     anacomRef: 'PARTE A / 1', examinedFrom: '3',
     pt: 'Teoria da eletricidade, do eletromagnetismo e das radiocomunicações',
     en: 'Electrical, electromagnetic and radio theory',
+    shortPt: 'Teoria', shortEn: 'Theory',
     scope: 'Condutividade, fontes de eletricidade, campos elétrico e magnético, sinais sinusoidais e não sinusoidais, ruído, sinais modulados, potência e energia, processamento digital de sinais.',
     boundary: 'Uma grandeza ou um princípio físico pertence aqui; um objeto que se compra pertence a componentes. A aritmética de decibéis é aqui — o Anexo 1 põe em 1.9 c) a \'relação de potência entre entrada/saída em dB de amplificadores e/ou atenuadores\' — mas só quando a razão é o assunto. Se os dB apenas especificam um parâmetro (largura de banda a -3 dB, ganho de antena, relação frente/costas), a pergunta pertence ao capítulo da coisa descrita.',
   },
@@ -75,6 +86,7 @@ export const TOPICS: readonly Topic[] = [
     anacomRef: 'PARTE A / 2', examinedFrom: '3',
     pt: 'Componentes',
     en: 'Components',
+    shortPt: 'Componentes', shortEn: 'Components',
     scope: 'Resistências, condensadores, bobinas, transformadores, díodos, transístores, válvulas e outros dispositivos considerados isoladamente.',
     boundary: 'Um componente sozinho, e as suas características, pertence aqui. Vários componentes combinados para desempenhar uma função pertencem a circuitos.',
   },
@@ -83,6 +95,7 @@ export const TOPICS: readonly Topic[] = [
     anacomRef: 'PARTE A / 3', examinedFrom: '2',
     pt: 'Circuitos',
     en: 'Circuits',
+    shortPt: 'Circuitos', shortEn: 'Circuits',
     scope: 'Combinações de componentes, filtros, fontes de alimentação, amplificadores, detetores, osciladores, PLL, sistemas de tempo discreto (DSP).',
     boundary: 'Se o enunciado descreve uma montagem com uma função (oscilar, filtrar, amplificar, regular), é circuitos, mesmo que nomeie os componentes que a compõem.',
   },
@@ -91,6 +104,7 @@ export const TOPICS: readonly Topic[] = [
     anacomRef: 'PARTE A / 4', examinedFrom: '2',
     pt: 'Recetores',
     en: 'Receivers',
+    shortPt: 'Recetores', shortEn: 'Receivers',
     scope: 'Tipos de recetor, diagramas de blocos, funcionamento dos andares, características do recetor (sensibilidade, seletividade, bloqueio, intermodulação).',
     boundary: 'Um andar identificado como parte de um recetor pertence aqui, não a circuitos.',
   },
@@ -99,6 +113,7 @@ export const TOPICS: readonly Topic[] = [
     anacomRef: 'PARTE A / 5', examinedFrom: '2',
     pt: 'Emissores',
     en: 'Transmitters',
+    shortPt: 'Emissores', shortEn: 'Transmitters',
     scope: 'Tipos de emissor, diagramas de blocos, funcionamento dos andares, características do emissor, modulação e classes de funcionamento do andar final.',
     boundary: 'Um andar identificado como parte de um emissor pertence aqui, não a circuitos. As designações de classe de emissão (A3E, J3E, F3E) pertencem aqui e não a regulamentação: identificam a modulação, e o seu significado não muda quando a lei muda.',
   },
@@ -107,6 +122,7 @@ export const TOPICS: readonly Topic[] = [
     anacomRef: 'PARTE A / 6', examinedFrom: '2',
     pt: 'Antenas e linhas de transmissão',
     en: 'Antennas and transmission lines',
+    shortPt: 'Antenas', shortEn: 'Antennas',
     scope: 'Tipos e características de antenas, ganho, diretividade, polarização, linhas de transmissão, ROE, adaptação de impedâncias, p.a.r. e p.i.r.e.',
     boundary: 'Potência radiada, ROE e a adaptação de uma antena à linha ou ao emissor pertencem aqui, não a emissores, porque medem o que sai da antena e não o que o emissor produz. Mas adaptação de impedâncias entre dois circuitos, sem antena no enunciado, é circuitos.',
   },
@@ -115,6 +131,7 @@ export const TOPICS: readonly Topic[] = [
     anacomRef: 'PARTE A / 7', examinedFrom: '2',
     pt: 'Propagação',
     en: 'Propagation',
+    shortPt: 'Propagação', shortEn: 'Propagation',
     scope: 'Espectro de frequências, camadas ionosféricas, onda terrestre e ionosférica, MUF, desvanecimento, alcance, horizonte rádio, modos de propagação particulares.',
   },
   {
@@ -122,6 +139,7 @@ export const TOPICS: readonly Topic[] = [
     anacomRef: 'PARTE A / 8', examinedFrom: '2',
     pt: 'Medições',
     en: 'Measurements',
+    shortPt: 'Medições', shortEn: 'Measurements',
     scope: 'Realização de medições e instrumentos: multímetro, osciloscópio, wattímetro, medidor de ROE, analisador de espectro, frequencímetro, medidor S.',
     boundary: 'Se a pergunta é sobre o instrumento ou sobre como medir, é medidas, mesmo que a grandeza medida pertença a outro capítulo.',
   },
@@ -130,6 +148,7 @@ export const TOPICS: readonly Topic[] = [
     anacomRef: 'PARTE A / 9', examinedFrom: '3',
     pt: 'Interferência e imunidade',
     en: 'Interference and immunity',
+    shortPt: 'Interferências', shortEn: 'Interference',
     scope: 'Interferência em equipamentos eletrónicos, causas, harmónicas e espúrias, blindagem, filtragem, ligação à terra, imunidade, compatibilidade eletromagnética.',
     boundary: 'A blindagem pertence aqui quando serve para evitar interferência; a teoria do campo que a blindagem trava pertence a teoria.',
   },
@@ -138,6 +157,7 @@ export const TOPICS: readonly Topic[] = [
     anacomRef: 'PARTE A / 10', examinedFrom: '3',
     pt: 'Segurança',
     en: 'Safety',
+    shortPt: 'Segurança', shortEn: 'Safety',
     scope: 'O corpo humano, tensões e correntes perigosas, rede elétrica, ligação à terra de proteção, descargas atmosféricas, exposição a campos eletromagnéticos, segurança em torres e mastros.',
     boundary: 'Exposição a campos eletromagnéticos pertence aqui, não a teoria, porque a pergunta é sobre o risco para pessoas.',
   },
@@ -146,6 +166,7 @@ export const TOPICS: readonly Topic[] = [
     anacomRef: 'PARTE B', examinedFrom: '3',
     pt: 'Regulamentos e procedimentos nacionais e internacionais de operação',
     en: 'Operating rules and procedures',
+    shortPt: 'Operação', shortEn: 'Operating',
     scope: 'Alfabeto fonético, código Q, abreviaturas de operação, indicativos de chamada, planos de faixas da IARU, procedimentos de contacto, tráfego de emergência, diário de estação.',
     boundary: 'Uma prática acordada entre amadores é operação; uma obrigação imposta por lei é regulamentação. Os planos de faixas da IARU são operação, mesmo quando a pergunta parece regulamentar. Nos indicativos de chamada a divisão é: como se forma e se transmite um indicativo no ar é operação; quem tem direito a qual série, e por quanto tempo, é regulamentação.',
   },
@@ -154,6 +175,7 @@ export const TOPICS: readonly Topic[] = [
     anacomRef: 'PARTE C', examinedFrom: '3',
     pt: 'Regulamentação nacional e internacional relevante para os serviços de amador e amador por satélite',
     en: 'National and international regulations',
+    shortPt: 'Regulamentação', shortEn: 'Regulations',
     scope: 'Regulamento das Radiocomunicações da UIT, regulamentação CEPT, legislação nacional, categorias e CAN, licenciamento de estações, atribuição de faixas e estatutos, potências máximas, entidades (ANACOM, UIT, CEPT, IARU).',
     boundary: 'Se a resposta muda quando a lei muda, é regulamentação.',
   },
@@ -180,3 +202,10 @@ export function isTopicSlug(value: unknown): value is TopicSlug {
 export const ABOVE_ENTRY_LEVEL: readonly TopicSlug[] = TOPICS
   .filter((t) => t.examinedFrom !== '3')
   .map((t) => t.slug);
+
+/** Card-sized label for a topic slug in the reader's locale. */
+export function topicShortLabel(slug: string, locale: string): string | null {
+  if (!isTopicSlug(slug)) return null;
+  const topic = TOPIC_BY_SLUG[slug];
+  return locale.startsWith('pt') ? topic.shortPt : topic.shortEn;
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -349,6 +349,7 @@
     "successRate": "{rate}% success",
     "suggestedCalculator": "Suggested calculator:",
     "suggestedCalculators": "Suggested calculators:",
+    "topic": "Topic",
     "unanswered": "Unanswered"
   },
   "SubmitExam": {

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -349,6 +349,7 @@
     "successRate": "{rate}% de acerto",
     "suggestedCalculator": "Calculadora sugerida:",
     "suggestedCalculators": "Calculadoras sugeridas:",
+    "topic": "Matéria",
     "unanswered": "Sem resposta"
   },
   "SubmitExam": {


### PR DESCRIPTION
#35 gave every question a topic. Nothing displayed it. This does.

Mockup this implements: https://claude.ai/code/artifact/4ec1bfb0-c480-481f-8c68-3fd2ba06ea61

## One component, three modes

`browse`, `flash` and `smart-practice` all render the same `QuestionCard`, and `Question` already carried `materia?: string | null`. So this is a single component change with no plumbing and no prop threading.

## The placement was chosen for what the label promises

The topic opens a **meta row above the question**, and the success-rate chip and bookmark move up into it.

That second part is the argument. A chip on the right — the obvious first idea — would have sat beside the calculator hints, which are buttons: the label would look tappable while doing nothing. And on a phone, three items competing on the right squeeze the enunciado to a couple of words a line. Putting the topic inline with the index number made it read as part of the sentence.

Giving the topic its own row costs a row and pays for it twice: a stable left-hand column you can scan without reading, and **the question text gets full width** — which fixes a problem that already existed, where long questions wrapped around the right-hand cluster.

The row is conditional on having something to hold. With no topic, no attempts and no bookmark it doesn't render, and the card falls back to exactly the previous layout.

## Two deliberate non-decisions

**Not colour-coded.** Green, amber and rose already mean category 3, 2 and 1 across the app — that's colour with a job. Twelve more hues on top stop informing and start decorating, and nobody memorises twelve. The topic is text: read, not decoded.

**Not a control.** Nothing about it suggests tapping. It's the obvious hook for filtering the list by topic and per-topic progress on the dashboard, but those are worth designing once the caption is in place rather than at the same time.

## Short labels are authored, not truncated

`shortPt` / `shortEn` per topic, plus a `topicShortLabel(slug, locale)` helper. The full Anexo 1 titles are reference-page length — CSS-truncating `Regulamentação nacional e internacional relevante para os serviços de amador e amador por satélite` gives `Regulamentação nacional e intern…`, which is worse than useless on a card.

One new message key, `QuestionCard.topic` (`Matéria` / `Topic`), used as the `sr-only` prefix so a screen reader hears "Matéria: Propagação" rather than a bare word ahead of the question.

## Verification

Playwright has no Chrome on this machine, so I verified through the test suite instead — better anyway, since it locks the behaviour rather than eyeballing it once. Three tests added to the existing `test-QuestionCard.test.tsx`:

- a valid slug renders its localised short label
- **a stale slug renders nothing** — `materia` was a freeform legacy field and `topic: ohm` was in the bank until this week, so it must not leak onto a card
- an otherwise-empty meta row doesn't render

234 tests pass (was 231), type-check and lint clean, `content:check` at 759, production build succeeds. I also confirmed the Portuguese labels appear in the client chunk, so `topics.ts` genuinely reaches the browser rather than being tree-shaken to the server only.