### PR TITLE
Stop losing bookmarks, notes and streak history

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,16 @@ Uses `next-intl` v4. Default locale is **Portuguese (pt)**, also supports Englis
   absent until somebody resolves it. Never use the pergunta number as a page
 - **Image paths are already absolute** in the shipped JSON (`/images/cat{id}/file.png`); source files store them public-relative (`images/...`) and the compiler resolves them. Consumers use `question.img` directly — don't re-prepend
 - **`lib/data.ts` does no normalization.** If question data looks wrong, fix the source and rebuild; don't add a runtime coercion. Malformed data should fail `content:check`, not be patched per visitor
-- **Progress version migration**: Auto-migrates localStorage on load if version < `PROGRESS_VERSION` (currently V3)
+- **Progress version migration**: Auto-migrates localStorage on load if version < `PROGRESS_VERSION` (currently V5)
+- **Streaks are derived, never incremented.** `UserProgress.activeDays` is the
+  set of local days the user studied; `currentStreak`/`longestStreak`/
+  `lastStudyDate` fall out of it via `lib/streaks.ts`. `longestStreak` is kept
+  monotonic because pre-V5 users have a real longest run whose days were never
+  recorded. Never bump a streak counter in place — it cannot be merged between
+  two devices and cannot be recomputed once it drifts
+- **`examHistory` is capped** at `EXAM_HISTORY_LIMIT` (300, newest-first) with
+  the overflow folded into `archivedExams`. Anything counting exams from the
+  array alone is approximate for very heavy users
 - **Exam replay via URL params**: `q=` (question IDs), `a=` (base36-encoded answers), `t=` (time remaining) — no server storage needed
 - **Calculator is a modal context**, not a route — opening calculators doesn't change URL
 

