### PR TITLE
Filter and search the browse list

### DIFF
--- a/__tests__/unit/test-search.test.ts
+++ b/__tests__/unit/test-search.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { fold, findMatch, questionMatches } from "@/lib/utils/search";
+
+describe("Unit: search folding", () => {
+  it("folds diacritics and case", () => {
+    expect(fold("Propagação")).toBe("propagacao");
+    expect(fold("ELÉCTRICO")).toBe("electrico");
+  });
+
+  it("matches across the 1990 orthography split", () => {
+    // The bank mixes "eléctrico" and "elétrico"; neither spelling should be a
+    // dead end for someone typing the other.
+    const q = { question: "O circuito eléctrico", options: ["nenhuma"] };
+    expect(questionMatches(q, "electrico")).toBe(true);
+    expect(questionMatches(q, "eléctrico")).toBe(true);
+  });
+
+  it("matches on the options, not just the stem", () => {
+    // Searching cat 3 for "antena" finds 13 questions, and eight carry the word
+    // only in an option.
+    const q = {
+      question: "A potência aparente radiada é função",
+      options: ["do ganho da antena", "da corrente"],
+    };
+    expect(questionMatches(q, "antena")).toBe(true);
+  });
+
+  it("treats an empty term as matching everything", () => {
+    const q = { question: "qualquer", options: ["a"] };
+    expect(questionMatches(q, "")).toBe(true);
+    expect(questionMatches(q, "   ")).toBe(true);
+  });
+
+  it("does not match an absent term", () => {
+    expect(questionMatches({ question: "abc", options: ["def"] }, "xyz")).toBe(false);
+  });
+});
+
+describe("Unit: findMatch", () => {
+  it("returns offsets into the original string, not the folded one", () => {
+    // "ã" folds to one character but occupies one slot; the accented word must
+    // still be sliced out intact.
+    const text = "A reflexão ionosférica";
+    const range = findMatch(text, "reflexao");
+    expect(range).not.toBeNull();
+    expect(text.slice(range!.start, range!.end)).toBe("reflexão");
+  });
+
+  it("maps correctly when accents precede the match", () => {
+    const text = "Ação: propagação troposférica";
+    const range = findMatch(text, "propagacao");
+    expect(text.slice(range!.start, range!.end)).toBe("propagação");
+  });
+
+  it("returns null for an empty or unmatched term", () => {
+    expect(findMatch("abc", "")).toBeNull();
+    expect(findMatch("abc", "  ")).toBeNull();
+    expect(findMatch("abc", "z")).toBeNull();
+  });
+});
+
+import { topicCounts } from "@/components/QuestionFilters";
+
+describe("Unit: topicCounts", () => {
+  const bank = [
+    { materia: "propagacao" }, { materia: "propagacao" }, { materia: "propagacao" },
+    { materia: "seguranca" },
+    { materia: "antenas" }, { materia: "antenas" },
+    { materia: null },
+    {},
+  ];
+
+  it("orders by count, descending", () => {
+    expect(topicCounts(bank, "pt").map((t) => t.slug)).toEqual([
+      "propagacao", "antenas", "seguranca",
+    ]);
+  });
+
+  it("drops topics with nothing in them", () => {
+    // cat 1 has a single safety question and no receivers-heavy tail; an empty
+    // chip is an invitation to a blank screen.
+    const slugs = topicCounts(bank, "pt").map((t) => t.slug);
+    expect(slugs).not.toContain("circuitos");
+    expect(slugs).toHaveLength(3);
+  });
+
+  it("ignores questions with no topic", () => {
+    const total = topicCounts(bank, "pt").reduce((n, t) => n + t.count, 0);
+    expect(total).toBe(6);
+  });
+
+  it("labels in the reader's locale", () => {
+    expect(topicCounts([{ materia: "medidas" }], "pt")[0]?.label).toBe("Medições");
+    expect(topicCounts([{ materia: "medidas" }], "en")[0]?.label).toBe("Measurements");
+  });
+});

--- a/app/browse/[category]/page.tsx
+++ b/app/browse/[category]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
-import React, { useState, useEffect, useCallback } from 'react';
-import { useParams } from 'next/navigation';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { Category } from '@/lib/types';
 import { loadData } from '@/lib/data';
