### PR TITLE
Correct three transcribed answers, and add the tool that found them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ bun run test:coverage # Vitest with V8 coverage
 bun run type-check   # tsc --noEmit
 bun run content:build # Compile content/questions/** into shipped artifacts
 bun run content:check # Verify artifacts match their source (writes nothing)
+bun run qbank <cmd>  # Inspect the question bank (search, dupes, coverage, …)
 ```
 
 ## Deployment
@@ -92,6 +93,37 @@ and `tesseract`; install `tesseract-data-por` for accented text). With
 a `sources` entry, because that needs the question number read off the scan,
 which is the least reliable part — those are proposed in the report for a human
 to confirm. `bun run data:fonte-pages` is the manual equivalent.
+
+## Inspecting the bank
+
+`bun run qbank` is a read-only developer tool over `content/questions/**` —
+`search`, `show`, `dupes`, `pairs`, `coverage`, `topics`, `paper`, `answers`.
+Analysis lives in `lib/content/analysis.ts` as pure functions; the script is
+I/O and formatting.
+
+It is deliberately **not** wired into CI. `content:check` owns per-file
+validity, and duplicating that here would create a second source of truth that
+drifts. What `qbank` reports is the class of problem no per-file rule can see:
+two files that are each valid but disagree with each other.
+
+- **A duplicate is not automatically a defect.** The same regulatory question is
+  legitimately examined at all three levels, so groups are *classified*, not
+  condemned — `contradiction` (same options, disagreeing on which is right),
+  `typo`, `divergent`, `shared-answers`, `exact`, worst first
+- **Every fuzzy finder also requires the answers to agree.** Stem similarity
+  alone is useless: "Qual das seguintes afirmações é incorreta?" is a template
+  shared by dozens of unrelated questions, and its nearest neighbour by string
+  distance is the *opposite* question. Without the answer check, `pairs`
+  reports hundreds of unrelated matches
+- **`canonical()` is for prose, not for options.** It strips punctuation, which
+  makes `10 dB` and `-10 dB`, or `0,01 µF` and `0,01 F`, compare equal — the
+  within-question duplicate-option check therefore compares raw text. Morse
+  answers canonicalise to the empty string entirely, which is what
+  `comparisonKey()` guards against
+- `--new` against `content/qbank-baseline.json` (written by
+  `dupes --update-baseline`) is the same ratchet as `content/missing-exams.json`.
+  No baseline is committed: the findings currently in the bank are real and
+  unfixed, and baselining them would mark them accepted
 
 Why `order` lives in `category.json`: the question order is **editorial, not id
 order** (in cat3, questions 210-213 sit at positions 8, 10, 19 and 31, grouped

--- a/__tests__/unit/test-content-analysis.test.ts
+++ b/__tests__/unit/test-content-analysis.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect } from "vitest";
+import {
+  canonical,
+  comparisonKey,
+  polarityOf,
+  stripPolarity,
+  worstPairedDistance,
+  buildBank,
+  findDuplicateGroups,
+  findPairFindings,
+  auditAnswers,
+  auditPapers,
+  auditTopics,
+  parseRef,
+  type DuplicateTier,
+} from "@/lib/content/analysis";
+import type { ContentCategory, ContentQuestion } from "@/lib/content/schema";
+
+/** A question with everything optional defaulted, so a test states only what it means. */
+function q(
+  id: number,
+  question: string,
+  options: string[],
+  correctIndex = 0,
+  extra: Partial<ContentQuestion> = {}
+): ContentQuestion {
+  return {
+    id,
+    question,
+    answers: options.map((text, i) => ({ text, correct: i === correctIndex })),
+    topic: null,
+    sources: [],
+    image: null,
+    tutorial: null,
+    calc: null,
+    explanation: null,
+    ...extra,
+  };
+}
+
+function category(id: "1" | "2" | "3", questions: ContentQuestion[]): ContentCategory {
+  return { id, anacomFile: 90, questions };
+}
+
+const tiersOf = (groups: { tier: DuplicateTier }[]) => groups.map((g) => g.tier);
+
+describe("Unit: text normalisation", () => {
+  it("folds accents, case and punctuation", () => {
+    expect(canonical("Discordância à ANACOM, propondo")).toBe("discordancia a anacom propondo");
+    expect(canonical("ELÉCTRICO")).toBe("electrico");
+  });
+
+  it("leaves the 1990 orthography split visible rather than folding it away", () => {
+    // Folding drops the accent, not the silent consonant, so "directa" and
+    // "direta" stay distinct. That is what surfaces a spelling inconsistency
+    // as a typo-tier group instead of silently treating the two as the same.
+    expect(canonical("directa")).not.toBe(canonical("direta"));
+  });
+
+  it("keeps Morse options distinct instead of collapsing them to nothing", () => {
+    // Every dot-and-dash option canonicalises to "", so without the raw
+    // fallback cat3 #109's four answers would compare equal to each other.
+    expect(canonical(". . . - - - . . .")).toBe("");
+    expect(comparisonKey(". . . - - - . . .")).not.toBe(comparisonKey("- - - . . . - - -"));
+  });
+});
+
+describe("Unit: polarity", () => {
+  it("reads the sense of a stem", () => {
+    expect(polarityOf("Qual das seguintes afirmações é incorreta?")).toBe("negative");
+    expect(polarityOf("Qual das seguintes afirmações está correta?")).toBe("positive");
+    expect(polarityOf("Uma antena isotrópica radia")).toBe("positive");
+    // "não" folds to "nao"; the pre-1990 "excepto" is still in the bank.
+    expect(polarityOf("Qual destas NÃO é uma banda de amador?")).toBe("negative");
+    expect(polarityOf("Todas são válidas excepto")).toBe("negative");
+  });
+
+  it("aligns a flipped pair by removing the words that invert it", () => {
+    expect(stripPolarity("Qual das afirmações é incorreta")).toEqual(
+      stripPolarity("Qual das afirmações é correta")
+    );
+  });
+});
+
+describe("Unit: worstPairedDistance", () => {
+  it("is zero for the same options in a different order", () => {
+    expect(worstPairedDistance(["alfa", "bravo"], ["bravo", "alfa"])).toBe(0);
+  });
+
+  it("stays small for a misspelling and large for a different answer", () => {
+    const typo = worstPairedDistance(["ferro pulverizado"], ["fero pulverizado"]);
+    const different = worstPairedDistance(["ferro pulverizado"], ["ferrite de niquel"]);
+    expect(typo).toBeLessThan(0.12);
+    expect(different).toBeGreaterThan(0.12);
+  });
+
+  it("refuses to pair option lists of different lengths", () => {
+    expect(worstPairedDistance(["a"], ["a", "b"])).toBeNull();
+  });
+});
+
+describe("Unit: duplicate tiers", () => {
+  it("calls the same question with the same answers exact", () => {
+    const bank = buildBank([
+      category("3", [q(1, "Quantas categorias de amadores existem?", ["Três", "Duas"])]),
+      category("2", [q(9, "Quantas categorias de amadores existem?", ["Três", "Duas"])]),
+    ]);
+    const groups = findDuplicateGroups(bank);
+    expect(tiersOf(groups)).toEqual(["exact"]);
+    expect(groups[0]?.crossCategory).toBe(true);
+  });
+
+  it("flags a disagreement about which option is right as a contradiction", () => {
+    // Nothing else in the pipeline catches this: each file is valid on its own.
+    const bank = buildBank([
+      category("3", [
+        q(1, "Quantas categorias de amadores existem?", ["Três", "Duas"], 0),
+        q(2, "Quantas categorias de amadores existem?", ["Três", "Duas"], 1),
+      ]),
+    ]);
+    expect(tiersOf(findDuplicateGroups(bank))).toEqual(["contradiction"]);
+  });
+
+  it("separates a misspelling from a genuinely different option set", () => {
+    const bank = buildBank([
+      category("1", [
+        q(36, "Que toróides usar?", ["Os toróides de ferro pulverizado", "Os de ferrite"]),
+        q(343, "Que toróides usar?", ["Os toróides de fero pulverizado", "Os de ferrite"]),
+      ]),
+      category("2", [
+        q(7, "Que toróides usar?", ["Uma resposta completamente diferente", "E outra ainda"]),
+      ]),
+    ]);
+    const groups = findDuplicateGroups(bank);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.tier).toBe("divergent");
+
+    const justTheTypo = buildBank([
+      category("1", [
+        q(36, "Que toróides usar?", ["Os toróides de ferro pulverizado", "Os de ferrite"]),
+        q(343, "Que toróides usar?", ["Os toróides de fero pulverizado", "Os de ferrite"]),
+      ]),
+    ]);
+    expect(tiersOf(findDuplicateGroups(justTheTypo))).toEqual(["typo"]);
+  });
+
+  it("reports an identical option set under different stems once", () => {
+    const bank = buildBank([
+      category("3", [
+        q(1, "O que é correto fazer?", ["Respeitar", "Ignorar"]),
+        q(2, "Qual a atitude certa?", ["Respeitar", "Ignorar"]),
+      ]),
+    ]);
+    const groups = findDuplicateGroups(bank);
+    expect(tiersOf(groups)).toEqual(["shared-answers"]);
+  });
+
+  it("names the fields a group disagrees on", () => {
+    const bank = buildBank([
+      category("3", [q(1, "Quantas categorias?", ["Três", "Duas"], 0, { topic: "operacao" })]),
+      category("2", [
+        q(9, "Quantas categorias?", ["Três", "Duas"], 0, {
+          topic: "regulamentacao",
+          explanation: "São três.",
+        }),
+      ]),
+    ]);
+    const kinds = findDuplicateGroups(bank)[0]?.issues.map((i) => i.kind);
+    expect(kinds).toContain("topic");
+    expect(kinds).toContain("explanation");
+  });
+
+  it("calls a punctuation-only difference cosmetic rather than a typo", () => {
+    const bank = buildBank([
+      category("3", [
+        q(1, "O que fazer?", ["Apresentar a discordância, propondo alterações", "Ignorar"]),
+        q(2, "O que fazer?", ["Apresentar a discordância propondo alterações", "Ignorar"]),
+      ]),
+    ]);
+    const group = findDuplicateGroups(bank)[0];
+    expect(group?.tier).toBe("exact");
+    expect(group?.issues.map((i) => i.kind)).toContain("cosmetic");
+  });
+});
+
+describe("Unit: fuzzy pairs", () => {
+  const shared = ["A ionosfera reflete", "A troposfera absorve", "O solo difrata", "Nada acontece"];
+
+  it("catches a polarity flip when the two questions are otherwise the same", () => {
+    const bank = buildBank([
+      category("3", [
+        q(1, "Qual das seguintes afirmações sobre propagação ionosférica é correta?", shared),
+        q(2, "Qual das seguintes afirmações sobre propagação ionosférica é incorreta?", shared, 1),
+      ]),
+    ]);
+    const findings = findPairFindings(bank);
+    expect(findings.map((f) => f.kind)).toContain("polarity");
+  });
+
+  it("does not pair two questions that merely share a template stem", () => {
+    // The noise control that makes the report readable: same sentence pattern,
+    // unrelated subject matter, so there is nothing here for a human to act on.
+    const bank = buildBank([
+      category("3", [
+        q(1, "Qual das seguintes afirmações é incorreta?", [
+          "O amador deve respeitar o plano de bandas",
+          "O amador deve identificar-se",
+        ]),
+        q(2, "Qual das seguintes afirmações está correta?", [
+          "Um condensador armazena carga",
+          "Uma bobina dissipa potência",
+        ]),
+      ]),
+    ]);
+    expect(findPairFindings(bank)).toEqual([]);
+  });
+});
+
+describe("Unit: answer audit", () => {
+  it("treats a sign or a unit prefix as a real difference between options", () => {
+    // "10 dB" and "-10 dB" canonicalise identically; reporting them as the same
+    // option would bury the two questions where the text really is repeated.
+    const bank = buildBank([
+      category("2", [
+        q(387, "Qual a atenuação?", ["8 dB", "10 dB", "-10 dB", "-200 dB"], 1),
+        q(103, "Qual a equivalência?", ["0,01 F", "0,01 mF", "0,01 µF", "0,01 nF"], 2),
+      ]),
+    ]);
+    expect(auditAnswers(bank).duplicateOptions).toEqual([]);
+  });
+
+  it("reports an option that is genuinely written twice", () => {
+    const bank = buildBank([
+      category("3", [q(68, "Referência para", ["o cálculo da p.a.r.", "o cálculo da p.a.r."])]),
+    ]);
+    expect(auditAnswers(bank).duplicateOptions.map((d) => d.ref)).toEqual(["cat3#68"]);
+  });
+
+  it("counts where the correct answer sits", () => {
+    const bank = buildBank([
+      category("3", [q(1, "a", ["x", "y"], 0), q(2, "b", ["x", "y"], 1), q(3, "c", ["x", "y"], 1)]),
+    ]);
+    expect(auditAnswers(bank).correctIndexCounts).toEqual([1, 2]);
+  });
+
+  it("flags a catch-all option that is not last", () => {
+    const bank = buildBank([
+      category("3", [q(1, "Qual?", ["Todas as anteriores", "Uma", "Duas", "Três"])]),
+    ]);
+    expect(auditAnswers(bank).misplacedCatchAll.map((m) => m.ref)).toEqual(["cat3#1"]);
+  });
+});
+
+describe("Unit: paper audit", () => {
+  it("finds unclaimed perguntas and two questions claiming the same one", () => {
+    const source = (pdf: string, question: number, page: number | null = null) => ({
+      sources: [{ pdf, question, page }],
+    });
+    const bank = buildBank([
+      category("3", [
+        q(1, "uma", ["a", "b"], 0, source("cat3/2023_08_18", 1, 1)),
+        q(2, "outra", ["a", "b"], 0, source("cat3/2023_08_18", 3)),
+        q(3, "terceira", ["a", "b"], 0, source("cat3/2023_08_18", 3)),
+      ]),
+    ]);
+    const paper = auditPapers(bank)[0];
+    expect(paper?.gaps).toEqual([2]);
+    expect(paper?.collisions).toEqual([{ question: 3, refs: ["cat3#2", "cat3#3"] }]);
+  });
+});
+
+describe("Unit: topic audit", () => {
+  it("separates an untagged question from one tagged with a slug that does not exist", () => {
+    const bank = buildBank([
+      category("3", [
+        q(1, "uma", ["a", "b"], 0, { topic: "antenas" }),
+        q(2, "outra", ["a", "b"], 0, { topic: "ohm" }),
+        q(3, "terceira", ["a", "b"]),
+      ]),
+    ]);
+    const audit = auditTopics(bank);
+    expect(audit.invalid.map((x) => x.ref)).toEqual(["cat3#2"]);
+    expect(audit.untagged.map((x) => x.ref)).toEqual(["cat3#3"]);
+    // Antennas start at category 2 in Anexo 1, so a cat 3 question is advisory.
+    expect(audit.aboveEntryLevel.map((x) => x.ref)).toEqual(["cat3#1"]);
+  });
+});
+
+describe("Unit: parseRef", () => {
+  it("accepts the forms a developer actually types", () => {
+    expect(parseRef("cat3#12")).toEqual({ category: "3", id: 12 });
+    expect(parseRef("3#12")).toEqual({ category: "3", id: 12 });
+    expect(parseRef("cat1/284")).toEqual({ category: "1", id: 284 });
+    expect(parseRef("nonsense")).toBeNull();
+    expect(parseRef("cat4#1")).toBeNull();
+  });
+});