--- a/__tests__/unit/test-storage-progress.test.ts
+++ b/__tests__/unit/test-storage-progress.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  localStorageProvider,
+  migrateProgress,
+  toggleBookmark,
+  saveQuestionNotes,
+  STORAGE_ERROR_EVENT,
+  type StorageWriteError,
+} from "@/lib/storage/localStorage";
+import {
+  createEmptyProgress,
+  createInitialSRStats,
+  getQuestionKey,
+  EXAM_HISTORY_LIMIT,
+  PROGRESS_VERSION,
+  type ExamAttempt,
+  type UserProgress,
+} from "@/lib/types/progress";
+import { getTodayDateString } from "@/lib/gamification/daily-goals";
+
+const STORAGE_KEY = "hamradio_progress";
+
+function seed(progress: UserProgress): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(progress));
+}
+
+function stored(): UserProgress {
+  return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}") as UserProgress;
+}
+
+function makeExam(overrides: Partial<ExamAttempt> = {}): ExamAttempt {
+  return {
+    id: `exam-${Math.random().toString(36).slice(2)}`,
+    category: "3",
+    score: 30,
+    totalQuestions: 40,
+    correctCount: 30,
+    incorrectCount: 10,
+    unansweredCount: 0,
+    timeSpent: 600,
+    passed: true,
+    timestamp: 1_700_000_000_000,
+    questionIds: [1, 2, 3],
+    answers: { 1: 0 },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  // The legacy auto-migration only runs once per browser; mark it done so it
+  // does not interfere with tests that start from an empty store.
+  localStorage.setItem("hamradio_legacy_migrated", "1");
+});
+
+describe("recordQuestionAttempt", () => {
+  it("preserves the bookmark and the note when a bookmarked question is answered", async () => {
+    // Regression: this used to rebuild the record field by field, silently
+    // deleting bookmarked / bookmarkedAt / notes on every answer.
+    seed(createEmptyProgress());
+    await toggleBookmark("3", 42);
+    await saveQuestionNotes("3", 42, "lembrar: 3.5 MHz");
+
+    await localStorageProvider.recordQuestionAttempt({
+      questionId: 42,
+      category: "3",
+      correct: true,
+      timestamp: 1_700_000_000_000,
+    });
+
+    const stats = stored().questionStats[getQuestionKey("3", 42)];
+    expect(stats?.bookmarked).toBe(true);
+    expect(stats?.bookmarkedAt).toEqual(expect.any(Number));
+    expect(stats?.notes).toBe("lembrar: 3.5 MHz");
+  });
+
+  it("preserves spaced-repetition scheduling", async () => {
+    const progress = createEmptyProgress();
+    const srStats = { ...createInitialSRStats(), interval: 30, repetitionNumber: 4 };
+    progress.questionStats[getQuestionKey("3", 7)] = {
+      attempts: 3,
+      correct: 3,
+      lastAttempt: 1,
+      lastCorrect: true,
+      spacedRep: srStats,
+    };
+    seed(progress);
+
+    await localStorageProvider.recordQuestionAttempt({
+      questionId: 7,
+      category: "3",
+      correct: false,
+      timestamp: 1_700_000_000_000,
+    });
+
+    const stats = stored().questionStats[getQuestionKey("3", 7)];
+    expect(stats?.spacedRep).toEqual(srStats);
+    expect(stats?.attempts).toBe(4);
+    expect(stats?.correct).toBe(3);
+    expect(stats?.lastCorrect).toBe(false);
+  });
+
+  it("records today as a study day", async () => {
+    seed(createEmptyProgress());
+
+    await localStorageProvider.recordQuestionAttempt({
+      questionId: 1,
+      category: "3",
+      correct: true,
+      timestamp: Date.now(),
+    });
+
+    const after = stored();
+    expect(after.activeDays).toEqual([getTodayDateString()]);
+    expect(after.stats.currentStreak).toBe(1);
+    expect(after.stats.lastStudyDate).toBe(getTodayDateString());
+  });
+
+  it("does not add a second entry for the same day", async () => {
+    seed(createEmptyProgress());
+    for (const questionId of [1, 2, 3]) {
+      await localStorageProvider.recordQuestionAttempt({
+        questionId,
+        category: "3",
+        correct: true,
+        timestamp: Date.now(),
+      });
+    }
+    expect(stored().activeDays).toHaveLength(1);
+  });
+});
+
+describe("recordExamAttempt", () => {
+  it("caps the history and folds the overflow into archivedExams", async () => {
+    const progress = createEmptyProgress();
+    progress.examHistory = Array.from({ length: EXAM_HISTORY_LIMIT }, (_, i) =>
+      makeExam({
+        id: `old-${i}`,
+        // Oldest last: the array is newest-first.
+        timestamp: 1_700_000_000_000 - i,
+        passed: i % 2 === 0,
+        score: 10 + (i % 5),
+        category: "2",
+      })
+    );
+    seed(progress);
+
+    await localStorageProvider.recordExamAttempt(makeExam({ id: "newest", score: 38 }));
+
+    const after = stored();
+    expect(after.examHistory).toHaveLength(EXAM_HISTORY_LIMIT);
+    expect(after.examHistory[0]?.id).toBe("newest");
+    // Exactly one exam fell off the end: the oldest.
+    expect(after.examHistory.some((e) => e.id === `old-${EXAM_HISTORY_LIMIT - 1}`)).toBe(false);
+    expect(after.archivedExams?.count).toBe(1);
+    expect(after.archivedExams?.bestScores["2"]).toBeDefined();
+    // Lifetime totals are unaffected by the trim.
+    expect(after.stats.totalExams).toBe(1);
+  });
+
+  it("leaves a short history untouched", async () => {
+    seed(createEmptyProgress());
+    await localStorageProvider.recordExamAttempt(makeExam());
+    const after = stored();
+    expect(after.examHistory).toHaveLength(1);
+    expect(after.archivedExams).toBeUndefined();
+  });
+});
+
+describe("migrateProgress V4 -> V5", () => {
+  function makeV4(): UserProgress {
+    const progress = createEmptyProgress();
+    progress.version = 4;
+    delete (progress as Partial<UserProgress>).activeDays;
+    return progress;
+  }
+
+  it("backfills the days a stored streak implies", () => {
+    const v4 = makeV4();
+    v4.stats.currentStreak = 5;
+    v4.stats.longestStreak = 11;
+    v4.stats.lastStudyDate = "2026-08-25";
+
+    const migrated = migrateProgress(v4);
+
+    expect(migrated.version).toBe(PROGRESS_VERSION);
+    expect(migrated.activeDays).toEqual([
+      "2026-08-21", "2026-08-22", "2026-08-23", "2026-08-24", "2026-08-25",
+    ]);
+    // The days behind the old longest streak were never recorded, so the stored
+    // value must survive as a floor rather than being recomputed downwards.
+    expect(migrated.stats.longestStreak).toBe(11);
+  });
+
+  it("copes with a user who has never studied", () => {
+    const migrated = migrateProgress(makeV4());
+    expect(migrated.activeDays).toEqual([]);
+  });
+
+  it("caps an oversized history that predates the limit", () => {
+    const v4 = makeV4();
+    v4.examHistory = Array.from({ length: EXAM_HISTORY_LIMIT + 25 }, (_, i) =>
+      makeExam({ id: `e-${i}`, timestamp: 1_700_000_000_000 - i, passed: i < 10 })
+    );
+
+    const migrated = migrateProgress(v4);
+
+    expect(migrated.examHistory).toHaveLength(EXAM_HISTORY_LIMIT);
+    expect(migrated.archivedExams?.count).toBe(25);
+    expect(migrated.archivedExams?.passed).toBe(0);
+  });
+
+  it("is idempotent", () => {
+    const v4 = makeV4();
+    v4.stats.currentStreak = 3;
+    v4.stats.lastStudyDate = "2026-08-25";
+
+    const once = migrateProgress(v4);
+    const twice = migrateProgress(once);
+
+    expect(twice.activeDays).toEqual(once.activeDays);
+    expect(twice.archivedExams).toEqual(once.archivedExams);
+  });
+});
+
+describe("getProgress on stored V4 data", () => {
+  it("migrates, persists and keeps the visible streak — the path every existing user hits", async () => {
+    const v4 = createEmptyProgress();
+    v4.version = 4;
+    delete (v4 as Partial<UserProgress>).activeDays;
+    v4.stats.currentStreak = 6;
+    v4.stats.longestStreak = 14;
+    v4.stats.lastStudyDate = getTodayDateString();
+    v4.questionStats[getQuestionKey("3", 9)] = {
+      attempts: 2,
+      correct: 1,
+      lastAttempt: 1,
+      lastCorrect: false,
+      bookmarked: true,
+      bookmarkedAt: 5,
+      notes: "rever",
+    };
+    seed(v4);
+
+    const loaded = await localStorageProvider.getProgress();
+
+    expect(loaded?.version).toBe(PROGRESS_VERSION);
+    expect(loaded?.activeDays).toHaveLength(6);
+    expect(loaded?.stats.currentStreak).toBe(6);
+    expect(loaded?.stats.longestStreak).toBe(14);
+    // The migration must not disturb existing question data.
+    expect(loaded?.questionStats[getQuestionKey("3", 9)]?.notes).toBe("rever");
+    // ...and it is written back, so it only runs once.
+    expect(stored().version).toBe(PROGRESS_VERSION);
+  });
+});
+
+describe("failed writes", () => {
+  let setItem: typeof Storage.prototype.setItem;
+
+  beforeEach(() => {
+    setItem = Storage.prototype.setItem;
+  });
+
+  afterEach(() => {
+    Storage.prototype.setItem = setItem;
+    vi.restoreAllMocks();
+  });
+
+  it("announces a quota failure instead of failing silently", async () => {
+    seed(createEmptyProgress());
+
+    const events: StorageWriteError[] = [];
+    const onError = (event: Event) => {
+      events.push((event as CustomEvent<StorageWriteError>).detail);
+    };
+    window.addEventListener(STORAGE_ERROR_EVENT, onError);
+
+    // Reject only the real write: the availability probe uses its own key.
+    Storage.prototype.setItem = function (key: string, value: string) {
+      if (key === STORAGE_KEY) {
+        const error = new DOMException("exceeded the quota", "QuotaExceededError");
+        throw error;
+      }
+      return setItem.call(this, key, value);
+    };
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      localStorageProvider.recordQuestionAttempt({
+        questionId: 1,
+        category: "3",
+        correct: true,
+        timestamp: Date.now(),
+      })
+    ).rejects.toBeInstanceOf(DOMException);
+
+    window.removeEventListener(STORAGE_ERROR_EVENT, onError);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe("quota");
+  });
+});