@@ -11,6 +11,9 @@ import { StudyHeader } from '@/components/StudyHeader';
 import type { CalculatorCode } from '@/lib/types';
 import { useProgressContext } from '@/components/providers/ProgressProvider';
 import { toggleBookmark } from '@/lib/storage/localStorage';
+import { QuestionFilters, useTopicCounts } from '@/components/QuestionFilters';
+import { questionMatches } from '@/lib/utils';
+import { isTopicSlug } from '@/lib/config';
 
 export default function BrowsePage() {
   const params = useParams();
@@ -24,6 +27,20 @@ export default function BrowsePage() {
   const { openCalculator } = useCalculators();
   const { recordQuestionWithGamification, progress, refreshProgress } = useProgressContext();
   const t = useTranslations('Browse');
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [search, setSearch] = useState('');
+
+  // The topic lives in the URL so the dashboard can link straight to a weak
+  // area; the search does not, because a query is a passing question and
+  // pushing one per keystroke would bury the back button.
+  const topicParam = searchParams.get('topic');
+  const activeTopic = topicParam && isTopicSlug(topicParam) ? topicParam : null;
+
+  const setTopic = useCallback((slug: string | null) => {
+    const base = `/browse/${categoryId}`;
+    router.push(slug ? `${base}?topic=${slug}` : base);
+  }, [router, categoryId]);
 
   const isBookmarked = useCallback((questionId: number) => {
     const key = `cat${categoryId}_${questionId}`;
@@ -51,15 +68,37 @@ export default function BrowsePage() {
     });
   }, [categoryId]);
 
+  // Search narrows the set the chips describe; the topic then narrows that.
+  const searched = useMemo(
+    () => (category ? category.questions.filter((q) => questionMatches(q, search)) : []),
+    [category, search]
+  );
+  const counts = useTopicCounts(searched);
+  const visible = useMemo(
+    () => (activeTopic ? searched.filter((q) => q.materia === activeTopic) : searched),
+    [searched, activeTopic]
+  );
+  // Matches outside the active topic, to tell an empty result which of the two
+  // conditions is the one to drop.
+  const elsewhere = searched.length - visible.length;
+
   // Questions load after the native anchor scroll would have fired, so honor
   // #q-{id} links (e.g. from the dashboard's weak areas) once they render.
   useEffect(() => {
     if (!category) return;
     const hash = window.location.hash;
-    if (/^#q-\d+$/.test(hash)) {
-      document.querySelector(hash)?.scrollIntoView();
+    if (!/^#q-\d+$/.test(hash)) return;
+    // A deep link means "show me this question". A topic in the URL could be
+    // hiding it, and the scroll would then fail silently, so the link wins and
+    // the topic is dropped — replace, not push, so back still leaves the page.
+    // The search box needs no such handling: it starts empty on every
+    // navigation, so it cannot be stale when a hash arrives.
+    if (activeTopic) {
+      router.replace(`/browse/${categoryId}`);
+      return;
     }
-  }, [category]);
+    document.querySelector(hash)?.scrollIntoView();
+  }, [category, activeTopic, router, categoryId]);
 
   const handleLaunchCalculator = useCallback((code: string) => {
     openCalculator(code as CalculatorCode);
@@ -77,8 +116,47 @@ export default function BrowsePage() {
         backHref="/"
         subtitle={t("questionCount", { count: category.questions.length })}
       />
+      <QuestionFilters
+        counts={counts}
+        total={searched.length}
+        bankTotal={category.questions.length}
+        activeTopic={activeTopic}
+        onTopicChange={setTopic}
+        search={search}
+        onSearchChange={setSearch}
+      />
       <section className="sm:px-0">
-        {category.questions.map((q, idx) => {
+        {visible.length === 0 && (
+          <div className="px-4 py-12 text-center sm:px-0">
+            <p className="text-sm text-slate-600 dark:text-slate-300">{t('emptyTitle')}</p>
+            {elsewhere > 0 && activeTopic ? (
+              <>
+                <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
+                  {t('emptyElsewhere', { count: elsewhere })}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setTopic(null)}
+                  className="mt-4 rounded-lg bg-amber-500 px-3 py-1.5 text-sm font-semibold text-slate-900 hover:bg-amber-400"
+                >
+                  {t('emptySearchAll')}
+                </button>
+              </>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setSearch('')}
+                className="mt-4 rounded-lg bg-slate-100 px-3 py-1.5 text-sm font-medium text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+              >
+                {t('emptyClear')}
+              </button>
+            )}
+          </div>
+        )}
+        {visible.map((q) => {
+          // Position in the unfiltered bank: a question keeps one number in
+          // every view, so it stays something you can refer to and link to.
+          const idx = category.questions.indexOf(q);
           const selected = answers[q.id];
           const isAnswered = selected !== undefined;
           const difficultyStats = getQuestionDifficultyStats(q.id);
@@ -102,6 +180,7 @@ export default function BrowsePage() {
                 }}
                 showImage
                 indexNumber={idx + 1}
+                highlight={search}
                 showCalcHint
                 onLaunchCalculator={handleLaunchCalculator}
                 ended={isAnswered}

--- a/components/QuestionCard.tsx
+++ b/components/QuestionCard.tsx
@@ -9,6 +9,7 @@ import { getCalculatorMeta, topicShortLabel } from '@/lib/config';
 import type { CalculatorCode } from '@/lib/types';
 import { AnswerOption, type AnswerOptionState } from '@/components/ui/answer-option';
 import BookmarkButton from '@/components/BookmarkButton';
+import { Highlight } from '@/components/ui/highlight';
 import PdfPageDialog from '@/components/PdfPageDialog';
 import StudyGuideLink from '@/components/StudyGuideLink';
 import {
@@ -34,6 +35,8 @@ interface QuestionCardProps {
   // Difficulty indicator
   successRate?: number; // 0-100 percentage
   attemptCount?: number;
+  /** Search term to mark in the question and its options. */
+  highlight?: string;
 }
 
 /**
@@ -125,6 +128,7 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
   onToggleBookmark,
   successRate,
   attemptCount,
+  highlight,
   categoryId,
 }) => {
   const t = useTranslations('QuestionCard');
@@ -281,7 +285,7 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
         {indexNumber && (
           <span className="font-semibold text-amber-600 dark:text-amber-500 mr-2">{indexNumber}.</span>
         )}
-        {question.question}
+        <Highlight text={question.question} term={highlight} />
       </p>
 
       <div className={showImage && question.img ? "flex flex-col gap-4 sm:flex-row sm:items-start" : undefined}>
@@ -294,7 +298,7 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
               disabled={disabled || ended}
               onClick={() => onSelect(idx)}
             >
-              {option}
+              <Highlight text={option} term={highlight} />
             </AnswerOption>
           ))}
         </div>

--- a/components/QuestionFilters.tsx
+++ b/components/QuestionFilters.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import React from "react";
+import { Search, X } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
+import { TOPICS, topicShortLabel } from "@/lib/config";
+
+export type TopicCount = { slug: string; label: string; count: number };
+
+interface QuestionFiltersProps {
+  /** Per-topic counts over the *current search results*, not the whole bank. */
+  counts: TopicCount[];
+  total: number;
+  bankTotal: number;
+  activeTopic: string | null;
+  onTopicChange: (slug: string | null) => void;
+  search: string;
+  onSearchChange: (value: string) => void;
+}
+
+const CHIP =
+  "inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500";
+const CHIP_OFF =
+  "bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700";
+const CHIP_ON = "bg-amber-500 text-slate-900";
+
+/**
+ * Search field plus one chip per topic, sitting under StudyHeader.
+ *
+ * Counts come from the search results rather than the bank, so with a term
+ * typed the chips stop being a menu and become a distribution: searching cat 3
+ * for "antena" shows that only four of the thirteen matches live in Antenas.
+ */
+export function QuestionFilters({
+  counts, total, bankTotal, activeTopic, onTopicChange, search, onSearchChange,
+}: QuestionFiltersProps) {
+  const t = useTranslations("Browse");
+
+  return (
+    <div className="sticky top-[6.25rem] z-10 -mx-4 sm:mx-0 mb-4 border-b border-slate-200/60 bg-white/80 px-4 py-2.5 backdrop-blur-xl dark:border-slate-700/40 dark:bg-slate-900/80">
+      <div className="flex items-center gap-2">
+        <div className="flex flex-1 items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-1.5 focus-within:border-amber-400 dark:border-slate-700 dark:bg-slate-800">
+          <Search className="h-3.5 w-3.5 shrink-0 text-slate-400" aria-hidden="true" />
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder={t("searchPlaceholder")}
+            aria-label={t("searchLabel")}
+            className="w-full bg-transparent text-sm text-slate-900 outline-none placeholder:text-slate-400 dark:text-slate-100"
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => onSearchChange("")}
+              aria-label={t("searchClear")}
+              className="shrink-0 rounded text-slate-400 hover:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 dark:hover:text-slate-200"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+        <span className="shrink-0 font-mono text-xs tabular-nums text-slate-500 dark:text-slate-400">
+          {total === bankTotal ? bankTotal : t("resultCount", { shown: total, total: bankTotal })}
+        </span>
+      </div>
+
+      <div className="mt-2 flex gap-1.5 overflow-x-auto pb-0.5 sm:flex-wrap sm:overflow-visible [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <button
+          type="button"
+          onClick={() => onTopicChange(null)}
+          aria-pressed={activeTopic === null}
+          className={`${CHIP} ${activeTopic === null ? CHIP_ON : CHIP_OFF}`}
+        >
+          {t("topicAll")}
+          <span className="font-mono text-[10px] tabular-nums opacity-60">{total}</span>
+        </button>
+        {counts.map(({ slug, label, count }) => (
+          <button
+            key={slug}
+            type="button"
+            onClick={() => onTopicChange(slug)}
+            aria-pressed={activeTopic === slug}
+            className={`${CHIP} ${activeTopic === slug ? CHIP_ON : CHIP_OFF}`}
+          >
+            {label}
+            <span className="font-mono text-[10px] tabular-nums opacity-60">{count}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Topic counts over a set of questions, ordered by count.
+ *
+ * Topics with nothing in them are dropped rather than shown at zero — cat 1
+ * has a single safety question, and an empty chip is an invitation to a blank
+ * screen.
+ */
+export function topicCounts(
+  questions: { materia?: string | null }[],
+  locale: string
+): TopicCount[] {
+  const tally = new Map<string, number>();
+  for (const q of questions) {
+    if (!q.materia) continue;
+    tally.set(q.materia, (tally.get(q.materia) ?? 0) + 1);
+  }
+  return TOPICS.flatMap((topic) => {
+    const count = tally.get(topic.slug) ?? 0;
+    if (count === 0) return [];
+    const label = topicShortLabel(topic.slug, locale);
+    return label ? [{ slug: topic.slug, label, count }] : [];
+  }).sort((a, b) => b.count - a.count);
+}
+
+/** Convenience for callers that already have the locale from context. */
+export function useTopicCounts(questions: { materia?: string | null }[]) {
+  const locale = useLocale();
+  return React.useMemo(() => topicCounts(questions, locale), [questions, locale]);
+}

--- a/components/ui/highlight.tsx
+++ b/components/ui/highlight.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import React from "react";
+import { findMatch } from "@/lib/utils";
+
+interface HighlightProps {
+  text: string;
+  /** Search term to mark. Falsy or unmatched renders the text untouched. */
+  term?: string | undefined;
+}
+
+/**
+ * Marks the first occurrence of `term` in `text`.
+ *
+ * Only the first: a question that says "antena" four times would otherwise
+ * turn into a stripe of highlight and become harder to read than it was
+ * unmarked. One mark answers the question the reader has — why did this
+ * result appear — and stops.
+ */
+export function Highlight({ text, term }: HighlightProps) {
+  const range = term ? findMatch(text, term) : null;
+  if (!range) return <>{text}</>;
+  return (
+    <>
+      {text.slice(0, range.start)}
+      <mark className="rounded-sm bg-amber-200 px-0.5 text-slate-900 dark:bg-amber-500/40 dark:text-amber-50">
+        {text.slice(range.start, range.end)}
+      </mark>
+      {text.slice(range.end)}
+    </>
+  );
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -8,6 +8,7 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+export * from "./search";
 export * from "./unit-conversion";
 export * from "./electrical";
 export * from "./pdf-generator";

--- a/lib/utils/search.ts
+++ b/lib/utils/search.ts
@@ -1,0 +1,68 @@
+/**
+ * Text search over the question bank.
+ *
+ * Matching folds away diacritics and case. That is not a nicety here: the bank
+ * mixes pre-1990 and current orthography, so a reader typing "eletrico" has to
+ * find "eléctrico", and one typing "propagacao" has to find "propagação".
+ */
+
+/**
+ * Folds a string for comparison, and records where each folded character came
+ * from in the original.
+ *
+ * The map is what makes highlighting possible. Stripping combining marks
+ * changes a string's length, so a match found in the folded text cannot be
+ * sliced out of the original by the same offsets — the map translates back.
+ */
+export function foldWithMap(input: string): { folded: string; map: number[] } {
+  let folded = "";
+  const map: number[] = [];
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+    if (char === undefined) continue;
+    const stripped = char.normalize("NFD").replace(/\p{M}/gu, "").toLowerCase();
+    for (let j = 0; j < stripped.length; j++) {
+      folded += stripped[j];
+      map.push(i);
+    }
+  }
+  return { folded, map };
+}
+
+/** Folds a string for comparison, discarding the position map. */
+export function fold(input: string): string {
+  return input.normalize("NFD").replace(/\p{M}/gu, "").toLowerCase();
+}
+
+/** Range of a match in the *original* string, or null when there is none. */
+export function findMatch(
+  haystack: string,
+  needle: string
+): { start: number; end: number } | null {
+  const term = fold(needle).trim();
+  if (term.length === 0) return null;
+  const { folded, map } = foldWithMap(haystack);
+  const at = folded.indexOf(term);
+  if (at === -1) return null;
+  const start = map[at];
+  const last = map[at + term.length - 1];
+  if (start === undefined || last === undefined) return null;
+  return { start, end: last + 1 };
+}
+
+/**
+ * Whether a question matches a search term.
+ *
+ * Answers count, not just the stem. Searching cat 3 for "antena" finds 13
+ * questions and eight of them carry the word only in an option — stem-only
+ * matching would lose most of the result set.
+ */
+export function questionMatches(
+  question: { question: string; options: string[] },
+  term: string
+): boolean {
+  const needle = fold(term).trim();
+  if (needle.length === 0) return true;
+  if (fold(question.question).includes(needle)) return true;
+  return question.options.some((option) => fold(option).includes(needle));
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -56,16 +56,25 @@
     "slogan": "Made by amateur radio operators, for (future) amateur radio operators"
   },
   "Browse": {
-    "title": "Browse Category {id}",
-    "loading": "Loading questions...",
-    "flashTitle": "Flashcards Category {id}",
-    "flashLoading": "Loading flashcards...",
-    "flashNotFound": "We could not find category {id}. Try choosing a category from the Browse menu.",
-    "flashNoQuestions": "There are no questions available for this category yet.",
-    "flashSubtitle": "Practice one random question at a time. Reviewed {count} so far.",
+    "emptyClear": "Clear search",
+    "emptyElsewhere": "There are {count} in other topics.",
+    "emptySearchAll": "Search all topics",
+    "emptyTitle": "No questions found.",
     "flashCard": "Card {position} of {total} in this round.",
+    "flashLoading": "Loading flashcards...",
     "flashNext": "Next question",
-    "questionCount": "{count} questions"
+    "flashNoQuestions": "There are no questions available for this category yet.",
+    "flashNotFound": "We could not find category {id}. Try choosing a category from the Browse menu.",
+    "flashSubtitle": "Practice one random question at a time. Reviewed {count} so far.",
+    "flashTitle": "Flashcards Category {id}",
+    "loading": "Loading questions...",
+    "questionCount": "{count} questions",
+    "resultCount": "{shown} of {total}",
+    "searchClear": "Clear search",
+    "searchLabel": "Search",
+    "searchPlaceholder": "Search questions and answers",
+    "title": "Browse Category {id}",
+    "topicAll": "All"
   },
   "StudyHeader": {
     "mode": {

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -56,16 +56,25 @@
     "slogan": "Feito por radioamadores, para (futuros) radioamadores"
   },
   "Browse": {
-    "title": "Estudar Categoria {id}",
-    "loading": "A carregar questões...",
-    "flashTitle": "Flashcards Categoria {id}",
-    "flashLoading": "A carregar flashcards...",
-    "flashNotFound": "Não encontrámos a categoria {id}. Tenta escolher uma categoria no menu Explorar.",
-    "flashNoQuestions": "Ainda não há questões disponíveis para esta categoria.",
-    "flashSubtitle": "Pratica uma questão aleatória de cada vez. Já reviste {count}.",
+    "emptyClear": "Limpar pesquisa",
+    "emptyElsewhere": "Há {count} noutras matérias.",
+    "emptySearchAll": "Procurar em todas as matérias",
+    "emptyTitle": "Nenhuma pergunta encontrada.",
     "flashCard": "Cartão {position} de {total} nesta ronda.",
+    "flashLoading": "A carregar flashcards...",
     "flashNext": "Próxima questão",
-    "questionCount": "{count} questões"
+    "flashNoQuestions": "Ainda não há questões disponíveis para esta categoria.",
+    "flashNotFound": "Não encontrámos a categoria {id}. Tenta escolher uma categoria no menu Explorar.",
+    "flashSubtitle": "Pratica uma questão aleatória de cada vez. Já reviste {count}.",
+    "flashTitle": "Flashcards Categoria {id}",
+    "loading": "A carregar questões...",
+    "questionCount": "{count} questões",
+    "resultCount": "{shown} de {total}",
+    "searchClear": "Limpar pesquisa",
+    "searchLabel": "Pesquisar",
+    "searchPlaceholder": "Pesquisar nas perguntas e respostas",
+    "title": "Estudar Categoria {id}",
+    "topicAll": "Todas"
   },
   "StudyHeader": {
     "mode": {


### PR DESCRIPTION
The category 3 list is 209 questions and reads end to end. Now that every question carries a topic, two ways to cut it down: **a chip per topic**, and **a search box over the question and its answers**.

Mockup this implements: https://claude.ai/code/artifact/ed343937-f277-41de-8309-7b690ffc2fb4

## Why the two belong together

Search narrows first, the topic narrows that, and **the chip counts describe the search results rather than the bank**.

Searching cat 3 for `antena` returns **13 questions, and only 4 are in `Antenas`** — the rest sit in Segurança, Interferências, Recetores and Operação. So with a term typed, the chips stop being a menu and become the distribution of what was found: an answer to *where does this subject actually come up?* without reading a single question.

## Search covers the answers

Not an extra. Of those 13 `antena` hits, **eight carry the word only in an option** — stem-only matching would lose most of the result set. And the match is highlighted where it actually is, or question 70 looks like it appeared for no reason.

Only the **first** occurrence is marked. A question saying "antena" four times would become a stripe of highlight and read worse than unmarked.

## The part that needed care

Matching folds diacritics and case, because the bank still mixes pre-1990 and current orthography — `eletrico` has to find `eléctrico`.

Folding changes a string's length, so a match found in folded text **cannot** be sliced out of the original by the same offsets. `findMatch` carries a position map to translate back. Without it, highlighting `propagacao` would cut the accented word apart. There's a test for exactly that.

## Question numbers keep their unfiltered position

A question is `115` in every view, so it stays something you can refer to and link to. The gaps in a filtered list are themselves a signal that you're looking at a subset — cat 3's eight `Propagação` questions sit at 12, 115–119, 121 and 139, and that clustering is real information about how the bank is ordered.

## State split

Topic in the URL, search in component state — same as `/study`, and for a reason. A topic is a **place** the dashboard can link straight to; a search is a passing question, and pushing one per keystroke would bury the back button.

## Two edge cases worth naming

- **A `#q-` deep link drops the topic.** The link means "show me this question", and a filter hiding it would make the scroll fail silently. Uses `replace`, not `push`, so back still leaves the page. Lint caught a `setState`-in-effect here, and it was a real find: it made clear the `setSearch('')` was dead, since search starts empty on every navigation and only the URL topic can be stale.
- **An unknown `?topic=` is guarded** by `isTopicSlug`. `/browse/3?topic=bogus` returns 200 and shows everything rather than an empty list.

## Empty state

Two combinable controls produce empty combinations, and a bare "no results" leaves you guessing which one to drop. So it counts matches *without* the topic filter and offers the button that fixes it.

## Scope

Browse only. `flash` shuffles and `smart-practice` schedules by SM-2, so filtering there changes **selection** rather than display, and each needs its own decision. `?topic=` is the natural seed when we get there.

## Verification

246 tests pass, up from 234. The 12 new ones cover the logic worth locking: accent folding across the orthography split, matching on options, `findMatch` slicing `reflexão` out intact when you typed `reflexao`, and `topicCounts` ordering, zero-dropping and locale labels. Type-check, lint and a production build all clean; `/browse/3`, `?topic=propagacao` and `?topic=bogus` all serve 200.