--- a/content/questions/cat1/0036.mdx
+++ b/content/questions/cat1/0036.mdx
@@ -5,16 +5,16 @@ question: >-
   pulverizado em vez de toróides de ferrite?
 answers:
   - text: >-
-      Os toróides de fero pulverizado têm normalmente maior permeabilidade
+      Os toróides de ferro pulverizado têm normalmente maior permeabilidade
       inicial
   - text: >-
-      Os toróides de fero pulverizado têm normalmente maior estabilidade de
+      Os toróides de ferro pulverizado têm normalmente maior estabilidade de
       temperatura
     correct: true
   - text: >-
-      Os toróides de fero pulverizado requerem normalmente um menor número de
+      Os toróides de ferro pulverizado requerem normalmente um menor número de
       espiras para produzir uma determinada indutância
-  - text: Os toróides de fero pulverizado apresentam a maior potência nominal
+  - text: Os toróides de ferro pulverizado apresentam a maior potência nominal
 topic: componentes
 sources:
   - pdf: cat1/2011_12_13

--- a/content/questions/cat1/0210.mdx
+++ b/content/questions/cat1/0210.mdx
@@ -8,7 +8,7 @@ answers:
   - text: Aumenta
     correct: true
   - text: Diminui
-  - text: Atinge o máximo próximo dos 18 MHz
+  - text: Atinge um máximo próximo dos 18 MHz
 topic: antenas
 sources:
   - pdf: cat1/2011_12_13

--- a/content/questions/cat3/0012.mdx
+++ b/content/questions/cat3/0012.mdx
@@ -6,7 +6,7 @@ question: >-
 answers:
   - text: Não as respeitar
   - text: Incentivar a que outros amadores não as respeitem
-  - text: Apresentar fundamentalmente e discordância à ANACOM propondo alterações
+  - text: Apresentar fundamentadamente a discordância à ANACOM, propondo alterações
     correct: true
   - text: >-
       Recorrer a instâncias internacionais, no sentido destas entrarem em