--- a/__tests__/unit/test-streaks.test.ts
+++ b/__tests__/unit/test-streaks.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  shiftDay,
+  addActiveDay,
+  normalizeActiveDays,
+  deriveStreaks,
+  backfillActiveDays,
+} from "@/lib/streaks";
+
+describe("shiftDay", () => {
+  it("steps across a month boundary", () => {
+    expect(shiftDay("2026-01-31", 1)).toBe("2026-02-01");
+    expect(shiftDay("2026-03-01", -1)).toBe("2026-02-28");
+  });
+
+  it("steps across a year boundary", () => {
+    expect(shiftDay("2025-12-31", 1)).toBe("2026-01-01");
+    expect(shiftDay("2026-01-01", -1)).toBe("2025-12-31");
+  });
+
+  it("handles leap days", () => {
+    expect(shiftDay("2028-02-28", 1)).toBe("2028-02-29");
+    expect(shiftDay("2028-03-01", -1)).toBe("2028-02-29");
+  });
+
+  it("steps by whole days across a DST change (Portugal springs forward 29 Mar 2026)", () => {
+    expect(shiftDay("2026-03-28", 1)).toBe("2026-03-29");
+    expect(shiftDay("2026-03-29", 1)).toBe("2026-03-30");
+  });
+
+  it("leaves an unparseable day alone", () => {
+    expect(shiftDay("nonsense", 1)).toBe("nonsense");
+  });
+});
+
+describe("addActiveDay", () => {
+  it("keeps the set sorted", () => {
+    expect(addActiveDay(["2026-08-03", "2026-08-01"], "2026-08-02")).toEqual([
+      "2026-08-01",
+      "2026-08-02",
+      "2026-08-03",
+    ]);
+  });
+
+  it("returns the same array when the day is already present", () => {
+    const days = ["2026-08-01"];
+    expect(addActiveDay(days, "2026-08-01")).toBe(days);
+  });
+});
+
+describe("normalizeActiveDays", () => {
+  it("sorts, de-duplicates and drops junk", () => {
+    expect(
+      normalizeActiveDays(["2026-08-02", "2026-08-01", "2026-08-02", "", "oops"])
+    ).toEqual(["2026-08-01", "2026-08-02"]);
+  });
+});
+
+describe("deriveStreaks", () => {
+  it("reports nothing for an empty set", () => {
+    expect(deriveStreaks([], "2026-08-25")).toEqual({
+      currentStreak: 0,
+      longestStreak: 0,
+      lastStudyDate: null,
+    });
+  });
+
+  it("counts a run ending today", () => {
+    const days = ["2026-08-23", "2026-08-24", "2026-08-25"];
+    expect(deriveStreaks(days, "2026-08-25")).toEqual({
+      currentStreak: 3,
+      longestStreak: 3,
+      lastStudyDate: "2026-08-25",
+    });
+  });
+
+  it("keeps a streak alive on a day the user has not studied yet", () => {
+    const days = ["2026-08-23", "2026-08-24"];
+    expect(deriveStreaks(days, "2026-08-25").currentStreak).toBe(2);
+  });
+
+  it("breaks a streak once a whole day is missed", () => {
+    const days = ["2026-08-22", "2026-08-23"];
+    expect(deriveStreaks(days, "2026-08-25").currentStreak).toBe(0);
+  });
+
+  it("finds the longest run even when it is not the current one", () => {
+    const days = [
+      "2026-08-01", "2026-08-02", "2026-08-03", "2026-08-04",
+      "2026-08-24", "2026-08-25",
+    ];
+    expect(deriveStreaks(days, "2026-08-25")).toEqual({
+      currentStreak: 2,
+      longestStreak: 4,
+      lastStudyDate: "2026-08-25",
+    });
+  });
+
+  it("is order-independent", () => {
+    const shuffled = ["2026-08-25", "2026-08-23", "2026-08-24"];
+    expect(deriveStreaks(shuffled, "2026-08-25").currentStreak).toBe(3);
+  });
+
+  it("counts a run that spans a month boundary", () => {
+    const days = ["2026-07-30", "2026-07-31", "2026-08-01"];
+    expect(deriveStreaks(days, "2026-08-01").currentStreak).toBe(3);
+  });
+});
+
+describe("backfillActiveDays", () => {
+  it("returns nothing when there is no last study date", () => {
+    expect(backfillActiveDays(null, 7)).toEqual([]);
+  });
+
+  it("reconstructs exactly the days the stored streak implies", () => {
+    expect(backfillActiveDays("2026-08-25", 3)).toEqual([
+      "2026-08-23",
+      "2026-08-24",
+      "2026-08-25",
+    ]);
+  });
+
+  it("still records the last study day when the streak counter is 0", () => {
+    expect(backfillActiveDays("2026-08-25", 0)).toEqual(["2026-08-25"]);
+  });
+
+  it("round-trips through deriveStreaks without changing the visible streak", () => {
+    const days = backfillActiveDays("2026-08-25", 12);
+    expect(deriveStreaks(days, "2026-08-25").currentStreak).toBe(12);
+  });
+});

--- a/components/StorageWarning.tsx
+++ b/components/StorageWarning.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { AlertTriangle, X } from "lucide-react";
+import { useProgressContext } from "@/components/providers/ProgressProvider";
+
+/**
+ * Tells the user when their progress stopped being saved.
+ *
+ * Answers are written to localStorage from handlers that do not await the
+ * write, so a full quota used to fail in complete silence: the session looked
+ * normal and nothing was persisted. This is the one place that failure surfaces.
+ */
+export function StorageWarning() {
+  const t = useTranslations("Storage");
+  const { storageError, dismissStorageError } = useProgressContext();
+
+  if (!storageError) return null;
+
+  return (
+    <div
+      role="alert"
+      className="fixed bottom-0 left-0 right-0 z-50 border-t border-red-700 bg-red-600 px-4 py-3 text-white"
+    >
+      <div className="mx-auto flex max-w-3xl items-start gap-3 text-sm">
+        <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
+        <div className="flex-1">
+          <p className="font-semibold">{t("notSavedTitle")}</p>
+          <p className="mt-0.5 text-red-50">
+            {storageError.kind === "quota" ? t("quotaBody") : t("unknownBody")}
+          </p>
+        </div>
+        <button
+          onClick={dismissStorageError}
+          className="rounded p-1 transition-colors hover:bg-red-700"
+          aria-label={t("dismiss")}
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/providers/ProgressProvider.tsx
+++ b/components/providers/ProgressProvider.tsx
@@ -10,6 +10,8 @@ import type {
   QuestionStats,
   SpacedRepetitionStats,
 } from "@/lib/types/progress";
+import type { StorageWriteError } from "@/lib/storage/localStorage";
+import { StorageWarning } from "@/components/StorageWarning";
 import type {
   GamificationState,
   GamificationResult,
@@ -29,6 +31,8 @@ import { GAMIFICATION_ENABLED } from "@/lib/config/features";
 type ProgressContextType = {
   progress: UserProgress | null;
   isLoading: boolean;
+  storageError: StorageWriteError | null;
+  dismissStorageError: () => void;
   recordExam: (attempt: ExamAttempt) => Promise<UserProgress | null>;
   recordQuestion: (attempt: QuestionAttempt) => Promise<void>;
   recordQuestionWithGamification: (
@@ -229,6 +233,7 @@ export default function ProgressProvider({
   return (
     <ProgressContext.Provider value={contextValue}>
       {children}
+      <StorageWarning />
     </ProgressContext.Provider>
   );
 }

--- a/hooks/useProgress.ts
+++ b/hooks/useProgress.ts
@@ -18,10 +18,17 @@ import {
   getCategoryProgress,
   updateQuestionSR,
 } from "@/lib/storage";
+import {
+  STORAGE_ERROR_EVENT,
+  type StorageWriteError,
+} from "@/lib/storage/localStorage";
 
 interface UseProgressReturn {
   progress: UserProgress | null;
   isLoading: boolean;
+  /** Set when a write to storage failed. Null while writes are succeeding. */
+  storageError: StorageWriteError | null;
+  dismissStorageError: () => void;
   recordExam: (attempt: ExamAttempt) => Promise<UserProgress | null>;
   recordQuestion: (attempt: QuestionAttempt) => Promise<void>;
   recordQuestionBatch: (attempts: QuestionAttempt[]) => Promise<void>;
@@ -52,6 +59,22 @@ interface UseProgressReturn {
 export function useProgress(): UseProgressReturn {
   const [progress, setProgress] = useState<UserProgress | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [storageError, setStorageError] = useState<StorageWriteError | null>(null);
+
+  // Answer handlers fire these writes without awaiting them, so a failure would
+  // otherwise be an unhandled rejection nobody sees. The storage layer reports
+  // every failed write on this event; each record* below also swallows the
+  // rejection so a full quota cannot take a study session down with it.
+  useEffect(() => {
+    const onStorageError = (event: Event) => {
+      const detail = (event as CustomEvent<StorageWriteError>).detail;
+      setStorageError(detail ?? { kind: "unknown", message: "" });
+    };
+    window.addEventListener(STORAGE_ERROR_EVENT, onStorageError);
+    return () => window.removeEventListener(STORAGE_ERROR_EVENT, onStorageError);
+  }, []);
+
+  const dismissStorageError = useCallback(() => setStorageError(null), []);
 
   const loadProgress = useCallback(async () => {
     setIsLoading(true);
@@ -71,7 +94,11 @@ export function useProgress(): UseProgressReturn {
 
   const recordExam = useCallback(
     async (attempt: ExamAttempt): Promise<UserProgress | null> => {
-      await storageProvider.recordExamAttempt(attempt);
+      try {
+        await storageProvider.recordExamAttempt(attempt);
+      } catch (error) {
+        console.error("Failed to record exam attempt:", error);
+      }
       // Reload progress to get updated state, and hand the fresh copy back so
       // callers can process gamification against post-exam stats without racing
       // the async React state update.
@@ -83,14 +110,22 @@ export function useProgress(): UseProgressReturn {
   );
 
   const recordQuestion = useCallback(async (attempt: QuestionAttempt) => {
-    await storageProvider.recordQuestionAttempt(attempt);
+    try {
+      await storageProvider.recordQuestionAttempt(attempt);
+    } catch (error) {
+      console.error("Failed to record question attempt:", error);
+    }
     // Don't reload for single questions to avoid performance issues
   }, []);
 
   const recordQuestionBatch = useCallback(
     async (attempts: QuestionAttempt[]) => {
-      for (const attempt of attempts) {
-        await storageProvider.recordQuestionAttempt(attempt);
+      try {
+        for (const attempt of attempts) {
+          await storageProvider.recordQuestionAttempt(attempt);
+        }
+      } catch (error) {
+        console.error("Failed to record question batch:", error);
       }
       // Reload progress after batch
       const updated = await storageProvider.getProgress();
@@ -106,7 +141,11 @@ export function useProgress(): UseProgressReturn {
       srStats: SpacedRepetitionStats,
       wasCorrect: boolean
     ) => {
-      await updateQuestionSR(category, questionId, srStats, wasCorrect);
+      try {
+        await updateQuestionSR(category, questionId, srStats, wasCorrect);
+      } catch (error) {
+        console.error("Failed to record smart-practice review:", error);
+      }
       // Reload progress to get updated state
       const updated = await storageProvider.getProgress();
       setProgress(updated);
@@ -181,6 +220,8 @@ export function useProgress(): UseProgressReturn {
   return {
     progress,
     isLoading,
+    storageError,
+    dismissStorageError,
     recordExam,
     recordQuestion,
     recordQuestionBatch,

--- a/lib/backup/import.ts
+++ b/lib/backup/import.ts
@@ -1,5 +1,7 @@
-import type { UserProgress, QuestionStats, ExamAttempt } from "@/lib/types/progress";
+import type { UserProgress, QuestionStats, ExamAttempt, ArchivedExams } from "@/lib/types/progress";
 import { PROGRESS_VERSION } from "@/lib/types/progress";
+import { deriveStreaks, normalizeActiveDays } from "@/lib/streaks";
+import { getTodayDateString } from "@/lib/gamification/daily-goals";
 import type { GamificationState, UnlockedAchievement } from "@/lib/types/gamification";
 import type { BackupFile, ValidationResult, ImportResult, ImportStrategy } from "./types";
 import { generateChecksum } from "./export";
@@ -192,6 +194,34 @@ function mergeGamification(
   };
 }
 
+/**
+ * Combine two exam rollups. The individual attempts behind them are gone, so
+ * counts are taken as the larger of the two rather than summed: the common case
+ * is the same history exported and re-imported, which summing would double.
+ */
+function mergeArchivedExams(
+  existing: ArchivedExams | undefined,
+  imported: ArchivedExams | undefined
+): { archivedExams?: ArchivedExams } {
+  if (!existing && !imported) return {};
+  if (!existing) return { archivedExams: imported };
+  if (!imported) return { archivedExams: existing };
+
+  const bestScores = { ...existing.bestScores };
+  for (const [cat, score] of Object.entries(imported.bestScores)) {
+    const current = bestScores[cat];
+    if (current === undefined || score > current) bestScores[cat] = score;
+  }
+
+  return {
+    archivedExams: {
+      count: Math.max(existing.count, imported.count),
+      passed: Math.max(existing.passed, imported.passed),
+      bestScores,
+    },
+  };
+}
+
 export function mergeProgress(
   existing: UserProgress,
   imported: UserProgress
@@ -211,22 +241,36 @@ export function mergeProgress(
     imported.gamification
   );
 
+  const activeDays = normalizeActiveDays([
+    ...(existing.activeDays ?? []),
+    ...(imported.activeDays ?? []),
+  ]);
+  const derivedStreaks = deriveStreaks(activeDays, getTodayDateString());
+
   const merged: UserProgress = {
     version: PROGRESS_VERSION,
     lastUpdated: Date.now(),
     questionStats,
     examHistory,
+    // A study day happened or it did not, on either device — union is the whole
+    // merge rule, and it is the one field here that is genuinely conflict-free.
+    activeDays,
+    ...mergeArchivedExams(existing.archivedExams, imported.archivedExams),
     stats: {
       totalExams: Math.max(existing.stats.totalExams, imported.stats.totalExams),
       totalPassed: Math.max(existing.stats.totalPassed, imported.stats.totalPassed),
       bestScores: { ...existing.stats.bestScores },
-      currentStreak: Math.max(existing.stats.currentStreak, imported.stats.currentStreak),
-      longestStreak: Math.max(existing.stats.longestStreak, imported.stats.longestStreak),
-      lastStudyDate: existing.stats.lastStudyDate && imported.stats.lastStudyDate
-        ? existing.stats.lastStudyDate > imported.stats.lastStudyDate
-          ? existing.stats.lastStudyDate
-          : imported.stats.lastStudyDate
-        : existing.stats.lastStudyDate || imported.stats.lastStudyDate,
+      // Derived from the unioned day set, not from the two stored counters —
+      // merging two streaks by taking the larger invents a streak neither
+      // device had. longestStreak still floors at the stored values, because a
+      // pre-V5 backup's longest run predates the days we can see.
+      currentStreak: derivedStreaks.currentStreak,
+      longestStreak: Math.max(
+        existing.stats.longestStreak,
+        imported.stats.longestStreak,
+        derivedStreaks.longestStreak
+      ),
+      lastStudyDate: derivedStreaks.lastStudyDate,
     },
     gamification,
   };

--- a/lib/storage/localStorage.ts
+++ b/lib/storage/localStorage.ts
@@ -9,10 +9,18 @@ import {
   type QuestionAttempt,
   type QuestionStats,
   type SpacedRepetitionStats,
+  type ArchivedExams,
   PROGRESS_VERSION,
+  EXAM_HISTORY_LIMIT,
   createEmptyProgress,
   getQuestionKey,
 } from "@/lib/types/progress";
+import {
+  addActiveDay,
+  backfillActiveDays,
+  deriveStreaks,
+  normalizeActiveDays,
+} from "@/lib/streaks";
 import { migrateToGamification } from "@/lib/gamification/engine";
 import { createInitialGamificationState } from "@/lib/types/gamification";
 import type { GamificationState } from "@/lib/types/gamification";
@@ -21,6 +29,43 @@ import { convertLegacyExport } from "@/lib/backup/legacy-import";
 
 const STORAGE_KEY = "hamradio_progress";
 const LEGACY_MIGRATED_KEY = "hamradio_legacy_migrated";
+
+/** Fired on `window` when a write to localStorage fails. */
+export const STORAGE_ERROR_EVENT = "hamradio:storage-error";
+
+export interface StorageWriteError {
+  /** `quota` means the browser refused the write because storage is full. */
+  kind: "quota" | "unknown";
+  message: string;
+}
+
+function isQuotaError(error: unknown): boolean {
+  if (typeof DOMException !== "undefined" && error instanceof DOMException) {
+    // Browsers disagree on the name and Firefox only sets the legacy code.
+    return (
+      error.name === "QuotaExceededError" ||
+      error.name === "NS_ERROR_DOM_QUOTA_REACHED" ||
+      error.code === 22 ||
+      error.code === 1014
+    );
+  }
+  return error instanceof Error && error.name === "QuotaExceededError";
+}
+
+/**
+ * Surface a failed write instead of letting it become an unhandled rejection.
+ * Progress writes are fired from answer handlers that do not await them, so a
+ * full quota otherwise fails completely silently — the user keeps studying and
+ * nothing is being saved.
+ */
+function reportStorageError(error: unknown): void {
+  if (typeof window === "undefined") return;
+  const detail: StorageWriteError = {
+    kind: isQuotaError(error) ? "quota" : "unknown",
+    message: error instanceof Error ? error.message : String(error),
+  };
+  window.dispatchEvent(new CustomEvent(STORAGE_ERROR_EVENT, { detail }));
+}
 
 function isLocalStorageAvailable(): boolean {
   if (typeof window === "undefined") return false;
@@ -132,6 +177,7 @@ function saveProgress(progress: UserProgress): Promise<void> {
       resolve();
     } catch (error) {
       console.error("Failed to save progress to localStorage:", error);
+      reportStorageError(error);
       reject(error);
     }
   });
@@ -163,39 +209,69 @@ export function migrateProgress(progress: UserProgress): UserProgress {
     }
   }
 
+  // V4 -> V5: streaks move from three mutable counters to a set of study days,
+  // and examHistory gains a cap. Backfill the days the stored streak implies so
+  // no visible streak collapses; every day before that run was never recorded
+  // anywhere and is unrecoverable, which is the reason V5 starts writing them.
+  if (!Array.isArray(migrated.activeDays)) {
+    migrated.activeDays = backfillActiveDays(
+      migrated.stats.lastStudyDate,
+      migrated.stats.currentStreak
+    );
+  } else {
+    migrated.activeDays = normalizeActiveDays(migrated.activeDays);
+  }
+
+  capExamHistory(migrated);
+
   migrated.version = PROGRESS_VERSION;
   return migrated;
 }
 
-function updateStreak(stats: UserProgress["stats"]): void {
-  const today = getTodayDateString();
-  const lastDate = stats.lastStudyDate;
+/**
+ * Fold exams beyond EXAM_HISTORY_LIMIT into `archivedExams`.
+ * `examHistory` is newest-first, so the tail is the oldest.
+ */
+function capExamHistory(progress: UserProgress): void {
+  if (progress.examHistory.length <= EXAM_HISTORY_LIMIT) return;
 
-  if (!lastDate) {
-    // First time studying
-    stats.currentStreak = 1;
-    stats.longestStreak = 1;
-  } else if (lastDate === today) {
-    // Already studied today, no change
-    return;
-  } else {
-    const lastDateObj = new Date(lastDate);
-    const todayObj = new Date(today);
-    const diffDays = Math.floor(
-      (todayObj.getTime() - lastDateObj.getTime()) / (1000 * 60 * 60 * 24)
-    );
+  const dropped = progress.examHistory.slice(EXAM_HISTORY_LIMIT);
+  progress.examHistory = progress.examHistory.slice(0, EXAM_HISTORY_LIMIT);
 
-    if (diffDays === 1) {
-      // Consecutive day
-      stats.currentStreak += 1;
-      stats.longestStreak = Math.max(stats.longestStreak, stats.currentStreak);
-    } else {
-      // Streak broken
-      stats.currentStreak = 1;
+  const archive: ArchivedExams = progress.archivedExams
+    ? { ...progress.archivedExams, bestScores: { ...progress.archivedExams.bestScores } }
+    : { count: 0, passed: 0, bestScores: {} };
+
+  for (const exam of dropped) {
+    archive.count += 1;
+    if (exam.passed) archive.passed += 1;
+    const best = archive.bestScores[exam.category];
+    if (best === undefined || exam.score > best) {
+      archive.bestScores[exam.category] = exam.score;
     }
   }
 
-  stats.lastStudyDate = today;
+  progress.archivedExams = archive;
+}
+
+/**
+ * Record today as a study day and re-derive every streak number from the set.
+ *
+ * `longestStreak` stays monotonic: users migrated from V4 have a real longest
+ * streak whose days were never written down, so a value derived from the days
+ * we do have must never lower it.
+ */
+function recordStudyDay(progress: UserProgress): void {
+  const today = getTodayDateString();
+  progress.activeDays = addActiveDay(progress.activeDays ?? [], today);
+
+  const derived = deriveStreaks(progress.activeDays, today);
+  progress.stats.currentStreak = derived.currentStreak;
+  progress.stats.longestStreak = Math.max(
+    progress.stats.longestStreak,
+    derived.longestStreak
+  );
+  progress.stats.lastStudyDate = derived.lastStudyDate;
 }
 
 async function recordExamAttempt(attempt: ExamAttempt): Promise<void> {
@@ -220,7 +296,9 @@ async function recordExamAttempt(attempt: ExamAttempt): Promise<void> {
   }
 
   // Update streak
-  updateStreak(progress.stats);
+  recordStudyDay(progress);
+
+  capExamHistory(progress);
 
   await saveProgress(progress);
 }
@@ -235,12 +313,15 @@ async function recordQuestionAttempt(attempt: QuestionAttempt): Promise<void> {
   const existing = progress.questionStats[key];
 
   if (existing) {
+    // Spread `existing` rather than rebuilding the record: bookmarks, notes and
+    // bookmarkedAt live on the same object, and listing fields by hand silently
+    // deleted them every time a bookmarked question was answered.
     progress.questionStats[key] = {
+      ...existing,
       attempts: existing.attempts + 1,
       correct: existing.correct + (attempt.correct ? 1 : 0),
       lastAttempt: attempt.timestamp,
       lastCorrect: attempt.correct,
-      spacedRep: existing.spacedRep, // Preserve existing SR data
     };
   } else {
     progress.questionStats[key] = {
@@ -252,7 +333,7 @@ async function recordQuestionAttempt(attempt: QuestionAttempt): Promise<void> {
   }
 
   // Update streak for any study activity
-  updateStreak(progress.stats);
+  recordStudyDay(progress);
 
   await saveProgress(progress);
 }
@@ -311,7 +392,7 @@ export async function updateQuestionSR(
   }
 
   // Update streak for any study activity
-  updateStreak(progress.stats);
+  recordStudyDay(progress);
 
   await saveProgress(progress);
 }

--- a/lib/streaks.ts
+++ b/lib/streaks.ts
@@ -1,0 +1,131 @@
+/**
+ * Study-streak derivation.
+ *
+ * Streaks are computed from `UserProgress.activeDays` — the set of local
+ * calendar days the user studied — rather than incremented in place. An
+ * incremented counter cannot be merged between two devices and cannot be
+ * recomputed once it drifts; a set of days can be unioned, and every streak
+ * number falls out of it.
+ *
+ * Day strings are local calendar days produced by `toLocalDateString`
+ * (Portugal/WEST, not UTC). They are only ever *compared* and *stepped* here,
+ * which is done through UTC so DST never shortens or lengthens a step.
+ */
+
+const DAY_MS = 86_400_000;
+
+/** `YYYY-MM-DD` → UTC epoch ms. Returns NaN for anything malformed. */
+function dayToUtcMs(day: string): number {
+  const parts = day.split("-");
+  if (parts.length !== 3) return NaN;
+  const year = Number(parts[0]);
+  const month = Number(parts[1]);
+  const date = Number(parts[2]);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(date)) {
+    return NaN;
+  }
+  return Date.UTC(year, month - 1, date);
+}
+
+function utcMsToDay(ms: number): string {
+  const d = new Date(ms);
+  const year = String(d.getUTCFullYear()).padStart(4, "0");
+  const month = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const date = String(d.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${date}`;
+}
+
+/** Move a `YYYY-MM-DD` day string by whole days. */
+export function shiftDay(day: string, deltaDays: number): string {
+  const ms = dayToUtcMs(day);
+  if (Number.isNaN(ms)) return day;
+  return utcMsToDay(ms + deltaDays * DAY_MS);
+}
+
+/**
+ * Add a day to the set, keeping it sorted and unique.
+ * Returns the original array unchanged when the day is already present, so
+ * callers can cheaply skip a write.
+ */
+export function addActiveDay(activeDays: string[], day: string): string[] {
+  if (activeDays.includes(day)) return activeDays;
+  return [...activeDays, day].sort();
+}
+
+/** Sort, de-duplicate and drop anything that is not a usable day string. */
+export function normalizeActiveDays(activeDays: readonly string[]): string[] {
+  const seen = new Set<string>();
+  for (const day of activeDays) {
+    if (typeof day === "string" && !Number.isNaN(dayToUtcMs(day))) {
+      seen.add(day);
+    }
+  }
+  return [...seen].sort();
+}
+
+export interface DerivedStreaks {
+  currentStreak: number;
+  longestStreak: number;
+  lastStudyDate: string | null;
+}
+
+/**
+ * Derive every streak number from the set of active days.
+ *
+ * `currentStreak` counts the consecutive run ending today, or — if the user
+ * has not studied yet today — the run ending yesterday, which is what keeps a
+ * streak visibly alive between sessions. Anything older reads as 0.
+ */
+export function deriveStreaks(activeDays: readonly string[], today: string): DerivedStreaks {
+  const days = normalizeActiveDays(activeDays);
+  if (days.length === 0) {
+    return { currentStreak: 0, longestStreak: 0, lastStudyDate: null };
+  }
+
+  let longest = 1;
+  let run = 1;
+  for (let i = 1; i < days.length; i++) {
+    const prev = days[i - 1] as string;
+    const curr = days[i] as string;
+    run = shiftDay(prev, 1) === curr ? run + 1 : 1;
+    if (run > longest) longest = run;
+  }
+
+  const last = days[days.length - 1] as string;
+  const yesterday = shiftDay(today, -1);
+
+  let current = 0;
+  if (last === today || last === yesterday) {
+    current = 1;
+    for (let i = days.length - 1; i > 0; i--) {
+      const prev = days[i - 1] as string;
+      const curr = days[i] as string;
+      if (shiftDay(prev, 1) !== curr) break;
+      current++;
+    }
+  }
+
+  return { currentStreak: current, longestStreak: longest, lastStudyDate: last };
+}
+
+/**
+ * Reconstruct the days a pre-V5 streak implies, so migrating does not collapse
+ * a visible streak to 1.
+ *
+ * A stored `currentStreak` of 12 ending on `lastStudyDate` means exactly those
+ * 12 consecutive days were study days. Every earlier day is unrecoverable —
+ * it was never written down — which is why V5 starts recording them.
+ */
+export function backfillActiveDays(
+  lastStudyDate: string | null,
+  currentStreak: number
+): string[] {
+  if (!lastStudyDate || Number.isNaN(dayToUtcMs(lastStudyDate))) return [];
+
+  const span = Math.max(1, Math.min(currentStreak, 3650));
+  const days: string[] = [];
+  for (let i = span - 1; i >= 0; i--) {
+    days.push(shiftDay(lastStudyDate, -i));
+  }
+  return days;
+}

--- a/lib/types/progress.ts
+++ b/lib/types/progress.ts
@@ -56,11 +56,31 @@ export interface UserStats {
   lastStudyDate: string | null;
 }
 
+/**
+ * Lifetime rollup of exams trimmed out of `examHistory` by EXAM_HISTORY_LIMIT.
+ * Keeps the totals honest once the cap starts biting; the individual attempts
+ * are gone. Absent until the first trim.
+ */
+export interface ArchivedExams {
+  count: number;
+  passed: number;
+  bestScores: Record<string, number>;
+}
+
 export interface UserProgress {
   version: number;
   lastUpdated: number;
   questionStats: Record<string, QuestionStats>;
   examHistory: ExamAttempt[];
+  /**
+   * Every local calendar day (YYYY-MM-DD) the user studied, sorted and unique.
+   * Streaks are derived from this set (see `lib/streaks.ts`) rather than
+   * incremented in place, because a counter cannot be merged across devices
+   * and cannot be recomputed once it drifts. Added in V5.
+   */
+  activeDays: string[];
+  /** Rollup of exams the history cap dropped. Absent until it first bites. */
+  archivedExams?: ArchivedExams;
   stats: UserStats;
   gamification?: GamificationState;  // Optional for V3+, added via migration
 }
@@ -81,7 +101,14 @@ export interface StorageProvider {
   updateGamification(newState: GamificationState): Promise<UserProgress | null>;
 }
 
-export const PROGRESS_VERSION = 4;
+export const PROGRESS_VERSION = 5;
+
+/**
+ * How many individual exam attempts `examHistory` keeps. Older attempts are
+ * folded into `archivedExams`. Without a bound the array grows until
+ * `localStorage.setItem` throws QuotaExceededError and every later write fails.
+ */
+export const EXAM_HISTORY_LIMIT = 300;
 
 // SM-2 Algorithm Constants
 export const SM2_CONFIG = {
@@ -106,6 +133,7 @@ export function createEmptyProgress(): UserProgress {
     lastUpdated: Date.now(),
     questionStats: {},
     examHistory: [],
+    activeDays: [],
     stats: {
       totalExams: 0,
       totalPassed: 0,

--- a/messages/en.json
+++ b/messages/en.json
@@ -946,5 +946,11 @@
     "message": "You're offline. Some features may be limited.",
     "reconnected": "Back online!",
     "dismiss": "Dismiss"
+  },
+  "Storage": {
+    "notSavedTitle": "Your progress isn't being saved",
+    "quotaBody": "This browser's storage is full. Export a backup from settings and clear old data to start saving again.",
+    "unknownBody": "This browser refused the write. If you're browsing privately, progress isn't saved.",
+    "dismiss": "Dismiss"
   }
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -946,5 +946,11 @@
     "message": "Estás offline. Algumas funcionalidades podem estar limitadas.",
     "reconnected": "De volta online!",
     "dismiss": "Fechar"
+  },
+  "Storage": {
+    "notSavedTitle": "O teu progresso não está a ser guardado",
+    "quotaBody": "O armazenamento deste navegador está cheio. Exporta uma cópia de segurança nas definições e limpa dados antigos para voltar a guardar.",
+    "unknownBody": "Este navegador recusou a gravação. Se estás em navegação privada, o progresso não é guardado.",
+    "dismiss": "Fechar"
   }
 }


### PR DESCRIPTION
Three fixes to the progress layer. All local — no server, no schema beyond `localStorage`.

### 1. Live data loss

`recordQuestionAttempt` rebuilt `questionStats[key]` field by field, preserving only `spacedRep`. Answering a bookmarked question in Browse, Flash, Drill or an exam **silently deleted the bookmark, `bookmarkedAt` and the user's personal note**. `updateQuestionSR` and `toggleBookmark` both spread correctly — this was one function's mistake. It now spreads too.

### 2. Streak history was unrecoverable

`updateStreak` only ever bumped by 1, no-opped, or reset from a single `lastStudyDate`. The set of days somebody actually studied was stored nowhere, and nothing else can reconstruct it: `questionStats` keeps only the last attempt per question, `examHistory` covers exam days only, `xpHistory` is capped at 100.

`UserProgress` gains `activeDays` — the local `YYYY-MM-DD` days the user studied — and `currentStreak` / `longestStreak` / `lastStudyDate` are derived from it by the new `lib/streaks.ts`.

- Migration backfills the days the stored streak *implies* (a stored streak of 6 ending yesterday becomes those 6 day strings), so no visible streak collapses to 1.
- `longestStreak` is floored at its stored value: pre-V5 users have a real longest run whose days were never written down, so a derived value must never lower it.
- Day arithmetic goes through UTC so DST cannot shorten a step. Tested against Portugal's 29 Mar 2026 change.

### 3. `examHistory` grew without bound

`unshift` with no cap, growing toward the ~5 MB quota, after which every write fails. Now capped at 300 newest-first, with the overflow folded into a new `archivedExams: {count, passed, bestScores}` rollup — applied on write and retroactively at migration. Lifetime totals are unaffected.

### 4. Failed writes were completely silent

Those writes are fired from answer handlers that never awaited them, so a full quota failed with no signal at all: the session looked normal and nothing was persisted. Failed writes now emit `hamradio:storage-error`, `useProgress` catches the rejection instead of leaving it unhandled, and a banner tells the user their progress is not being saved (PT/EN strings added).

### Also

`mergeProgress` in `lib/backup/import.ts` unions `activeDays` and derives the merged streak from that union. Taking `Math.max` of two counters invented a streak neither device had.

`PROGRESS_VERSION` → 5.

## Tests

`lib/storage/` had **zero** coverage, which is why these survived. 30 tests added across `test-streaks.test.ts` and `test-storage-progress.test.ts`: month/year/leap/DST boundaries, order-independence, backfill round-trip, the bookmark regression, SR preservation, the history cap, migration idempotence, quota reporting, and the full `getProgress()`-on-stored-v4 path every existing user hits on their next visit.

The bookmark regression test was verified to fail against the old code before being kept.

`type-check`, `lint`, 277 tests and `bun run build` all pass.

## Not in this PR

- `StreakCalendar` still derives its calendar from `xpHistory` (capped at 100, gamification-gated). `activeDays` is strictly better data for it, but that's a display change.
- Achievements that scan `examHistory` (perfect-score counts, categories attempted) become approximate past 300 exams. `archivedExams` keeps counts and best scores, not per-exam detail.