--- a/lib/content/analysis.ts
+++ b/lib/content/analysis.ts
@@ -1,0 +1,724 @@
+/**
+ * Question-bank analysis for the `qbank` developer tool.
+ *
+ * Pure functions over parsed source questions — no filesystem, no printing —
+ * so the parts that are actually hard to get right (what counts as a
+ * duplicate, what counts as a template stem) are unit-testable without a
+ * fixture tree on disk.
+ *
+ * The framing that matters: **a duplicate is not automatically a defect.**
+ * Question 12 of cat 3, 255 of cat 2 and 284 of cat 1 are the same regulatory
+ * question legitimately examined at all three levels, and the bank has 27 such
+ * groups. What is worth a human's attention is a group whose members
+ * *disagree* — different options, a different correct answer, a different
+ * topic. So the finders below classify rather than condemn, and the tiers are
+ * ordered by how likely they are to be a real bug.
+ *
+ * The second constraint is noise. Stem similarity on its own is useless here:
+ * "Qual das seguintes afirmações é incorreta?" is a template shared by dozens
+ * of unrelated questions, and its nearest neighbour by every string metric is
+ * "Qual das seguintes afirmações está correta?" — the opposite question. Every
+ * fuzzy finder therefore requires agreement on the *answers* too, which is
+ * what separates a rephrased duplicate from two questions built from one
+ * sentence pattern.
+ */
+import { fold } from "../utils/search";
+import { questionFileName } from "./source";
+import type { ContentCategory, ContentQuestion } from "./schema";
+import type { CategoryId } from "../config/categories";
+import { ABOVE_ENTRY_LEVEL, isTopicSlug } from "../config/topics";
+
+/* -------------------------------------------------------------------------- */
+/* Text normalisation                                                          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Comparison form of a string: folded, punctuation-free, single-spaced.
+ *
+ * Punctuation is dropped rather than kept because the bank is inconsistent
+ * about it — cat2 #255 writes "discordância à ANACOM, propondo" and cat3 #12
+ * writes it without the comma. Treating that as a difference would bury the
+ * real difference in the same sentence (see `DuplicateTier.typo`).
+ */
+export function canonical(text: string): string {
+  return fold(text).replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+/** Canonical form split into words. */
+export function tokens(text: string): string[] {
+  const c = canonical(text);
+  return c.length === 0 ? [] : c.split(" ");
+}
+
+/**
+ * Comparison key for a stem or an option — canonical form, or the raw text
+ * with whitespace collapsed when canonicalising leaves nothing behind.
+ *
+ * The fallback exists because of telegraphy. Question 109 of cat 3 answers in
+ * dots and dashes, so all four of its options canonicalise to the empty string
+ * and would compare equal to each other and to every other Morse question in
+ * the bank. Comparing what is actually written keeps them distinct.
+ */
+export function comparisonKey(text: string): string {
+  const c = canonical(text);
+  return c.length > 0 ? c : text.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Words that invert a question rather than describe it.
+ *
+ * `nao` is the folded form of "não"; the bank uses both "exceto" and the
+ * pre-1990 "excepto".
+ */
+const NEGATIVE_MARKERS: ReadonlySet<string> = new Set([
+  "incorreta", "incorretas", "incorrecta", "incorrectas",
+  "incorreto", "incorretos", "incorrecto", "incorrectos",
+  "errada", "erradas", "errado", "errados",
+  "falsa", "falsas", "falso", "falsos",
+  "nao", "excepto", "exceto", "salvo",
+]);
+
+/** The affirmative counterparts, stripped alongside so a flipped pair aligns. */
+const POSITIVE_MARKERS: ReadonlySet<string> = new Set([
+  "correta", "corretas", "correcta", "correctas",
+  "correto", "corretos", "correcto", "correctos",
+  "verdadeira", "verdadeiras", "verdadeiro", "verdadeiros",
+  "certa", "certas", "certo", "certos",
+]);
+
+export type Polarity = "positive" | "negative";
+
+/** Whether a stem asks for the true statement or the false one. */
+export function polarityOf(stem: string): Polarity {
+  return tokens(stem).some((t) => NEGATIVE_MARKERS.has(t)) ? "negative" : "positive";
+}
+
+/**
+ * Stem tokens with the polarity words removed.
+ *
+ * Comparing on this is what lets a flipped pair be recognised as flipped: with
+ * "incorreta" and "correta" both gone, the two stems are otherwise the same
+ * sentence, which is exactly the signal wanted.
+ */
+export function stripPolarity(stem: string): string[] {
+  return tokens(stem).filter(
+    (t) => !NEGATIVE_MARKERS.has(t) && !POSITIVE_MARKERS.has(t)
+  );
+}
+
+/** Jaccard similarity of two token lists, treated as sets. */
+export function jaccard(a: readonly string[], b: readonly string[]): number {
+  const setA = new Set(a);
+  const setB = new Set(b);
+  if (setA.size === 0 && setB.size === 0) return 1;
+  let shared = 0;
+  for (const t of setA) if (setB.has(t)) shared++;
+  return shared / (setA.size + setB.size - shared);
+}
+
+/** Levenshtein distance. Strings here are single options, so O(nm) is fine. */
+export function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  let prev: number[] = Array.from({ length: b.length + 1 }, (_, j) => j);
+  let curr: number[] = new Array<number>(b.length + 1).fill(0);
+
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    const ai = a.charCodeAt(i - 1);
+    for (let j = 1; j <= b.length; j++) {
+      const cost = ai === b.charCodeAt(j - 1) ? 0 : 1;
+      curr[j] = Math.min(
+        (curr[j - 1] ?? 0) + 1,
+        (prev[j] ?? 0) + 1,
+        (prev[j - 1] ?? 0) + cost
+      );
+    }
+    const swap = prev;
+    prev = curr;
+    curr = swap;
+  }
+  return prev[b.length] ?? 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/* The bank                                                                    */
+/* -------------------------------------------------------------------------- */
+
+/** A source question with its identity and comparison keys resolved once. */
+export type BankQuestion = ContentQuestion & {
+  category: CategoryId;
+  /** Path of the file to edit, e.g. "content/questions/cat3/0012.mdx". */
+  file: string;
+  /** Human-facing identity, e.g. "cat3#12". Unique across the bank. */
+  ref: string;
+  /** Text of the one correct answer. */
+  correctText: string;
+  /** Canonical stem. */
+  stemKey: string;
+  /** Canonical options, sorted and joined — order-independent by design. */
+  answerKey: string;
+  /** Canonical correct answer. */
+  correctKey: string;
+  stemTokens: string[];
+  /** Stem tokens with polarity words removed. */
+  coreTokens: string[];
+  /** Every option token, for answer-level similarity. */
+  answerTokens: string[];
+  polarity: Polarity;
+};
+
+export function questionPath(category: CategoryId, id: number): string {
+  return `content/questions/cat${category}/${questionFileName(id)}`;
+}
+
+export function bankRef(category: CategoryId, id: number): string {
+  return `cat${category}#${id}`;
+}
+
+/** Parses a "cat3#12" or "3#12" reference. */
+export function parseRef(input: string): { category: CategoryId; id: number } | null {
+  const m = /^(?:cat)?([123])[#:/ ](\d+)$/.exec(input.trim());
+  if (!m) return null;
+  return { category: m[1] as CategoryId, id: Number.parseInt(m[2]!, 10) };
+}
+
+export function buildBank(categories: readonly ContentCategory[]): BankQuestion[] {
+  const bank: BankQuestion[] = [];
+  for (const category of categories) {
+    const id = category.id as CategoryId;
+    for (const q of category.questions) {
+      const options = q.answers.map((a) => a.text);
+      const correct = q.answers.find((a) => a.correct);
+      // The schema guarantees exactly one, so this is a type narrowing rather
+      // than a real fallback.
+      const correctText = correct?.text ?? "";
+      bank.push({
+        ...q,
+        category: id,
+        file: questionPath(id, q.id),
+        ref: bankRef(id, q.id),
+        correctText,
+        stemKey: comparisonKey(q.question),
+        answerKey: options.map(comparisonKey).sort().join(" | "),
+        correctKey: comparisonKey(correctText),
+        stemTokens: tokens(q.question),
+        coreTokens: stripPolarity(q.question),
+        answerTokens: options.flatMap(tokens),
+        polarity: polarityOf(q.question),
+      });
+    }
+  }
+  return bank;
+}
+
+function groupBy<T>(items: readonly T[], key: (item: T) => string): Map<string, T[]> {
+  const out = new Map<string, T[]>();
+  for (const item of items) {
+    const k = key(item);
+    const bucket = out.get(k);
+    if (bucket) bucket.push(item);
+    else out.set(k, [item]);
+  }
+  return out;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Duplicate groups                                                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Ordered by how likely the tier is to be a defect, worst first.
+ *
+ * - `contradiction` — same question, same options, disagreeing on which option
+ *   is right. One of them is simply wrong; nothing else in the pipeline can
+ *   catch this, since each file is individually valid.
+ * - `typo` — same question, options differing only below an edit-distance
+ *   threshold. Mechanical to fix and easy to miss by eye.
+ * - `divergent` — same stem, materially different options. Either a genuine
+ *   variant worth keeping or a stem that needs disambiguating.
+ * - `shared-answers` — different stems over an identical option set. Usually a
+ *   rephrasing, occasionally options pasted onto the wrong question.
+ * - `exact` — same question, same options, same answer. Benign across
+ *   categories; within one category it is a redundant entry.
+ */
+export type DuplicateTier =
+  | "contradiction"
+  | "typo"
+  | "divergent"
+  | "shared-answers"
+  | "exact";
+
+export const DUPLICATE_TIERS: readonly DuplicateTier[] = [
+  "contradiction",
+  "typo",
+  "divergent",
+  "shared-answers",
+  "exact",
+];
+
+/** A field the members of a group disagree on. Reported, never resolved. */
+export type GroupIssue = {
+  kind: "topic" | "explanation" | "sources" | "image" | "cosmetic";
+  detail: string;
+};
+
+export type DuplicateGroup = {
+  tier: DuplicateTier;
+  /** Stable across runs, so a baseline can suppress an accepted group. */
+  key: string;
+  members: BankQuestion[];
+  crossCategory: boolean;
+  issues: GroupIssue[];
+};
+
+/**
+ * Largest per-option edit distance, relative to option length, under the best
+ * one-to-one pairing of two option lists. Null when the lists cannot be paired.
+ *
+ * Greedy nearest-match rather than optimal assignment: with four short options
+ * that are either near-identical or plainly unrelated, the two agree, and the
+ * greedy version stays readable.
+ */
+export function worstPairedDistance(a: readonly string[], b: readonly string[]): number | null {
+  if (a.length !== b.length) return null;
+  const taken = new Array<boolean>(b.length).fill(false);
+  let worst = 0;
+  for (const x of a) {
+    let best = Number.POSITIVE_INFINITY;
+    let bestIndex = -1;
+    for (let i = 0; i < b.length; i++) {
+      if (taken[i]) continue;
+      const d = levenshtein(x, b[i] ?? "");
+      if (d < best) {
+        best = d;
+        bestIndex = i;
+      }
+    }
+    if (bestIndex === -1) return null;
+    taken[bestIndex] = true;
+    const span = Math.max(x.length, (b[bestIndex] ?? "").length, 1);
+    worst = Math.max(worst, best / span);
+  }
+  return worst;
+}
+
+/** Above this relative distance, two options are different rather than mistyped. */
+export const TYPO_RATIO = 0.12;
+
+function classifyStemGroup(members: readonly BankQuestion[]): DuplicateTier {
+  const answerKeys = new Set(members.map((m) => m.answerKey));
+  const correctKeys = new Set(members.map((m) => m.correctKey));
+
+  if (answerKeys.size === 1) {
+    return correctKeys.size === 1 ? "exact" : "contradiction";
+  }
+
+  // Compare every member against the first: a typo group is one where no
+  // member has drifted further than a misspelling from the reference.
+  const [first, ...rest] = members;
+  if (!first) return "divergent";
+  const reference = first.answers.map((a) => comparisonKey(a.text));
+  for (const other of rest) {
+    const worst = worstPairedDistance(reference, other.answers.map((a) => comparisonKey(a.text)));
+    if (worst === null || worst > TYPO_RATIO) return "divergent";
+  }
+  return "typo";
+}
+
+function describeIssues(members: readonly BankQuestion[]): GroupIssue[] {
+  const issues: GroupIssue[] = [];
+
+  const topics = new Set(members.map((m) => m.topic ?? "—"));
+  if (topics.size > 1) {
+    issues.push({
+      kind: "topic",
+      detail: members.map((m) => `${m.ref}=${m.topic ?? "untagged"}`).join(", "),
+    });
+  }
+
+  const withExplanation = members.filter((m) => m.explanation !== null);
+  if (withExplanation.length > 0 && withExplanation.length < members.length) {
+    issues.push({
+      kind: "explanation",
+      detail: `explained: ${withExplanation.map((m) => m.ref).join(", ")}; missing: ${members
+        .filter((m) => m.explanation === null)
+        .map((m) => m.ref)
+        .join(", ")}`,
+    });
+  }
+
+  const withSources = members.filter((m) => m.sources.length > 0);
+  if (withSources.length > 0 && withSources.length < members.length) {
+    issues.push({
+      kind: "sources",
+      detail: `sourced: ${withSources.map((m) => m.ref).join(", ")}; unsourced: ${members
+        .filter((m) => m.sources.length === 0)
+        .map((m) => m.ref)
+        .join(", ")}`,
+    });
+  }
+
+  const images = new Set(members.map((m) => m.image ?? "—"));
+  if (images.size > 1) {
+    issues.push({
+      kind: "image",
+      detail: members.map((m) => `${m.ref}=${m.image ?? "none"}`).join(", "),
+    });
+  }
+
+  // Punctuation, spacing and accents are folded away for matching, so a group
+  // can be "identical" and still not be byte-identical. Only worth saying when
+  // the canonical forms genuinely agree — otherwise the difference is
+  // substantive, and the tier has already reported it.
+  const sameStem = new Set(members.map((m) => m.stemKey)).size === 1;
+  const sameAnswers = new Set(members.map((m) => m.answerKey)).size === 1;
+  if (sameStem && sameAnswers) {
+    const rawStems = new Set(members.map((m) => m.question));
+    const rawAnswers = new Set(members.map((m) => m.answers.map((a) => a.text).join(" | ")));
+    if (rawStems.size > 1 || rawAnswers.size > 1) {
+      const parts = [rawStems.size > 1 ? "stem" : null, rawAnswers.size > 1 ? "options" : null]
+        .filter(Boolean)
+        .join(" and ");
+      issues.push({
+        kind: "cosmetic",
+        detail: `${parts} differ only in accents, spacing or punctuation`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+function makeGroup(tier: DuplicateTier, members: BankQuestion[]): DuplicateGroup {
+  const sorted = [...members].sort((a, b) => a.ref.localeCompare(b.ref));
+  return {
+    tier,
+    key: `${tier}:${sorted.map((m) => m.ref).join(",")}`,
+    members: sorted,
+    crossCategory: new Set(sorted.map((m) => m.category)).size > 1,
+    issues: describeIssues(sorted),
+  };
+}
+
+/**
+ * Every group of questions that share a stem or an option set.
+ *
+ * Stem groups are classified first; an option-set group is only reported when
+ * its members do *not* already share a stem, so nothing is listed twice.
+ */
+export function findDuplicateGroups(bank: readonly BankQuestion[]): DuplicateGroup[] {
+  const groups: DuplicateGroup[] = [];
+
+  for (const members of groupBy(bank, (q) => q.stemKey).values()) {
+    if (members.length < 2) continue;
+    groups.push(makeGroup(classifyStemGroup(members), members));
+  }
+
+  for (const members of groupBy(bank, (q) => q.answerKey).values()) {
+    if (members.length < 2) continue;
+    if (new Set(members.map((m) => m.stemKey)).size === 1) continue;
+    groups.push(makeGroup("shared-answers", members));
+  }
+
+  const rank = (t: DuplicateTier) => DUPLICATE_TIERS.indexOf(t);
+  return groups.sort(
+    (a, b) => rank(a.tier) - rank(b.tier) || a.members.length - b.members.length
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Fuzzy pairs                                                                 */
+/* -------------------------------------------------------------------------- */
+
+export type PairFinding = {
+  kind: "polarity" | "near-stem";
+  key: string;
+  a: BankQuestion;
+  b: BankQuestion;
+  stemSimilarity: number;
+  answerSimilarity: number;
+};
+
+/** Stems this similar are the same sentence, modulo a word or two. */
+export const NEAR_STEM_MIN = 0.7;
+
+/**
+ * Answer agreement required before a stem match is reported at all.
+ *
+ * This is the noise control. Without it, every question built on "Qual das
+ * seguintes afirmações…" pairs with every other one, and the report is 248
+ * pairs of unrelated questions that happen to share a sentence pattern.
+ */
+export const NEAR_ANSWER_MIN = 0.3;
+
+/**
+ * Stem-level near-duplicates and polarity flips.
+ *
+ * Candidates come from an inverted index rather than all-pairs: at 1,016
+ * questions the quadratic form is affordable, but it grows with the bank and
+ * the index costs nothing. Tokens appearing in more than `maxDocFrequency` of
+ * the bank are skipped as connectives — they generate candidates without
+ * discriminating between them.
+ */
+export function findPairFindings(
+  bank: readonly BankQuestion[],
+  options: { stemMin?: number; answerMin?: number; maxDocFrequency?: number } = {}
+): PairFinding[] {
+  const stemMin = options.stemMin ?? NEAR_STEM_MIN;
+  const answerMin = options.answerMin ?? NEAR_ANSWER_MIN;
+  const maxDf = options.maxDocFrequency ?? Math.max(20, Math.floor(bank.length / 20));
+
+  const index = new Map<string, number[]>();
+  bank.forEach((q, i) => {
+    for (const token of new Set(q.coreTokens)) {
+      const bucket = index.get(token);
+      if (bucket) bucket.push(i);
+      else index.set(token, [i]);
+    }
+  });
+
+  const seen = new Set<string>();
+  const findings: PairFinding[] = [];
+
+  bank.forEach((q, i) => {
+    const candidates = new Set<number>();
+    for (const token of new Set(q.coreTokens)) {
+      const bucket = index.get(token);
+      if (!bucket || bucket.length > maxDf) continue;
+      for (const j of bucket) if (j !== i) candidates.add(j);
+    }
+
+    for (const j of candidates) {
+      const pairKey = i < j ? `${i}:${j}` : `${j}:${i}`;
+      if (seen.has(pairKey)) continue;
+      seen.add(pairKey);
+
+      const other = bank[j];
+      if (!other) continue;
+
+      const stemSimilarity = jaccard(q.coreTokens, other.coreTokens);
+      if (stemSimilarity < stemMin) continue;
+
+      const answerSimilarity = jaccard(q.answerTokens, other.answerTokens);
+      if (answerSimilarity < answerMin) continue;
+
+      const flipped = q.polarity !== other.polarity;
+      // An exact stem match is already a duplicate group; only report it here
+      // when the polarity differs, which the stem key cannot express.
+      if (!flipped && q.stemKey === other.stemKey) continue;
+
+      const [a, b] = q.ref.localeCompare(other.ref) <= 0 ? [q, other] : [other, q];
+      const kind = flipped ? "polarity" : "near-stem";
+      findings.push({
+        kind,
+        key: `${kind}:${a!.ref},${b!.ref}`,
+        a: a!,
+        b: b!,
+        stemSimilarity,
+        answerSimilarity,
+      });
+    }
+  });
+
+  return findings.sort(
+    (x, y) =>
+      (x.kind === y.kind ? 0 : x.kind === "polarity" ? -1 : 1) ||
+      y.stemSimilarity + y.answerSimilarity - (x.stemSimilarity + x.answerSimilarity)
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Coverage                                                                    */
+/* -------------------------------------------------------------------------- */
+
+export type CoverageRow = {
+  label: string;
+  total: number;
+  withSources: number;
+  sourceRefs: number;
+  refsWithPage: number;
+  withExplanation: number;
+  withImage: number;
+  withTopic: number;
+};
+
+function coverageRow(label: string, questions: readonly BankQuestion[]): CoverageRow {
+  const refs = questions.flatMap((q) => q.sources);
+  return {
+    label,
+    total: questions.length,
+    withSources: questions.filter((q) => q.sources.length > 0).length,
+    sourceRefs: refs.length,
+    refsWithPage: refs.filter((s) => s.page !== null).length,
+    withExplanation: questions.filter((q) => q.explanation !== null).length,
+    withImage: questions.filter((q) => q.image !== null).length,
+    withTopic: questions.filter((q) => q.topic !== null).length,
+  };
+}
+
+export function coverage(bank: readonly BankQuestion[]): CoverageRow[] {
+  const rows: CoverageRow[] = [];
+  for (const c of ["3", "2", "1"] as const) {
+    rows.push(coverageRow(`cat${c}`, bank.filter((q) => q.category === c)));
+  }
+  rows.push(coverageRow("all", bank));
+  return rows;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Topics                                                                      */
+/* -------------------------------------------------------------------------- */
+
+export type TopicAudit = {
+  /** slug -> per-category counts, plus the total. */
+  distribution: { slug: string; counts: Record<CategoryId, number>; total: number }[];
+  untagged: BankQuestion[];
+  /** `topic` set to something that is not a slug in lib/config/topics.ts. */
+  invalid: BankQuestion[];
+  /**
+   * Category 3 questions in a chapter Anexo 1 marks as starting above entry
+   * level. Advisory: `examinedFrom` in lib/config/topics.ts documents six of
+   * these as genuine, sourced to real 2023 category 3 papers.
+   */
+  aboveEntryLevel: BankQuestion[];
+};
+
+export function auditTopics(bank: readonly BankQuestion[]): TopicAudit {
+  const above = new Set<string>(ABOVE_ENTRY_LEVEL);
+  const counts = new Map<string, Record<CategoryId, number>>();
+
+  for (const q of bank) {
+    if (q.topic === null || !isTopicSlug(q.topic)) continue;
+    const row = counts.get(q.topic) ?? { "3": 0, "2": 0, "1": 0 };
+    row[q.category]++;
+    counts.set(q.topic, row);
+  }
+
+  const distribution = [...counts.entries()]
+    .map(([slug, c]) => ({ slug, counts: c, total: c["3"] + c["2"] + c["1"] }))
+    .sort((a, b) => b.total - a.total);
+
+  return {
+    distribution,
+    untagged: bank.filter((q) => q.topic === null),
+    invalid: bank.filter((q) => q.topic !== null && !isTopicSlug(q.topic)),
+    aboveEntryLevel: bank.filter(
+      (q) => q.category === "3" && q.topic !== null && above.has(q.topic)
+    ),
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Exam papers                                                                 */
+/* -------------------------------------------------------------------------- */
+
+export type PaperAudit = {
+  pdf: string;
+  /** Perguntas cited from this paper, ascending. */
+  cited: { question: number; page: number | null; ref: string; file: string }[];
+  /** Pergunta numbers between the lowest and highest cited that nothing claims. */
+  gaps: number[];
+  /** Two questions claiming to be the same pergunta of the same paper. */
+  collisions: { question: number; refs: string[] }[];
+};
+
+export function auditPapers(bank: readonly BankQuestion[]): PaperAudit[] {
+  const papers = new Map<string, PaperAudit["cited"]>();
+  for (const q of bank) {
+    for (const s of q.sources) {
+      const list = papers.get(s.pdf) ?? [];
+      list.push({ question: s.question, page: s.page, ref: q.ref, file: q.file });
+      papers.set(s.pdf, list);
+    }
+  }
+
+  return [...papers.entries()]
+    .map(([pdf, cited]) => {
+      cited.sort((a, b) => a.question - b.question || a.ref.localeCompare(b.ref));
+
+      const byNumber = groupBy(cited, (c) => String(c.question));
+      const collisions = [...byNumber.entries()]
+        .filter(([, entries]) => entries.length > 1)
+        .map(([question, entries]) => ({
+          question: Number.parseInt(question, 10),
+          refs: entries.map((e) => e.ref),
+        }))
+        .sort((a, b) => a.question - b.question);
+
+      const numbers = new Set(cited.map((c) => c.question));
+      const highest = Math.max(...numbers);
+      const gaps: number[] = [];
+      for (let n = 1; n <= highest; n++) if (!numbers.has(n)) gaps.push(n);
+
+      return { pdf, cited, gaps, collisions };
+    })
+    .sort((a, b) => a.pdf.localeCompare(b.pdf));
+}
+
+/* -------------------------------------------------------------------------- */
+/* Answer construction                                                         */
+/* -------------------------------------------------------------------------- */
+
+export type AnswerAudit = {
+  total: number;
+  /** How often each option position holds the correct answer. */
+  correctIndexCounts: number[];
+  /** Questions where the correct answer is the longest option. */
+  longestIsCorrect: number;
+  /** Two options that are the same after folding — always a defect. */
+  duplicateOptions: { ref: string; file: string; text: string }[];
+  /** "todas as anteriores" and friends, which only make sense last. */
+  misplacedCatchAll: { ref: string; file: string; index: number; count: number }[];
+  /** Options identical but for spacing or punctuation across the same question. */
+  optionCount: Map<number, number>;
+};
+
+const CATCH_ALL = /(todas|nenhuma|qualquer)\s+(as|das)?\s*(anteriores|respostas|opcoes|afirmacoes)/;
+
+export function auditAnswers(bank: readonly BankQuestion[]): AnswerAudit {
+  const correctIndexCounts: number[] = [];
+  let longestIsCorrect = 0;
+  const duplicateOptions: AnswerAudit["duplicateOptions"] = [];
+  const misplacedCatchAll: AnswerAudit["misplacedCatchAll"] = [];
+  const optionCount = new Map<number, number>();
+
+  for (const q of bank) {
+    const texts = q.answers.map((a) => a.text);
+    const index = q.answers.findIndex((a) => a.correct);
+    correctIndexCounts[index] = (correctIndexCounts[index] ?? 0) + 1;
+    optionCount.set(texts.length, (optionCount.get(texts.length) ?? 0) + 1);
+
+    const longest = texts.reduce((best, t, i) => (t.length > (texts[best]?.length ?? 0) ? i : best), 0);
+    if (longest === index) longestIsCorrect++;
+
+    // Deliberately stricter than `comparisonKey`: within one question the
+    // distractors are frequently the same quantity with a sign, a prefix or an
+    // operator changed, and canonicalising away punctuation makes "10 dB" and
+    // "-10 dB", or "0,01 µF" and "0,01 F", look like the same option. Only
+    // text that is genuinely identical is a defect here.
+    const seen = new Set<string>();
+    for (const t of texts) {
+      const key = t.replace(/\s+/g, " ").trim();
+      if (seen.has(key)) duplicateOptions.push({ ref: q.ref, file: q.file, text: t });
+      seen.add(key);
+    }
+
+    texts.forEach((t, i) => {
+      if (CATCH_ALL.test(canonical(t)) && i !== texts.length - 1) {
+        misplacedCatchAll.push({ ref: q.ref, file: q.file, index: i, count: texts.length });
+      }
+    });
+  }
+
+  return {
+    total: bank.length,
+    correctIndexCounts,
+    longestIsCorrect,
+    duplicateOptions,
+    misplacedCatchAll,
+    optionCount,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "data:ocr-exams": "bun run scripts/ocr-exams.ts",
     "data:fonte-pages": "bun run scripts/resolve-fonte-pages.ts",
     "content:build": "bun run scripts/content-build.ts",
-    "content:check": "bun run scripts/content-build.ts --check"
+    "content:check": "bun run scripts/content-build.ts --check",
+    "qbank": "bun run scripts/qbank.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/public/data/cat1.json
+++ b/public/data/cat1.json
@@ -665,10 +665,10 @@
       "id": 36,
       "question": "Que razão importante existe para que numa bobina se usem toróides de ferro pulverizado em vez de toróides de ferrite?",
       "options": [
-        "Os toróides de fero pulverizado têm normalmente maior permeabilidade inicial",
-        "Os toróides de fero pulverizado têm normalmente maior estabilidade de temperatura",
-        "Os toróides de fero pulverizado requerem normalmente um menor número de espiras para produzir uma determinada indutância",
-        "Os toróides de fero pulverizado apresentam a maior potência nominal"
+        "Os toróides de ferro pulverizado têm normalmente maior permeabilidade inicial",
+        "Os toróides de ferro pulverizado têm normalmente maior estabilidade de temperatura",
+        "Os toróides de ferro pulverizado requerem normalmente um menor número de espiras para produzir uma determinada indutância",
+        "Os toróides de ferro pulverizado apresentam a maior potência nominal"
       ],
       "correctIndex": 1,
       "hasNotesMdx": true,
@@ -3833,7 +3833,7 @@
         "A atenuação é independente da frequência",
         "Aumenta",
         "Diminui",
-        "Atinge o máximo próximo dos 18 MHz"
+        "Atinge um máximo próximo dos 18 MHz"
       ],
       "correctIndex": 1,
       "hasNotesMdx": true,

--- a/public/data/cat3.json
+++ b/public/data/cat3.json
@@ -181,7 +181,7 @@
       "options": [
         "Não as respeitar",
         "Incentivar a que outros amadores não as respeitem",
-        "Apresentar fundamentalmente e discordância à ANACOM propondo alterações",
+        "Apresentar fundamentadamente a discordância à ANACOM, propondo alterações",
         "Recorrer a instâncias internacionais, no sentido destas entrarem em contacto com a ANACOM"
       ],
       "correctIndex": 2,

--- a/scripts/qbank.ts
+++ b/scripts/qbank.ts
@@ -1,0 +1,767 @@
+#!/usr/bin/env bun
+/**
+ * Developer tool for inspecting the question bank.
+ *
+ *   bun run qbank search "propagação"     # find questions by text
+ *   bun run qbank show cat3#12            # one question in full
+ *   bun run qbank dupes                   # duplicate groups, worst tier first
+ *   bun run qbank pairs                   # fuzzy near-duplicates, polarity flips
+ *   bun run qbank coverage                # sources, explanations, images
+ *   bun run qbank topics                  # taxonomy distribution and outliers
+ *   bun run qbank paper cat3/2023_08_18   # what cites a given exam paper
+ *   bun run qbank answers                 # answer-construction audit
+ *
+ * Read-only, and deliberately not wired into CI. Schema validity and artifact
+ * staleness are `content:check`'s job; duplicating them here would create a
+ * second source of truth that drifts. What this reports instead is the class of
+ * problem that cannot be expressed as a per-file rule — two files that are each
+ * valid but disagree with each other.
+ *
+ * It reads `content/questions/**`, never `public/data/*.json`: the JSON is a
+ * build artifact, so a finding against it could not name the file to edit and
+ * would go stale between `content:build` runs.
+ */
+import { existsSync, readFileSync, readdirSync, writeFileSync, statSync } from "fs";
+import { join } from "path";
+import { loadCategory } from "../lib/content/build";
+import { fold } from "../lib/utils/search";
+import {
+  buildBank,
+  findDuplicateGroups,
+  findPairFindings,
+  coverage,
+  auditTopics,
+  auditPapers,
+  auditAnswers,
+  canonical,
+  comparisonKey,
+  parseRef,
+  DUPLICATE_TIERS,
+  type BankQuestion,
+  type DuplicateTier,
+} from "../lib/content/analysis";
+import { topicShortLabel } from "../lib/config/topics";
+import type { CategoryId } from "../lib/config/categories";
+
+const BASELINE_FILE = join("content", "qbank-baseline.json");
+const CATEGORIES = ["3", "2", "1"] as const;
+
+/* -------------------------------------------------------------------------- */
+/* Argument handling                                                           */
+/* -------------------------------------------------------------------------- */
+
+const argv = process.argv.slice(2);
+const positional: string[] = [];
+const flags = new Map<string, string | true>();
+
+for (let i = 0; i < argv.length; i++) {
+  const arg = argv[i] ?? "";
+  if (!arg.startsWith("--")) {
+    positional.push(arg);
+    continue;
+  }
+  const [name, inline] = arg.slice(2).split("=", 2);
+  if (!name) continue;
+  if (inline !== undefined) {
+    flags.set(name, inline);
+    continue;
+  }
+  const next = argv[i + 1];
+  if (next !== undefined && !next.startsWith("--")) {
+    flags.set(name, next);
+    i++;
+  } else {
+    flags.set(name, true);
+  }
+}
+
+function flag(name: string): string | undefined {
+  const value = flags.get(name);
+  return typeof value === "string" ? value : undefined;
+}
+function has(name: string): boolean {
+  return flags.has(name);
+}
+function num(name: string, fallback: number): number {
+  const raw = flag(name);
+  if (raw === undefined) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+function ratio(name: string): number | undefined {
+  const raw = flag(name);
+  if (raw === undefined) return undefined;
+  const parsed = Number.parseFloat(raw);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+const asJson = has("json");
+const limit = num("limit", 30);
+
+/* -------------------------------------------------------------------------- */
+/* Output                                                                      */
+/* -------------------------------------------------------------------------- */
+
+const ESC = "\u001b";
+const colour = process.stdout.isTTY === true && !asJson;
+const paint = (code: string, text: string) =>
+  colour ? `${ESC}[${code}m${text}${ESC}[0m` : text;
+const bold = (t: string) => paint("1", t);
+const dim = (t: string) => paint("2", t);
+const red = (t: string) => paint("31", t);
+const green = (t: string) => paint("32", t);
+const yellow = (t: string) => paint("33", t);
+const cyan = (t: string) => paint("36", t);
+
+const ANSI = new RegExp(`${ESC}\\[[0-9;]*m`, "g");
+const stripAnsi = (s: string) => s.replace(ANSI, "");
+const pad = (s: string, width: number) => s + " ".repeat(Math.max(0, width - stripAnsi(s).length));
+
+const out: string[] = [];
+const say = (line = "") => out.push(line);
+function flush(payload?: unknown) {
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify(payload ?? null, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(`${out.join("\n")}\n`);
+}
+
+/** Truncates for a one-line summary, on a word boundary where it can. */
+function clip(text: string, width: number): string {
+  const flat = text.replace(/\s+/g, " ").trim();
+  if (flat.length <= width) return flat;
+  const cut = flat.slice(0, width - 1);
+  const space = cut.lastIndexOf(" ");
+  return `${space > width * 0.6 ? cut.slice(0, space) : cut}…`;
+}
+
+/* -------------------------------------------------------------------------- */
+/* File locations                                                              */
+/* -------------------------------------------------------------------------- */
+
+const fileCache = new Map<string, string[]>();
+
+/**
+ * Line number a piece of text sits on, so results are clickable.
+ *
+ * Matched on the folded text because a stem in the report has been through
+ * normalisation while the file still holds the accented original.
+ *
+ * Shortening prefixes rather than one lookup: `matter.stringify` writes a long
+ * stem as a folded scalar, so the question wraps across lines and no single
+ * line contains all of it. The first line of the fold does contain the start.
+ */
+function locate(file: string, needle: string): number | null {
+  if (!existsSync(file)) return null;
+  let lines = fileCache.get(file);
+  if (!lines) {
+    lines = readFileSync(file, "utf-8").split("\n");
+    fileCache.set(file, lines);
+  }
+
+  const full = fold(needle).trim();
+  if (full.length === 0) return null;
+  for (const width of [full.length, 48, 24]) {
+    const target = full.slice(0, width);
+    if (target.length < 8 && width !== full.length) continue;
+    for (let i = 0; i < lines.length; i++) {
+      if (fold(lines[i] ?? "").includes(target)) return i + 1;
+    }
+  }
+  return null;
+}
+
+function where(q: BankQuestion, needle?: string): string {
+  const line = locate(q.file, needle ?? q.question);
+  return line === null ? q.file : `${q.file}:${line}`;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Baseline                                                                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Findings a human has already looked at and accepted.
+ *
+ * Same ratchet as `content/missing-exams.json`, and for the same reason: a
+ * report of sixty-odd duplicate groups is read once and then ignored forever.
+ * With a baseline, `--new` shows only what has appeared since, which is the
+ * form that stays useful.
+ */
+function loadBaseline(): Set<string> {
+  if (!existsSync(BASELINE_FILE)) return new Set();
+  const raw: unknown = JSON.parse(readFileSync(BASELINE_FILE, "utf-8"));
+  const keys = (raw as { keys?: unknown }).keys;
+  return new Set(Array.isArray(keys) ? keys.filter((k): k is string => typeof k === "string") : []);
+}
+
+function writeBaseline(keys: readonly string[]): void {
+  const body = {
+    note:
+      "Findings from `bun run qbank` that a human has reviewed and accepted. A ratchet, not a permission slip: `--new` hides these, so only findings that appeared since show up. Shrink it when you fix something rather than letting it grow.",
+    keys: [...keys].sort(),
+  };
+  writeFileSync(BASELINE_FILE, `${JSON.stringify(body, null, 2)}\n`);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Loading                                                                     */
+/* -------------------------------------------------------------------------- */
+
+function load(): BankQuestion[] {
+  const categories = CATEGORIES.map((c) => join("content", "questions", `cat${c}`))
+    .filter((dir) => existsSync(dir))
+    .map((dir) => loadCategory(dir));
+  const bank = buildBank(categories);
+
+  const only = flag("cat");
+  if (only === undefined) return bank;
+  const wanted = new Set(only.split(",").map((c) => c.replace(/^cat/, "").trim()));
+  return bank.filter((q) => wanted.has(q.category));
+}
+
+/* -------------------------------------------------------------------------- */
+/* Rendering                                                                   */
+/* -------------------------------------------------------------------------- */
+
+function tierLabel(tier: DuplicateTier): string {
+  if (tier === "contradiction") return red(bold("contradiction"));
+  if (tier === "typo") return yellow("typo");
+  if (tier === "divergent") return yellow("divergent");
+  if (tier === "shared-answers") return cyan("shared-answers");
+  return dim("exact");
+}
+
+function renderQuestion(q: BankQuestion, needle?: string): void {
+  const topic = q.topic === null ? dim("untagged") : cyan(topicShortLabel(q.topic, "pt") ?? q.topic);
+  say(`${bold(q.ref)}  ${topic}  ${dim(where(q, needle))}`);
+  say(`  ${q.question}`);
+  for (const a of q.answers) {
+    say(`   ${a.correct ? green("✓") : dim("·")} ${clip(a.text, 100)}`);
+  }
+  const marks: string[] = [];
+  marks.push(
+    q.sources.length > 0
+      ? q.sources
+          .map((s) => `${s.pdf} pergunta ${s.question}${s.page === null ? "" : ` p.${s.page}`}`)
+          .join("; ")
+      : "no sources"
+  );
+  if (q.explanation === null) marks.push("no explanation");
+  if (q.image !== null) marks.push(`image ${q.image}`);
+  say(`  ${dim(marks.join("  |  "))}`);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Commands                                                                    */
+/* -------------------------------------------------------------------------- */
+
+function cmdSearch(): void {
+  const term = positional[1] ?? "";
+  if (term.trim().length === 0) {
+    say("usage: qbank search <term> [--field stem|options|explanation] [--regex] [--cat 3]");
+    return flush([]);
+  }
+
+  const field = flag("field") ?? "all";
+  const pattern = has("regex") ? new RegExp(term, "iu") : null;
+  const needle = canonical(term);
+  const hit = (text: string) =>
+    pattern !== null ? pattern.test(text) : canonical(text).includes(needle);
+
+  const bank = load().filter((q) => {
+    const inStem = hit(q.question);
+    const inOptions = q.answers.some((a) => hit(a.text));
+    const inExplanation = q.explanation !== null && hit(q.explanation);
+    if (field === "stem") return inStem;
+    if (field === "options") return inOptions;
+    if (field === "explanation") return inExplanation;
+    return inStem || inOptions || inExplanation;
+  });
+
+  if (asJson) {
+    return flush(
+      bank.map((q) => ({ ref: q.ref, file: q.file, question: q.question, topic: q.topic }))
+    );
+  }
+
+  say(
+    `${bold(String(bank.length))} question(s) matching ${cyan(term)}` +
+      `${field === "all" ? "" : ` in ${field}`}`
+  );
+  say();
+  for (const q of bank.slice(0, limit)) {
+    renderQuestion(q, term);
+    say();
+  }
+  if (bank.length > limit) say(dim(`…and ${bank.length - limit} more (--limit ${bank.length})`));
+  flush();
+}
+
+function cmdShow(): void {
+  const bank = load();
+  const refs = positional.slice(1);
+  if (refs.length === 0) {
+    say("usage: qbank show cat3#12 [cat2#255 …]");
+    return flush([]);
+  }
+
+  const found: BankQuestion[] = [];
+  for (const raw of refs) {
+    const parsed = parseRef(raw);
+    const q = parsed && bank.find((b) => b.category === parsed.category && b.id === parsed.id);
+    if (!q) {
+      say(red(`no such question: ${raw}`));
+      continue;
+    }
+    found.push(q);
+  }
+
+  if (asJson) return flush(found);
+
+  // A question is best understood next to its duplicates, so they come along.
+  const groups = findDuplicateGroups(bank);
+  for (const q of found) {
+    renderQuestion(q);
+    if (q.explanation !== null) {
+      say();
+      say(dim(clip(q.explanation, 400)));
+    }
+    for (const g of groups.filter((group) => group.members.some((m) => m.ref === q.ref))) {
+      const others = g.members.filter((m) => m.ref !== q.ref).map((m) => m.ref);
+      say();
+      say(`  ${tierLabel(g.tier)} with ${others.join(", ")}`);
+      for (const issue of g.issues) say(`    ${yellow(issue.kind)}: ${issue.detail}`);
+    }
+    say();
+  }
+  flush();
+}
+
+function cmdDupes(): void {
+  const bank = load();
+
+  if (has("update-baseline")) {
+    const keys = [
+      ...findDuplicateGroups(bank).map((g) => g.key),
+      ...findPairFindings(bank).map((p) => p.key),
+    ];
+    writeBaseline(keys);
+    say(`${green("baselined")} ${keys.length} finding(s) into ${BASELINE_FILE}`);
+    return flush({ baselined: keys.length });
+  }
+
+  let groups = findDuplicateGroups(bank);
+
+  const wanted = flag("tier");
+  if (wanted !== undefined) {
+    const set = new Set(wanted.split(","));
+    groups = groups.filter((g) => set.has(g.tier));
+  }
+  if (has("new")) {
+    const baseline = loadBaseline();
+    groups = groups.filter((g) => !baseline.has(g.key));
+  }
+
+  if (asJson) {
+    return flush(
+      groups.map((g) => ({
+        tier: g.tier,
+        key: g.key,
+        crossCategory: g.crossCategory,
+        issues: g.issues,
+        members: g.members.map((m) => ({ ref: m.ref, file: m.file, topic: m.topic })),
+      }))
+    );
+  }
+
+  const counts = new Map<DuplicateTier, number>();
+  for (const g of groups) counts.set(g.tier, (counts.get(g.tier) ?? 0) + 1);
+  say(
+    `${bold(String(groups.length))} group(s): ` +
+      DUPLICATE_TIERS.filter((t) => counts.has(t))
+        .map((t) => `${counts.get(t)} ${tierLabel(t)}`)
+        .join(", ")
+  );
+  say();
+
+  for (const g of groups.slice(0, limit)) {
+    const scope = g.crossCategory ? dim("across categories") : yellow("same category");
+    say(`${tierLabel(g.tier)}  ${g.members.map((m) => bold(m.ref)).join(" ≡ ")}  ${scope}`);
+    const first = g.members[0];
+    if (first) say(`  ${clip(first.question, 110)}`);
+
+    // For anything but an exact match, show what actually differs — the point
+    // of the report is the disagreement, not the fact of the pairing.
+    if (g.tier !== "exact") {
+      // Options every member shares are noise here; a typo is by definition in
+      // the one option that does not line up, which is rarely the correct one.
+      const shared = g.members
+        .map((m) => new Set(m.answers.map((a) => comparisonKey(a.text))))
+        .reduce((acc, set) => new Set([...acc].filter((t) => set.has(t))));
+
+      for (const m of g.members) {
+        if (g.tier === "shared-answers") {
+          say(`    ${dim(pad(m.ref, 9))} ${clip(m.question, 88)}`);
+          continue;
+        }
+        const odd = m.answers.filter((a) => !shared.has(comparisonKey(a.text)));
+        const shown = odd.length > 0 ? odd : m.answers.filter((a) => a.correct);
+        for (const [i, a] of shown.entries()) {
+          const label = i === 0 ? pad(m.ref, 9) : " ".repeat(9);
+          say(`    ${dim(label)} ${a.correct ? green("✓") : dim("·")} ${clip(a.text, 86)}`);
+        }
+      }
+    }
+    for (const issue of g.issues) say(`    ${yellow(issue.kind)}: ${issue.detail}`);
+    say(dim(`    ${g.members.map((m) => where(m)).join("  ")}`));
+    say();
+  }
+  if (groups.length > limit) {
+    say(dim(`…and ${groups.length - limit} more (--limit ${groups.length})`));
+  }
+  flush();
+}
+
+function cmdPairs(): void {
+  const bank = load();
+  let findings = findPairFindings(bank, {
+    stemMin: ratio("stem-min"),
+    answerMin: ratio("answer-min"),
+  });
+
+  // A pair whose members already share a stem or an option set is a duplicate
+  // group, and `dupes` says more about it than this does. Reporting it twice
+  // is how a report earns a reputation for repeating itself.
+  if (!has("all")) {
+    const grouped = new Set<string>();
+    for (const g of findDuplicateGroups(bank)) {
+      for (const x of g.members) {
+        for (const y of g.members) if (x.ref < y.ref) grouped.add(`${x.ref},${y.ref}`);
+      }
+    }
+    findings = findings.filter((f) => !grouped.has(`${f.a.ref},${f.b.ref}`));
+  }
+
+  const kind = flag("kind");
+  if (kind !== undefined) findings = findings.filter((f) => f.kind === kind);
+  if (has("new")) {
+    const baseline = loadBaseline();
+    findings = findings.filter((f) => !baseline.has(f.key));
+  }
+
+  if (asJson) {
+    return flush(
+      findings.map((f) => ({
+        kind: f.kind,
+        key: f.key,
+        stemSimilarity: Number(f.stemSimilarity.toFixed(3)),
+        answerSimilarity: Number(f.answerSimilarity.toFixed(3)),
+        a: { ref: f.a.ref, file: f.a.file, question: f.a.question },
+        b: { ref: f.b.ref, file: f.b.file, question: f.b.question },
+      }))
+    );
+  }
+
+  const flips = findings.filter((f) => f.kind === "polarity").length;
+  say(
+    `${bold(String(findings.length))} pair(s): ${flips} ${red("polarity flip")}, ` +
+      `${findings.length - flips} ${yellow("near-stem")}`
+  );
+  say(
+    dim(
+      "A polarity flip is two near-identical questions asking for opposite answers — verify, never merge."
+    )
+  );
+  say();
+
+  for (const f of findings.slice(0, limit)) {
+    const label = f.kind === "polarity" ? red(bold("polarity")) : yellow("near-stem");
+    say(
+      `${label}  ${bold(f.a.ref)} ↔ ${bold(f.b.ref)}  ` +
+        dim(`stem ${f.stemSimilarity.toFixed(2)} · answers ${f.answerSimilarity.toFixed(2)}`)
+    );
+    say(`    ${dim(pad(f.a.ref, 9))} ${clip(f.a.question, 92)}`);
+    say(`    ${dim(pad(f.b.ref, 9))} ${clip(f.b.question, 92)}`);
+    say(dim(`    ${where(f.a)}  ${where(f.b)}`));
+    say();
+  }
+  if (findings.length > limit) {
+    say(dim(`…and ${findings.length - limit} more (--limit ${findings.length})`));
+  }
+  flush();
+}
+
+/** Every image file under public/images, so orphans can be spotted. */
+function imagesOnDisk(): string[] {
+  const root = join("public", "images");
+  if (!existsSync(root)) return [];
+  const found: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const path = join(dir, entry);
+      if (statSync(path).isDirectory()) walk(path);
+      else found.push(path.replace(/^public\//, ""));
+    }
+  };
+  walk(root);
+  return found;
+}
+
+function cmdCoverage(): void {
+  const bank = load();
+  const rows = coverage(bank);
+
+  const referenced = new Set<string>();
+  for (const q of bank) {
+    if (q.image !== null) referenced.add(q.image.replace(/^\//, ""));
+    for (const m of (q.explanation ?? "").matchAll(/<img[^>]+src=['"]([^'"]+)['"]/gi)) {
+      referenced.add((m[1] ?? "").replace(/^\//, ""));
+    }
+  }
+  // Category covers are referenced from lib/config/categories.ts rather than
+  // from a question, so they are not orphans however this report counts them.
+  const orphans = imagesOnDisk().filter(
+    (f) => !referenced.has(f) && !/\/cover\.[a-z0-9]+$/.test(f)
+  );
+
+  if (asJson) return flush({ rows, orphanImages: orphans });
+
+  const pct = (n: number, total: number) =>
+    total === 0 ? "—" : `${Math.round((n / total) * 100)}%`;
+  const head = ["", "total", "sourced", "refs", "with page", "explained", "images", "topic"];
+  const table = rows.map((r) => [
+    r.label,
+    String(r.total),
+    `${r.withSources} ${dim(pct(r.withSources, r.total))}`,
+    String(r.sourceRefs),
+    `${r.refsWithPage} ${dim(pct(r.refsWithPage, r.sourceRefs))}`,
+    `${r.withExplanation} ${dim(pct(r.withExplanation, r.total))}`,
+    String(r.withImage),
+    `${r.withTopic} ${dim(pct(r.withTopic, r.total))}`,
+  ]);
+
+  const widths = head.map((h, i) =>
+    Math.max(h.length, ...table.map((row) => stripAnsi(row[i] ?? "").length))
+  );
+  say(bold(head.map((h, i) => pad(h, widths[i] ?? 0)).join("  ")));
+  for (const row of table) say(row.map((cell, i) => pad(cell, widths[i] ?? 0)).join("  "));
+
+  if (orphans.length > 0) {
+    say();
+    say(`${yellow(String(orphans.length))} image(s) on disk that no question references:`);
+    for (const o of orphans.slice(0, limit)) say(`  public/${o}`);
+    if (orphans.length > limit) say(dim(`  …and ${orphans.length - limit} more`));
+  }
+  flush();
+}
+
+function cmdTopics(): void {
+  const bank = load();
+  const audit = auditTopics(bank);
+
+  if (asJson) {
+    return flush({
+      distribution: audit.distribution,
+      untagged: audit.untagged.map((q) => q.ref),
+      invalid: audit.invalid.map((q) => ({ ref: q.ref, topic: q.topic })),
+      aboveEntryLevel: audit.aboveEntryLevel.map((q) => ({ ref: q.ref, topic: q.topic })),
+    });
+  }
+
+  const head = ["topic", "cat3", "cat2", "cat1", "total"];
+  const table = audit.distribution.map((d) => [
+    d.slug,
+    ...(["3", "2", "1"] as CategoryId[]).map((c) => String(d.counts[c])),
+    String(d.total),
+  ]);
+  const widths = head.map((h, i) =>
+    Math.max(h.length, ...table.map((row) => (row[i] ?? "").length))
+  );
+  say(bold(head.map((h, i) => pad(h, widths[i] ?? 0)).join("  ")));
+  for (const row of table) say(row.map((cell, i) => pad(cell, widths[i] ?? 0)).join("  "));
+
+  if (audit.invalid.length > 0) {
+    say();
+    say(
+      red(`${audit.invalid.length} question(s) with a topic that is not a slug in lib/config/topics.ts:`)
+    );
+    for (const q of audit.invalid) say(`  ${q.ref} = ${q.topic}  ${dim(where(q))}`);
+  }
+  if (audit.untagged.length > 0) {
+    say();
+    say(
+      `${yellow(String(audit.untagged.length))} untagged question(s): ` +
+        audit.untagged.slice(0, 20).map((q) => q.ref).join(", ")
+    );
+  }
+  if (audit.aboveEntryLevel.length > 0) {
+    say();
+    say(
+      `${audit.aboveEntryLevel.length} category 3 question(s) in a chapter Anexo 1 marks as ` +
+        "starting above entry level:"
+    );
+    say(
+      dim("  Advisory — real 2023 cat 3 papers do examine these. See examinedFrom in lib/config/topics.ts.")
+    );
+    for (const q of audit.aboveEntryLevel.slice(0, limit)) {
+      say(`  ${pad(q.ref, 9)} ${dim(pad(q.topic ?? "", 16))} ${clip(q.question, 70)}`);
+    }
+  }
+  flush();
+}
+
+function cmdPaper(): void {
+  const bank = load();
+  const papers = auditPapers(bank);
+  const wanted = positional[1];
+
+  if (wanted === undefined) {
+    if (asJson) {
+      return flush(
+        papers.map((p) => ({
+          pdf: p.pdf,
+          cited: p.cited.length,
+          resolved: p.cited.filter((c) => c.page !== null).length,
+          gaps: p.gaps.length,
+          collisions: p.collisions.length,
+          onDisk: existsSync(join("public", "exams", `${p.pdf}.pdf`)),
+        }))
+      );
+    }
+    say(bold(`${papers.length} paper(s) cited by the bank`));
+    say();
+    for (const p of papers) {
+      const disk = existsSync(join("public", "exams", `${p.pdf}.pdf`));
+      const resolved = p.cited.filter((c) => c.page !== null).length;
+      say(
+        `${bold(pad(p.pdf, 24))} ${String(p.cited.length).padStart(3)} cited  ` +
+          `${dim(`${resolved} with page`)}  ` +
+          `${p.gaps.length > 0 ? yellow(`${p.gaps.length} unclaimed`) : green("complete")}` +
+          `${p.collisions.length > 0 ? red(`  ${p.collisions.length} collisions`) : ""}` +
+          `${disk ? "" : red("  PDF absent")}`
+      );
+    }
+    return flush();
+  }
+
+  const paper = papers.find((p) => p.pdf === wanted || p.pdf.endsWith(`/${wanted}`));
+  if (!paper) {
+    say(red(`no question cites ${wanted}`));
+    return flush(null);
+  }
+  if (asJson) return flush(paper);
+
+  say(`${bold(paper.pdf)}  ${paper.cited.length} pergunta(s) cited`);
+  say();
+  for (const c of paper.cited) {
+    const q = bank.find((b) => b.ref === c.ref);
+    say(
+      `  ${String(c.question).padStart(3)}  ` +
+        `${c.page === null ? dim("p. —") : `p.${String(c.page).padStart(2)}`}  ` +
+        `${bold(pad(c.ref, 9))} ${clip(q?.question ?? "", 78)}`
+    );
+  }
+  if (paper.gaps.length > 0) {
+    say();
+    say(`${yellow("unclaimed perguntas")}: ${paper.gaps.join(", ")}`);
+    say(dim("  Either not in the bank yet, or in it without a source reference."));
+  }
+  for (const c of paper.collisions) {
+    say();
+    say(red(`pergunta ${c.question} claimed by ${c.refs.join(", ")} — at most one can be right`));
+  }
+  flush();
+}
+
+function cmdAnswers(): void {
+  const bank = load();
+  const audit = auditAnswers(bank);
+
+  if (asJson) {
+    return flush({
+      ...audit,
+      optionCount: Object.fromEntries(audit.optionCount),
+    });
+  }
+
+  const total = audit.total;
+  say(bold("correct-answer position"));
+  audit.correctIndexCounts.forEach((count, i) => {
+    const share = Math.round((count / total) * 100);
+    say(
+      `  ${String.fromCharCode(97 + i)}  ${String(count).padStart(4)}  ` +
+        `${String(share).padStart(2)}%  ${dim("█".repeat(Math.round(share / 2)))}`
+    );
+  });
+  say(
+    dim(
+      `  Uniform is ${Math.round(100 / audit.correctIndexCounts.length)}%; a spike means the bank is guessable.`
+    )
+  );
+
+  say();
+  const longestShare = Math.round((audit.longestIsCorrect / total) * 100);
+  const chance = Math.round(100 / (audit.correctIndexCounts.length || 4));
+  say(
+    `${bold("longest option is correct")}  ${audit.longestIsCorrect}/${total} (${longestShare}%)  ` +
+      dim(`chance is about ${chance}%`)
+  );
+
+  say();
+  say(bold("options per question"));
+  for (const [count, n] of [...audit.optionCount.entries()].sort((a, b) => a[0] - b[0])) {
+    say(`  ${count} options  ${n}`);
+  }
+
+  if (audit.duplicateOptions.length > 0) {
+    say();
+    say(red(`${audit.duplicateOptions.length} question(s) with two identical options:`));
+    for (const d of audit.duplicateOptions.slice(0, limit)) {
+      say(`  ${bold(d.ref)}  ${clip(d.text, 70)}  ${dim(d.file)}`);
+    }
+  }
+  if (audit.misplacedCatchAll.length > 0) {
+    say();
+    say(`${yellow(String(audit.misplacedCatchAll.length))} catch-all option(s) not in last position:`);
+    for (const m of audit.misplacedCatchAll.slice(0, limit)) {
+      say(`  ${bold(m.ref)}  position ${m.index + 1} of ${m.count}  ${dim(m.file)}`);
+    }
+  }
+  flush();
+}
+
+function usage(): void {
+  say(bold("qbank — question-bank inspection"));
+  say();
+  say("  search <term>    find questions by text  [--field stem|options|explanation] [--regex]");
+  say("  show <ref…>      one question in full, with its duplicates");
+  say("  dupes            duplicate groups, worst tier first  [--tier] [--new] [--update-baseline]");
+  say("  pairs            fuzzy near-duplicates and polarity flips  [--kind] [--new]");
+  say("  coverage         sources, explanations, images, orphans");
+  say("  topics           taxonomy distribution and outliers");
+  say("  paper [pdf]      what cites an exam paper, and what is unclaimed");
+  say("  answers          answer-construction audit");
+  say();
+  say(dim("  global: --cat 3,2   --limit N   --json"));
+  flush(null);
+}
+
+const command = positional[0] ?? "help";
+const commands: Record<string, () => void> = {
+  search: cmdSearch,
+  show: cmdShow,
+  dupes: cmdDupes,
+  duplicates: cmdDupes,
+  pairs: cmdPairs,
+  coverage: cmdCoverage,
+  topics: cmdTopics,
+  paper: cmdPaper,
+  papers: cmdPaper,
+  answers: cmdAnswers,
+};
+
+const run = commands[command];
+if (run) run();
+else usage();


### PR DESCRIPTION
## What

Two commits:

1. **`qbank`** — a read-only developer tool for inspecting the question bank
2. **Three answer corrections**, each verified against the cited exam paper

## The corrections

| Question | Was | Now | Verified against |
|---|---|---|---|
| cat3 #12 | fundamenta**lmente e** discordância | fundamenta**damente a** discordância | `cat3/2023_08_18` pergunta 29, p.9 |
| cat1 #36 | toróides de **fero** (×4) | toróides de **ferro** | `cat1/2011_12_13` pergunta 20, p.5 |
| cat1 #210 | Atinge **o** máximo | Atinge **um** máximo | `cat1/2011_12_13` pergunta 18, p.5 |

Verified by reading the papers, not by judging the Portuguese. Two notes:

- cat3 #12's own explanation body already spelled it correctly. The fix also restores the comma after ANACOM, which makes the answer identical to cat1 #284 and cat2 #255 — the same question examined at the other two levels — so the group drops from `typo` to `exact`.
- cat1 #210 diverged from the paper it cites, while the *unsourced* cat3 #166 had it right. Being sourced is not the same as being faithful.

**Four typo-tier groups remain and are deliberately untouched:** cat1 #53 cites `cat1/2014_12_19`, the paper in `content/missing-exams.json` that we genuinely do not have; cat3 #17 and #138 are both unsourced and each carries its own defect, so neither can arbitrate the other; and two more turned out to be genuine wording differences between different papers rather than errors.

## The tool

`bun run qbank <search|show|dupes|pairs|coverage|topics|paper|answers>`, reading `content/questions/**` rather than the generated JSON so a finding can name the file to edit. Analysis lives in `lib/content/analysis.ts` as pure functions; the script is I/O and formatting.

Not wired into CI on purpose — `content:check` owns per-file validity, and duplicating that here would create a second source of truth that drifts. What `qbank` reports is the class of problem no per-file rule can see: two files that are each valid but disagree with each other.

Two design constraints the data forced:

- **Fuzzy finders require the answers to agree, not just the stem.** "Qual das seguintes afirmações é incorreta?" is a template shared by dozens of unrelated questions, and its nearest neighbour by every string metric is *the opposite question*. Without the answer check, `pairs` reported 248 unrelated matches; with it, 77.
- **`canonical()` is for prose, not options.** It strips punctuation, so `10 dB`/`-10 dB` and `0,01 µF`/`0,01 F` compare equal, and Morse answers (`. . . - - - . . .`) reduce to the empty string entirely. The within-question duplicate-option check therefore compares raw text. My first pass reported 17 duplicated options; 15 were false positives from exactly this. Both cases are pinned by tests.

No baseline file is committed: `--new` works against `content/qbank-baseline.json` once you write one with `dupes --update-baseline`, but baselining now would mark the remaining real findings as accepted.

## Checks

`type-check`, `lint`, 300 tests (23 new), and `content:check` all pass. Regenerated `public/data/cat{1,3}.json` are in the second commit.