### PR TITLE
Add `content:new`, a tool for adding a question to the bank

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ bun run test:coverage # Vitest with V8 coverage
 bun run type-check   # tsc --noEmit
 bun run content:build # Compile content/questions/** into shipped artifacts
 bun run content:check # Verify artifacts match their source (writes nothing)
+bun run content:new  # Add a question: review, then write all four files
 bun run qbank <cmd>  # Inspect the question bank (search, dupes, coverage, …)
 ```
 
@@ -77,9 +78,6 @@ as the MDX body), plus `category.json` holding `anacomFile` and the question
   `loadData()` returns
 - `content/notes/cat{n}/{id}.mdx` — what `/api/notes` serves
 
-Adding a question is documented in `docs/novas-questoes.md` (pt-PT);
-the topic taxonomy in `docs/topicos.md` (pt-PT).
-
 `bun run content:build` regenerates them; `bun run content:check` verifies they
 match and is wired into `bun run build`, so a hand-edit or a stale artifact
 fails the build. It also fails on any `sources` entry pointing at an exam PDF
@@ -88,6 +86,28 @@ that is not in `public/exams/`. Papers we genuinely do not have are baselined in
 69 references do not break the build; the check also reports baseline entries
 that have become unnecessary. `scripts/content-migrate.ts <cat>` performs a migration and
 refuses to overwrite an existing source directory.
+
+`bun run content:new` is the way to add a question — interactive, or `--from
+draft.mdx` where the draft is a question file with the `id` left out (the same
+format it writes, so there is no second schema). It assigns the id, reviews the
+draft against the whole bank, and then writes all four files. The rules live in
+`lib/content/author.ts` as pure functions; the script is I/O and prompting,
+the same split as `qbank`.
+
+- **It refuses on `error`, asks on `warning`.** A duplicate is not
+  automatically a defect, so a `contradiction` (same options, different correct
+  answer) blocks while an `exact` match in another category only prompts
+- **The topic is picked from a list, never typed.** `topic` is free text in the
+  schema on purpose, which makes a typo the one mistake here that nothing
+  anywhere reports — the card silently loses its label and the browse filter
+  silently stops matching. This is the only place it can be made
+  unrepresentable rather than merely detectable
+- **The `order` position stays a human decision** — it is editorial, not
+  numeric. Interactively it shows the same-topic neighbourhood and asks;
+  otherwise `--after`/`--before`/`--end`. It never appends silently
+
+Adding a question by hand is still documented in `docs/novas-questoes.md`
+(pt-PT); the topic taxonomy in `docs/topicos.md` (pt-PT).
 
 **Linking questions to exam PDFs**: `bun run data:ocr-exams` OCRs the scanned
 papers in `public/exams/` and matches them back to the bank (needs `poppler`

--- a/__tests__/unit/test-content-author.test.ts
+++ b/__tests__/unit/test-content-author.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Authoring rules: what `content:new` refuses to write, and why
+ *
+ * The interesting half of the tool is the review, and it is pure — the
+ * filesystem arrives as two predicates — so everything here runs without a
+ * fixture tree.
+ *
+ * The cases worth pinning down are the ones no other check in the pipeline
+ * covers: a topic slug that fails silently, a question that contradicts one
+ * already in another category, and the two unrelated numbers in a source
+ * reference.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  reviewDraft,
+  insertIntoOrder,
+  nextId,
+  hasErrors,
+  type Draft,
+  type ReviewContext,
+} from "@/lib/content/author";
+import { buildBank } from "@/lib/content/analysis";
+import type { ContentCategory } from "@/lib/content/schema";
+
+const UIT: ContentCategory = {
+  id: "2",
+  anacomFile: 91,
+  questions: [
+    {
+      id: 255,
+      question: "O Regulamento das Radiocomunicações é uma publicação",
+      answers: [
+        { text: "da IARU", correct: false },
+        { text: "da CEPT", correct: false },
+        { text: "da UIT", correct: true },
+        { text: "da NATO", correct: false },
+      ],
+      topic: "regulamentacao",
+      sources: [],
+      image: null,
+      tutorial: null,
+      calc: null,
+      explanation: null,
+    },
+  ],
+};
+
+const BANK = buildBank([UIT]);
+
+function context(overrides: Partial<ReviewContext> = {}): ReviewContext {
+  return {
+    category: "3",
+    anacomFile: 90,
+    bank: BANK,
+    order: [1, 4, 5, 213],
+    pdfLookup: () => ({ exists: true, alsoIn: [] }),
+    imageExists: () => true,
+    ...overrides,
+  };
+}
+
+function draft(overrides: Partial<Draft> = {}): Draft {
+  return {
+    category: "3",
+    question: "Num condensador de placas paralelas, aumentar a distância entre as placas",
+    answers: [
+      { text: "aumenta a capacidade" },
+      { text: "diminui a capacidade", correct: true },
+      { text: "não altera a capacidade" },
+      { text: "aumenta a tensão de rutura" },
+    ],
+    topic: "componentes",
+    sources: [{ pdf: "cat3/2023_08_18", question: 29, page: 9 }],
+    explanation: "A capacidade é inversamente proporcional à distância entre as placas.",
+    ...overrides,
+  };
+}
+
+const codes = (findings: readonly { code: string }[]) => findings.map((f) => f.code);
+
+describe("nextId", () => {
+  it("is the maximum plus one, never a gap below it", () => {
+    // cat1 has a free id at 352 and the next question still got 390: recycling
+    // a retired id would silently repoint every stale link to it.
+    expect(nextId([1, 2, 5, 390])).toBe(391);
+    expect(nextId([])).toBe(1);
+  });
+});
+
+describe("insertIntoOrder", () => {
+  const order = [1, 4, 5, 213];
+
+  it("places a question relative to an anchor", () => {
+    expect(insertIntoOrder(order, 214, { kind: "after", id: 4 })).toEqual([1, 4, 214, 5, 213]);
+    expect(insertIntoOrder(order, 214, { kind: "before", id: 4 })).toEqual([1, 214, 4, 5, 213]);
+    expect(insertIntoOrder(order, 214, { kind: "end" })).toEqual([1, 4, 5, 213, 214]);
+  });
+
+  it("leaves the original untouched", () => {
+    insertIntoOrder(order, 214, { kind: "end" });
+    expect(order).toEqual([1, 4, 5, 213]);
+  });
+
+  it("refuses an anchor that is not in the order, and a duplicate id", () => {
+    expect(() => insertIntoOrder(order, 214, { kind: "after", id: 999 })).toThrow(/999/);
+    expect(() => insertIntoOrder(order, 5, { kind: "end" })).toThrow(/already/);
+  });
+});
+
+describe("reviewDraft", () => {
+  it("passes a clean draft", () => {
+    const review = reviewDraft(draft(), context());
+    expect(review.findings).toEqual([]);
+    expect(review.question?.id).toBe(214);
+    // The 1-indexed correctIndex is gone: the answer carries its own flag.
+    expect(review.question?.answers[1]?.correct).toBe(true);
+  });
+
+  it("rejects a topic slug that is not in the taxonomy", () => {
+    // The whole point of the tool: the schema takes `topic` as free text, so a
+    // typo compiles, ships, and shows an unlabelled card forever.
+    const review = reviewDraft(draft({ topic: "regulamentaçao" }), context());
+    expect(codes(review.findings)).toContain("topic-unknown");
+    expect(hasErrors(review.findings)).toBe(true);
+  });
+
+  it("warns, but does not fail, on an untagged question", () => {
+    const review = reviewDraft(draft({ topic: null }), context());
+    expect(codes(review.findings)).toEqual(["topic-missing"]);
+    expect(hasErrors(review.findings)).toBe(false);
+  });
+
+  it("flags a topic the annex examines above this category, advisory only", () => {
+    const review = reviewDraft(draft({ topic: "antenas" }), context({ category: "3" }));
+    expect(codes(review.findings)).toContain("topic-above-level");
+    expect(hasErrors(review.findings)).toBe(false);
+  });
+
+  it("reports schema failures by field instead of throwing", () => {
+    const review = reviewDraft(
+      draft({ answers: [{ text: "uma" }, { text: "duas", correct: true }, { text: "três", correct: true }] }),
+      context()
+    );
+    expect(review.question).toBeNull();
+    expect(codes(review.findings)).toEqual(["schema"]);
+    expect(review.findings[0]?.message).toMatch(/exactly one correct answer/);
+  });
+
+  it("refuses an id already in the order and names the free one", () => {
+    const review = reviewDraft(draft({ id: 5 }), context());
+    const finding = review.findings.find((f) => f.code === "id-taken");
+    expect(finding?.detail?.[0]).toMatch(/214/);
+  });
+
+  it("refuses a source pointing at a paper that is not on disk", () => {
+    const review = reviewDraft(
+      draft(),
+      context({ pdfLookup: () => ({ exists: false, alsoIn: ["cat2"] }) })
+    );
+    const finding = review.findings.find((f) => f.code === "pdf-missing");
+    expect(finding?.level).toBe("error");
+    expect(finding?.detail?.[0]).toMatch(/cat2/);
+  });
+
+  it("warns when the PDF page equals the pergunta number", () => {
+    // Unrelated numbers — the papers carry about four questions per page — so
+    // equality is nearly always the same number typed into both fields.
+    const review = reviewDraft(
+      draft({ sources: [{ pdf: "cat3/2023_08_18", question: 29, page: 29 }] }),
+      context()
+    );
+    expect(codes(review.findings)).toEqual(["page-equals-question"]);
+  });
+
+  it("accepts a source with no page yet", () => {
+    const review = reviewDraft(
+      draft({ sources: [{ pdf: "cat3/2023_08_18", question: 29 }] }),
+      context()
+    );
+    expect(review.findings).toEqual([]);
+    expect(review.question?.sources[0]?.page).toBeNull();
+  });
+
+  it("refuses an image, in the frontmatter or the body, that is not in public/", () => {
+    const missing = context({ imageExists: () => false });
+    expect(codes(reviewDraft(draft({ image: "images/cat3/x.png" }), missing).findings)).toContain(
+      "image-missing"
+    );
+    expect(
+      codes(
+        reviewDraft(draft({ explanation: '<img src="/images/cat3/y.png" />' }), missing).findings
+      )
+    ).toContain("image-missing");
+  });
+
+  it("refuses two options with the same text", () => {
+    const review = reviewDraft(
+      draft({
+        answers: [
+          { text: "10 dB" },
+          { text: "10 dB" },
+          { text: "20 dB", correct: true },
+          { text: "30 dB" },
+        ],
+      }),
+      context()
+    );
+    expect(codes(review.findings)).toContain("option-duplicate");
+  });
+
+  it("refuses a question that contradicts one already in the bank", () => {
+    // Same stem, same options, a different correct answer. Both files are
+    // individually valid, so nothing else in the pipeline can see this.
+    const review = reviewDraft(
+      draft({
+        question: "O Regulamento das Radiocomunicações é uma publicação",
+        answers: [
+          { text: "da IARU" },
+          { text: "da CEPT", correct: true },
+          { text: "da UIT" },
+          { text: "da NATO" },
+        ],
+        topic: "regulamentacao",
+      }),
+      context()
+    );
+    const finding = review.findings.find((f) => f.code === "duplicate-contradiction");
+    expect(finding?.level).toBe("error");
+    expect(finding?.message).toMatch(/cat2#255/);
+    expect(review.duplicates[0]?.tier).toBe("contradiction");
+  });
+
+  it("only warns on the same question examined at another level", () => {
+    // 27 groups in the bank are this: the same regulatory question asked at
+    // all three levels, which is legitimate and must stay writable.
+    const review = reviewDraft(
+      draft({
+        question: "O Regulamento das Radiocomunicações é uma publicação",
+        answers: [
+          { text: "da IARU" },
+          { text: "da CEPT" },
+          { text: "da UIT", correct: true },
+          { text: "da NATO" },
+        ],
+        topic: "regulamentacao",
+      }),
+      context()
+    );
+    expect(hasErrors(review.findings)).toBe(false);
+    expect(codes(review.findings)).toContain("duplicate-exact");
+  });
+
+  it("warns about an explanation-less question without blocking it", () => {
+    const review = reviewDraft(draft({ explanation: null }), context());
+    expect(codes(review.findings)).toEqual(["explanation-missing"]);
+  });
+});

--- a/docs/novas-questoes.md
+++ b/docs/novas-questoes.md
@@ -4,8 +4,67 @@ A fonte de verdade é `content/questions/cat{n}/` — **um ficheiro MDX por
 pergunta**, com os campos estruturados no frontmatter YAML e a explicação no
 corpo do documento. Tudo o resto é gerado a partir daí.
 
-Não existe nenhum script que crie uma pergunta. O processo é manual, e são
-apenas dois ficheiros a editar.
+Há duas maneiras de acrescentar uma: com a ferramenta, ou à mão. A ferramenta é a
+recomendada — faz as mesmas alterações e verifica, **antes de escrever**, o que
+mais nada no projeto verifica. O resto do documento descreve o formato que ela
+escreve, e continua a valer para quem edite os ficheiros diretamente.
+
+# A ferramenta: `bun run content:new`
+
+```bash
+bun run content:new                                  # interativo, campo a campo
+bun run content:new --from rascunho.mdx              # a partir de um ficheiro
+bun run content:new --from rascunho.mdx --dry-run    # mostra o que escreveria
+```
+
+Escreve os quatro ficheiros de uma vez — a pergunta, a linha do `order` e os
+dois artefactos gerados — e deixa a árvore no estado que o `content:check`
+espera.
+
+O rascunho do `--from` é **um ficheiro de pergunta com o `id` omitido**: o
+mesmo formato do destino, para não haver um segundo formato a aprender e para
+que um rascunho rejeitado se corrija e volte a submeter tal como está. A
+categoria vem de `--cat 3` ou de um `category: 3` no frontmatter, que é
+descartado ao escrever. Com `--from -` lê do stdin.
+
+O `id` não se escolhe: é o máximo atual mais um, nunca uma lacuna abaixo dele
+(a razão está em [§1](#1-escolher-a-categoria-e-o-id)).
+
+## O que verifica antes de escrever
+
+| Verificação | O que mais apanha isto |
+| --- | --- |
+| `topic` fora da taxonomia | **nada** — falha em silêncio para sempre |
+| contradiz uma pergunta noutra categoria | `qbank dupes`, se alguém se lembrar de o correr |
+| enunciado quase igual a outro, ou invertido | `qbank pairs`, idem |
+| `page` igual ao número da pergunta | nada |
+| `id` já usado | nada — mas é atribuído automaticamente |
+| duas opções com o mesmo texto | `qbank answers` |
+| PDF de `sources` que não existe | `content:check`, já depois de escrito |
+| imagem que não existe | `content:check`, já depois de escrito |
+| sem explicação, sem fonte, sem matéria, matéria acima do nível | avisos |
+
+Os **erros** impedem a escrita. Os **avisos** pedem confirmação, porque um
+duplicado não é automaticamente um defeito — a mesma pergunta de regulamentação
+é legitimamente examinada nos três níveis. `--force` escreve apesar dos avisos;
+`--yes` responde sim a todas as perguntas, e é obrigatório quando o stdin é um
+pipe.
+
+A matéria é escolhida de uma lista, não escrita: um slug mal escrito passa em
+todos os outros lados e depois não mostra etiqueta nenhuma, por isso aqui é
+impossível de representar em vez de meramente detetável.
+
+## A posição no `order`
+
+É a única decisão que a ferramenta não toma — a ordem é temática, não numérica.
+No modo interativo mostra a vizinhança (as últimas perguntas da mesma matéria,
+com a posição de cada uma) e pergunta depois de que `id` inserir; Enter põe no
+fim. Sem terminal usa-se `--after 107`, `--before 108` ou `--end`.
+
+# Fazer à mão
+
+O que se segue é o que a ferramenta faz — o formato dos ficheiros e a ordem
+das alterações. São dois ficheiros a editar.
 
 ## Antes de começar: a pergunta já existe?
 
@@ -19,6 +78,9 @@ bun run qbank search "toróide" --cat 1      # restringe a uma categoria
 
 A procura ignora acentos e maiúsculas, por isso `propagacao` encontra
 "propagação". Guia completo do `qbank` em [`qbank.md`](qbank.md).
+
+O `content:new` faz esta comparação sozinho, contra as três categorias, antes
+de escrever seja o que for.
 
 ## O que muda, e o que é gerado
 
@@ -317,6 +379,9 @@ Ler o número da pergunta na digitalização é a parte menos fiável do process
 relatório, para confirmação humana.
 
 ## Lista de verificação
+
+Com `bun run content:new`, os primeiros seis pontos são a própria ferramenta;
+sobram o último e a decisão da posição no `order`.
 
 - [ ] Procurei com `qbank search` e a pergunta ainda não existe
 - [ ] `id` = máximo atual + 1, sem reaproveitar lacunas

--- a/lib/content/author.ts
+++ b/lib/content/author.ts
@@ -1,0 +1,388 @@
+/**
+ * Authoring a new question
+ *
+ * The write half of the content pipeline. `content:check` validates one file
+ * at a time and `qbank` compares files against each other, but neither runs
+ * until the question has already been written by hand — so the mistakes that
+ * are cheapest to prevent are the ones currently caught last, or not at all:
+ * a misspelled `topic` fails silently forever, and a question that already
+ * exists in another category with a different answer is only found by
+ * remembering to run `qbank dupes` afterwards.
+ *
+ * Pure, like `analysis.ts`. Filesystem questions ("is that PDF on disk?")
+ * arrive as predicates, so the rules are unit-testable without a fixture tree
+ * and `scripts/content-new.ts` stays I/O and prompting.
+ *
+ * Findings are split by whether they can be waved through:
+ *
+ * - `error` — the build fails, or the question fails silently at runtime.
+ *   Never written without an explicit override.
+ * - `warning` — legitimate often enough that only a human can say. The bank
+ *   examines the same regulatory question at all three levels on purpose.
+ */
+import { QuestionSchema, type ContentQuestion } from "./schema";
+import {
+  auditAnswers,
+  buildBank,
+  findDuplicateGroups,
+  findPairFindings,
+  type BankQuestion,
+  type DuplicateGroup,
+  type PairFinding,
+} from "./analysis";
+import type { CategoryId } from "../config/categories";
+import { CATEGORIES } from "../config/categories";
+import { TOPIC_BY_SLUG, TOPIC_SLUGS, isTopicSlug } from "../config/topics";
+
+/** How many options every question in the bank actually has. */
+export const EXPECTED_OPTIONS = 4;
+
+export type DraftAnswer = { text: string; correct?: boolean };
+
+/**
+ * A question on its way in.
+ *
+ * Deliberately the shape of the destination file rather than a second format:
+ * `--from` takes a question file with the id left out, so nothing has to be
+ * translated and a draft that is rejected can be fixed and re-fed as-is.
+ */
+export type Draft = {
+  category: CategoryId;
+  /** Omitted for a new question; `nextId` supplies it. */
+  id?: number;
+  question: string;
+  answers: DraftAnswer[];
+  topic?: string | null;
+  sources?: { pdf: string; question: number; page?: number | null }[];
+  image?: string | null;
+  tutorial?: string | null;
+  calc?: string | null;
+  explanation?: string | null;
+};
+
+export type FindingLevel = "error" | "warning";
+
+export type Finding = {
+  level: FindingLevel;
+  /** Stable identifier, so a caller can suppress or test one rule. */
+  code: string;
+  message: string;
+  /** Indented lines under the message: the offending values, or the fix. */
+  detail?: string[];
+};
+
+export type Review = {
+  /** The parsed question, or null when it does not satisfy the schema. */
+  question: ContentQuestion | null;
+  findings: Finding[];
+  /** Duplicate groups the draft would join, worst tier first. */
+  duplicates: DuplicateGroup[];
+  /** Fuzzy near-neighbours of the draft. */
+  pairs: PairFinding[];
+};
+
+export type PdfLookup = (pdf: string) => { exists: boolean; alsoIn: string[] };
+
+export type ReviewContext = {
+  /** The category the draft is being added to. */
+  category: CategoryId;
+  anacomFile: number;
+  /** Every existing question, the draft excluded. */
+  bank: readonly BankQuestion[];
+  /** The category's current `order`, for the id collision check. */
+  order: readonly number[];
+  pdfLookup: PdfLookup;
+  /** Takes a public-relative path, e.g. "images/cat3/x.png". */
+  imageExists: (publicRelative: string) => boolean;
+};
+
+/**
+ * The next free id: the current maximum plus one, never a gap below it.
+ *
+ * The bank has holes — id 352 in cat1 is free — and they stay holes. Recycling
+ * a retired id would silently repoint every stale link to a different
+ * question, with nothing anywhere reporting an error.
+ */
+export function nextId(order: readonly number[]): number {
+  return order.reduce((max, id) => Math.max(max, id), 0) + 1;
+}
+
+export function hasErrors(findings: readonly Finding[]): boolean {
+  return findings.some((f) => f.level === "error");
+}
+
+/** Images referenced from inside an explanation body, as public-relative paths. */
+function imagesInBody(explanation: string | null): string[] {
+  const found: string[] = [];
+  for (const m of (explanation ?? "").matchAll(/<img[^>]+src=['"]([^'"]+)['"]/gi)) {
+    const rel = (m[1] ?? "").replace(/^\//, "");
+    if (rel.startsWith("images/")) found.push(rel);
+  }
+  return found;
+}
+
+function reviewTopic(topic: string | null, category: CategoryId): Finding[] {
+  if (topic === null) {
+    return [
+      {
+        level: "warning",
+        code: "topic-missing",
+        message: "Sem `topic` — a pergunta não recebe etiqueta e o filtro do browse ignora-a.",
+      },
+    ];
+  }
+
+  // The schema takes `topic` as free text on purpose — it is a join key, not a
+  // closed enum, and validating it there would couple the content schema to
+  // the UI's taxonomy. That leaves this as the one place a typo can be caught
+  // before it becomes a card that renders without a label.
+  if (!isTopicSlug(topic)) {
+    return [
+      {
+        level: "error",
+        code: "topic-unknown",
+        message: `\`topic: ${topic}\` não é um slug da taxonomia — falharia em silêncio.`,
+        detail: [TOPIC_SLUGS.join(", ")],
+      },
+    ];
+  }
+
+  const examinedFrom = TOPIC_BY_SLUG[topic].examinedFrom;
+  // CATEGORIES is 3 -> 2 -> 1, beginner first, so a later index is a higher level.
+  if (CATEGORIES.indexOf(category) < CATEGORIES.indexOf(examinedFrom)) {
+    return [
+      {
+        level: "warning",
+        code: "topic-above-level",
+        message: `O Anexo 1 marca \`${topic}\` como examinável a partir da categoria ${examinedFrom}.`,
+        detail: [
+          "Advisory, não um erro: o anexo é de 2009 e as provas de 2023 já examinam matéria acima do nível.",
+        ],
+      },
+    ];
+  }
+
+  return [];
+}
+
+function reviewAnswers(q: ContentQuestion, draftBank: BankQuestion): Finding[] {
+  const findings: Finding[] = [];
+
+  if (q.answers.length !== EXPECTED_OPTIONS) {
+    findings.push({
+      level: "warning",
+      code: "option-count",
+      message: `${q.answers.length} opções — as provas oficiais e todas as perguntas do banco têm ${EXPECTED_OPTIONS}.`,
+    });
+  }
+
+  const audit = auditAnswers([draftBank]);
+  for (const d of audit.duplicateOptions) {
+    findings.push({
+      level: "error",
+      code: "option-duplicate",
+      message: "Duas opções com o mesmo texto.",
+      detail: [d.text],
+    });
+  }
+  for (const m of audit.misplacedCatchAll) {
+    findings.push({
+      level: "warning",
+      code: "option-catch-all",
+      message: `Opção do tipo "todas as anteriores" na posição ${m.index + 1} de ${m.count}.`,
+      detail: ["Só faz sentido em último lugar."],
+    });
+  }
+
+  return findings;
+}
+
+function reviewSources(q: ContentQuestion, pdfLookup: PdfLookup): Finding[] {
+  const findings: Finding[] = [];
+
+  if (q.sources.length === 0) {
+    findings.push({
+      level: "warning",
+      code: "sources-missing",
+      message: "Sem `sources` — nada liga a pergunta à prova oficial de onde veio.",
+    });
+  }
+
+  for (const s of q.sources) {
+    const { exists, alsoIn } = pdfLookup(s.pdf);
+    if (!exists) {
+      findings.push({
+        level: "error",
+        code: "pdf-missing",
+        message: `\`${s.pdf}\` não existe em public/exams/ — o content:check falha.`,
+        detail:
+          alsoIn.length > 0
+            ? [`Existe em ${alsoIn.join(", ")}, portanto o prefixo da categoria está errado.`]
+            : [
+                "Acrescentar o PDF, corrigir a referência, ou (última opção) baselinar em content/missing-exams.json.",
+              ],
+      });
+    }
+
+    // The two numbers are unrelated — the papers carry about four questions
+    // per page — so equality is nearly always the pergunta number typed into
+    // both fields. It is legitimate for the first pages, hence a warning.
+    if (s.page !== null && s.page === s.question) {
+      findings.push({
+        level: "warning",
+        code: "page-equals-question",
+        message: `\`${s.pdf}\`: page ${s.page} igual ao número da pergunta.`,
+        detail: [
+          "São números sem relação: ~4 perguntas por página, a pergunta 29 está na página 9.",
+        ],
+      });
+    }
+  }
+
+  return findings;
+}
+
+/**
+ * Everything wrong with a draft, before anything is written.
+ *
+ * The duplicate pass is the reason this runs pre-write rather than post-commit:
+ * a new question that contradicts an existing one is invisible to every
+ * per-file rule, because both files are individually valid.
+ */
+export function reviewDraft(draft: Draft, ctx: ReviewContext): Review {
+  const id = draft.id ?? nextId(ctx.order);
+  const findings: Finding[] = [];
+
+  const parsed = QuestionSchema.safeParse({
+    id,
+    question: draft.question,
+    answers: draft.answers,
+    topic: draft.topic,
+    sources: draft.sources,
+    image: draft.image,
+    tutorial: draft.tutorial,
+    calc: draft.calc,
+    explanation: draft.explanation,
+  });
+
+  if (!parsed.success) {
+    for (const issue of parsed.error.issues) {
+      const path = issue.path.join(".");
+      findings.push({
+        level: "error",
+        code: "schema",
+        message: path.length > 0 ? `\`${path}\`: ${issue.message}` : issue.message,
+      });
+    }
+    return { question: null, findings, duplicates: [], pairs: [] };
+  }
+
+  const question = parsed.data;
+
+  if (ctx.order.includes(question.id)) {
+    findings.push({
+      level: "error",
+      code: "id-taken",
+      message: `O id ${question.id} já existe em cat${ctx.category}.`,
+      detail: [`Próximo livre: ${nextId(ctx.order)}.`],
+    });
+  }
+
+  // Built through `buildBank` rather than by hand so the comparison keys are
+  // computed exactly as they are for every other question.
+  const [draftBank] = buildBank([
+    { id: ctx.category, anacomFile: ctx.anacomFile, questions: [question] },
+  ]);
+  if (!draftBank) return { question, findings, duplicates: [], pairs: [] };
+
+  findings.push(...reviewTopic(question.topic, ctx.category));
+  findings.push(...reviewAnswers(question, draftBank));
+  findings.push(...reviewSources(question, ctx.pdfLookup));
+
+  for (const rel of [
+    ...(question.image === null ? [] : [question.image.replace(/^\//, "")]),
+    ...imagesInBody(question.explanation),
+  ]) {
+    if (ctx.imageExists(rel)) continue;
+    findings.push({
+      level: "error",
+      code: "image-missing",
+      message: `\`${rel}\` não existe em public/ — a compilação falha.`,
+    });
+  }
+
+  if (question.explanation === null) {
+    findings.push({
+      level: "warning",
+      code: "explanation-missing",
+      message: "Sem explicação. Válido — 260 perguntas estão assim — mas é o que dá valor à pergunta.",
+    });
+  }
+
+  const withDraft = [...ctx.bank, draftBank];
+  const duplicates = findDuplicateGroups(withDraft).filter((g) =>
+    g.members.some((m) => m.ref === draftBank.ref)
+  );
+  const pairs = findPairFindings(withDraft).filter(
+    (p) => p.a.ref === draftBank.ref || p.b.ref === draftBank.ref
+  );
+
+  for (const group of duplicates) {
+    const others = group.members.filter((m) => m.ref !== draftBank.ref);
+    // A contradiction is the one tier that is never legitimate: same stem,
+    // same options, disagreeing on which option is right. One of the two is
+    // simply wrong, and writing the second one hides it.
+    findings.push({
+      level: group.tier === "contradiction" ? "error" : "warning",
+      code: `duplicate-${group.tier}`,
+      message: `${group.tier}: já existe em ${others.map((m) => m.ref).join(", ")}.`,
+      detail: others.map((m) => `${m.file} — resposta certa: ${m.correctText}`),
+    });
+  }
+
+  for (const pair of pairs) {
+    const other = pair.a.ref === draftBank.ref ? pair.b : pair.a;
+    findings.push({
+      level: "warning",
+      code: `near-${pair.kind}`,
+      message:
+        pair.kind === "polarity"
+          ? `Possível inversão de ${other.ref} (enunciado ${Math.round(pair.stemSimilarity * 100)}% semelhante, polaridade oposta).`
+          : `Semelhante a ${other.ref} (enunciado ${Math.round(pair.stemSimilarity * 100)}%, opções ${Math.round(pair.answerSimilarity * 100)}%).`,
+      detail: [`${other.question}`, `${other.file} — resposta certa: ${other.correctText}`],
+    });
+  }
+
+  return { question, findings, duplicates, pairs };
+}
+
+export type OrderAnchor =
+  | { kind: "after"; id: number }
+  | { kind: "before"; id: number }
+  | { kind: "end" };
+
+/**
+ * Places a new id in the editorial order.
+ *
+ * The order is by subject, not by id — cat3's 210-213 sit at positions 8, 10,
+ * 19 and 31 — and it drives the browse sequence, so appending is a choice
+ * rather than the natural default. The caller has to make it explicitly.
+ */
+export function insertIntoOrder(
+  order: readonly number[],
+  id: number,
+  anchor: OrderAnchor
+): number[] {
+  if (order.includes(id)) {
+    throw new Error(`id ${id} is already in the order`);
+  }
+  if (anchor.kind === "end") return [...order, id];
+
+  const at = order.indexOf(anchor.id);
+  if (at === -1) {
+    throw new Error(`anchor id ${anchor.id} is not in the order`);
+  }
+  const next = [...order];
+  next.splice(anchor.kind === "after" ? at + 1 : at, 0, id);
+  return next;
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "data:fonte-pages": "bun run scripts/resolve-fonte-pages.ts",
     "content:build": "bun run scripts/content-build.ts",
     "content:check": "bun run scripts/content-build.ts --check",
+    "content:new": "bun run scripts/content-new.ts",
     "qbank": "bun run scripts/qbank.ts"
   },
   "dependencies": {

--- a/scripts/content-new.ts
+++ b/scripts/content-new.ts
@@ -1,0 +1,668 @@
+#!/usr/bin/env bun
+/**
+ * Adds a question to the bank.
+ *
+ *   bun run content:new                      # interactive
+ *   bun run content:new --from draft.mdx     # a question file, id left out
+ *   cat draft.mdx | bun run content:new --from - --cat 3 --yes
+ *   bun run content:new --from draft.mdx --dry-run
+ *
+ * It writes the two files a question owns — `content/questions/cat{n}/{id}.mdx`
+ * and one line of `order` in `category.json` — then regenerates that
+ * category's artifacts, leaving the tree in the state `content:check` expects.
+ *
+ * Everything it decides is in `lib/content/author.ts`; this file is I/O,
+ * prompting and formatting, the same split as `qbank`.
+ *
+ * The draft format is the destination format. `--from` takes a question file
+ * with the `id` omitted, so there is no second schema to learn, a rejected
+ * draft is fixed and re-fed unchanged, and the file that is finally written is
+ * the file that was reviewed.
+ */
+import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import readline from "node:readline";
+import { spawnSync } from "node:child_process";
+import matter from "gray-matter";
+import {
+  loadCategory,
+  emitCategory,
+  serializeManifest,
+  CategoryManifestSchema,
+  MANIFEST_FILE,
+  type CategoryManifest,
+} from "../lib/content/build";
+import { serializeQuestionFile, questionFileName } from "../lib/content/source";
+import { buildBank, type BankQuestion } from "../lib/content/analysis";
+import {
+  reviewDraft,
+  insertIntoOrder,
+  nextId,
+  hasErrors,
+  EXPECTED_OPTIONS,
+  type Draft,
+  type Finding,
+  type OrderAnchor,
+} from "../lib/content/author";
+import { TOPICS, topicShortLabel } from "../lib/config/topics";
+import { CATEGORIES, type CategoryId } from "../lib/config/categories";
+import type { ContentCategory } from "../lib/content/schema";
+
+// Resolved from the working directory, like the other content scripts; these
+// are always invoked via `bun run` from the project root.
+const ROOT = process.cwd();
+const EXAMS_DIR = join(ROOT, "public", "exams");
+const PUBLIC_DIR = join(ROOT, "public");
+
+/* -------------------------------------------------------------------------- */
+/* Arguments                                                                   */
+/* -------------------------------------------------------------------------- */
+
+const argv = process.argv.slice(2);
+const flags = new Map<string, string | true>();
+for (let i = 0; i < argv.length; i++) {
+  const arg = argv[i] ?? "";
+  if (!arg.startsWith("--")) continue;
+  const [name, inline] = arg.slice(2).split("=", 2);
+  if (!name) continue;
+  if (inline !== undefined) {
+    flags.set(name, inline);
+    continue;
+  }
+  const next = argv[i + 1];
+  if (next !== undefined && !next.startsWith("--")) {
+    flags.set(name, next);
+    i++;
+  } else {
+    flags.set(name, true);
+  }
+}
+const flag = (name: string): string | undefined => {
+  const value = flags.get(name);
+  return typeof value === "string" ? value : undefined;
+};
+const has = (name: string) => flags.has(name);
+
+const dryRun = has("dry-run");
+const assumeYes = has("yes");
+const force = has("force");
+
+/* -------------------------------------------------------------------------- */
+/* Output                                                                      */
+/* -------------------------------------------------------------------------- */
+
+const ESC = "\u001b";
+const colour = process.stdout.isTTY === true;
+const paint = (code: string, text: string) =>
+  colour ? `${ESC}[${code}m${text}${ESC}[0m` : text;
+const bold = (t: string) => paint("1", t);
+const dim = (t: string) => paint("2", t);
+const red = (t: string) => paint("31", t);
+const green = (t: string) => paint("32", t);
+const yellow = (t: string) => paint("33", t);
+
+/** Truncates for a one-line summary, on a word boundary where it can. */
+function clip(text: string, width: number): string {
+  const flat = text.replace(/\s+/g, " ").trim();
+  if (flat.length <= width) return flat;
+  const cut = flat.slice(0, width - 1);
+  const space = cut.lastIndexOf(" ");
+  return `${space > width * 0.6 ? cut.slice(0, space) : cut}…`;
+}
+
+function die(message: string, ...detail: string[]): never {
+  console.error(`\n${red("✗")} ${message}`);
+  for (const d of detail) console.error(`  ${d}`);
+  closePrompts();
+  process.exit(1);
+}
+
+function usage(): never {
+  console.log(bold("content:new — acrescentar uma pergunta ao banco"));
+  console.log();
+  console.log("  bun run content:new                     interativo");
+  console.log("  bun run content:new --from draft.mdx    a partir de um ficheiro (- para stdin)");
+  console.log();
+  console.log(dim("  --cat 3        categoria (perguntada se faltar)"));
+  console.log(dim("  --after 107    posição no order; também --before 108 ou --end"));
+  console.log(dim("  --dry-run      mostra o que escreveria, sem escrever nada"));
+  console.log(dim("  --yes          não pergunta (obrigatório quando stdin é um pipe)"));
+  console.log(dim("  --force        escreve apesar dos avisos"));
+  console.log();
+  console.log(dim("  O ficheiro de --from é um ficheiro de pergunta com o `id` omitido."));
+  process.exit(0);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Prompting                                                                   */
+/* -------------------------------------------------------------------------- */
+
+let rl: readline.Interface | null = null;
+const interactive = process.stdin.isTTY === true;
+
+function prompts(): readline.Interface {
+  if (rl === null) {
+    rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  }
+  return rl;
+}
+function closePrompts(): void {
+  rl?.close();
+  rl = null;
+}
+
+const ask = (question: string): Promise<string> =>
+  new Promise((resolve) => prompts().question(question, resolve));
+
+async function askText(label: string, { required = true } = {}): Promise<string> {
+  for (;;) {
+    const answer = (await ask(`${label} ${dim("›")} `)).trim();
+    if (answer.length > 0 || !required) return answer;
+    console.log(dim("  (obrigatório)"));
+  }
+}
+
+/**
+ * A numbered list rather than an arrow-key menu: raw mode would have to be
+ * handed back and forth with $EDITOR, and a number is one keystroke either way.
+ */
+async function askChoice<T>(
+  label: string,
+  options: readonly { value: T; label: string; hint?: string }[],
+  { allowNone = false } = {}
+): Promise<T | null> {
+  console.log(`\n${bold(label)}`);
+  options.forEach((o, i) => {
+    console.log(`  ${String(i + 1).padStart(2)}  ${o.label}${o.hint ? `  ${dim(o.hint)}` : ""}`);
+  });
+  if (allowNone) console.log(dim("   —  Enter para nenhum"));
+
+  for (;;) {
+    const raw = (await ask(`${dim("nº ›")} `)).trim();
+    if (raw.length === 0 && allowNone) return null;
+    const chosen = options[Number.parseInt(raw, 10) - 1];
+    if (chosen) return chosen.value;
+    console.log(dim(`  1-${options.length}${allowNone ? " ou Enter" : ""}`));
+  }
+}
+
+async function confirm(question: string, fallback = false): Promise<boolean> {
+  if (assumeYes) return true;
+  if (!interactive) return fallback;
+  const answer = (await ask(`${question} ${dim("[s/N]")} `)).trim().toLowerCase();
+  return answer === "s" || answer === "sim" || answer === "y" || answer === "yes";
+}
+
+/**
+ * The explanation body, through $EDITOR.
+ *
+ * Prose at a readline prompt is miserable, and this is the field that gives a
+ * question its value. The interface is closed first: the editor takes over the
+ * terminal, and two readers on one stdin fight over the keystrokes.
+ */
+async function askExplanation(): Promise<string | null> {
+  const editor = process.env.VISUAL ?? process.env.EDITOR;
+  if (editor === undefined || editor.trim().length === 0) {
+    console.log(dim("  $EDITOR não definido — escreva a explicação, terminando com uma linha só com ."));
+    const lines: string[] = [];
+    for (;;) {
+      const line = await ask(dim("| "));
+      if (line.trim() === ".") break;
+      lines.push(line);
+    }
+    const typed = lines.join("\n").trim();
+    return typed.length > 0 ? typed : null;
+  }
+
+  const tmp = join(tmpdir(), `content-new-${process.pid}.mdx`);
+  writeFileSync(tmp, "");
+  closePrompts();
+  const result = spawnSync(editor, [tmp], { stdio: "inherit", shell: true });
+  if (result.error) {
+    unlinkSync(tmp);
+    die(`não foi possível abrir ${editor}`, result.error.message);
+  }
+  const body = readFileSync(tmp, "utf-8").trim();
+  unlinkSync(tmp);
+  return body.length > 0 ? body : null;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Loading                                                                     */
+/* -------------------------------------------------------------------------- */
+
+function sourceDirOf(category: CategoryId): string {
+  return join(ROOT, "content", "questions", `cat${category}`);
+}
+
+function loadAll(): { categories: ContentCategory[]; bank: BankQuestion[] } {
+  const categories = CATEGORIES.filter((c) => existsSync(sourceDirOf(c))).map((c) =>
+    loadCategory(sourceDirOf(c))
+  );
+  return { categories, bank: buildBank(categories) };
+}
+
+function loadManifest(category: CategoryId): CategoryManifest {
+  return CategoryManifestSchema.parse(
+    JSON.parse(readFileSync(join(sourceDirOf(category), MANIFEST_FILE), "utf-8"))
+  );
+}
+
+/** Existence of an exam PDF, with the wrong-prefix hint `findDanglingPdfs` gives. */
+function pdfLookup(pdf: string): { exists: boolean; alsoIn: string[] } {
+  if (existsSync(join(EXAMS_DIR, `${pdf}.pdf`))) return { exists: true, alsoIn: [] };
+  const stem = pdf.slice(pdf.indexOf("/") + 1);
+  const alsoIn = CATEGORIES.filter(
+    (c) => `cat${c}` !== pdf.split("/")[0] && existsSync(join(EXAMS_DIR, `cat${c}`, `${stem}.pdf`))
+  ).map((c) => `cat${c}`);
+  return { exists: false, alsoIn };
+}
+
+const imageExists = (rel: string) => existsSync(join(PUBLIC_DIR, rel));
+
+/* -------------------------------------------------------------------------- */
+/* Drafts from a file                                                          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Reads a draft in the destination file format.
+ *
+ * Nothing is coerced here beyond the category: an unexpected shape has to
+ * reach the schema so the error names the field, rather than being quietly
+ * reinterpreted into something that parses.
+ */
+function draftFromFile(raw: string, category: CategoryId | null): Draft {
+  const { data, content } = matter(raw);
+  const fields = data as Record<string, unknown>;
+
+  // Coerced rather than type-checked: `category: 3` is a YAML number and
+  // `category: "3"` a string, and the difference is not one an author should
+  // have to know about.
+  const declared =
+    fields.category === undefined || fields.category === null
+      ? null
+      : String(fields.category).replace(/^cat/, "");
+  const resolved = category ?? declared;
+  if (resolved === null || !CATEGORIES.includes(resolved as CategoryId)) {
+    die(
+      "categoria em falta ou desconhecida",
+      "Passe --cat 3, ou acrescente `category: 3` ao frontmatter do rascunho."
+    );
+  }
+
+  const body = content.trim();
+  return {
+    category: resolved as CategoryId,
+    id: typeof fields.id === "number" ? fields.id : undefined,
+    question: fields.question as string,
+    answers: fields.answers as Draft["answers"],
+    topic: (fields.topic ?? null) as string | null,
+    sources: fields.sources as Draft["sources"],
+    image: (fields.image ?? null) as string | null,
+    tutorial: (fields.tutorial ?? null) as string | null,
+    calc: (fields.calc ?? null) as string | null,
+    explanation: body.length > 0 ? body : null,
+  };
+}
+
+function readDraftSource(from: string): string {
+  if (from === "-") return readFileSync(0, "utf-8");
+  if (!existsSync(from)) die(`${from} não existe`);
+  return readFileSync(from, "utf-8");
+}
+
+/* -------------------------------------------------------------------------- */
+/* Interactive draft                                                           */
+/* -------------------------------------------------------------------------- */
+
+async function askCategory(): Promise<CategoryId> {
+  const chosen = await askChoice<CategoryId>(
+    "Categoria",
+    CATEGORIES.map((c) => ({
+      value: c,
+      label: `cat${c}`,
+      hint: c === "3" ? "iniciado" : c === "1" ? "avançado" : "",
+    }))
+  );
+  return chosen ?? "3";
+}
+
+async function askAnswers(): Promise<Draft["answers"]> {
+  console.log(`\n${bold("Opções")} ${dim(`(${EXPECTED_OPTIONS}; Enter numa vazia termina)`)}`);
+  const texts: string[] = [];
+  for (let i = 0; i < 8; i++) {
+    const text = await askText(`  ${i + 1}`, { required: i < 2 });
+    if (text.length === 0) break;
+    texts.push(text);
+  }
+
+  const correct = await askChoice<number>(
+    "Qual é a correta?",
+    texts.map((t, i) => ({ value: i, label: clip(t, 90) }))
+  );
+  return texts.map((text, i) => (i === correct ? { text, correct: true } : { text }));
+}
+
+/**
+ * The taxonomy as a picker.
+ *
+ * `topic` is free text in the schema, and a misspelled slug is the one mistake
+ * in this file that nothing reports: the label silently stops rendering and
+ * the browse filter silently stops matching. Choosing from the list makes it
+ * unrepresentable rather than merely detectable.
+ */
+async function askTopic(): Promise<string | null> {
+  return askChoice<string>(
+    "Matéria",
+    TOPICS.map((t) => ({
+      value: t.slug,
+      label: t.slug.padEnd(16),
+      hint: `${t.shortPt} — a partir de cat${t.examinedFrom}`,
+    })),
+    { allowNone: true }
+  );
+}
+
+/**
+ * The two numbers are asked as two sentences.
+ *
+ * `question` is the pergunta number printed in the paper and `page` is the PDF
+ * page; the papers carry about four questions per page, so they are unrelated,
+ * and typing one into both fields is the easiest mistake here to make.
+ */
+async function askSources(): Promise<Draft["sources"]> {
+  const sources: NonNullable<Draft["sources"]> = [];
+  for (;;) {
+    console.log(
+      `\n${bold("Prova oficial")} ${dim(
+        sources.length === 0 ? "(Enter para saltar)" : "(Enter para terminar)"
+      )}`
+    );
+    const pdf = await askText("  Ficheiro sob public/exams (ex.: cat3/2023_08_18)", {
+      required: false,
+    });
+    if (pdf.length === 0) return sources;
+
+    const { exists, alsoIn } = pdfLookup(pdf);
+    console.log(
+      exists
+        ? `  ${green("✓")} ${dim("existe em public/exams")}`
+        : `  ${yellow("!")} ${dim(
+            alsoIn.length > 0
+              ? `não existe aqui, mas existe em ${alsoIn.join(", ")}`
+              : "não existe em public/exams"
+          )}`
+    );
+
+    const question = Number.parseInt(await askText("  Número da pergunta impresso na prova"), 10);
+    const pageRaw = await askText("  Página do PDF em que está impressa (Enter se desconhecida)", {
+      required: false,
+    });
+
+    sources.push({
+      pdf,
+      question,
+      page: pageRaw.length > 0 ? Number.parseInt(pageRaw, 10) : null,
+    });
+  }
+}
+
+async function askDraft(): Promise<Draft> {
+  const catFlag = flag("cat");
+  const category =
+    catFlag === undefined ? await askCategory() : (catFlag.replace(/^cat/, "") as CategoryId);
+  if (!CATEGORIES.includes(category)) {
+    die(`categoria ${category} desconhecida`, `Categorias: ${CATEGORIES.join(", ")}`);
+  }
+
+  const { order } = loadManifest(category);
+  console.log(
+    `\n${dim(
+      `cat${category}: ${order.length} perguntas, id mais alto ${Math.max(...order)}, novo id`
+    )} ${bold(String(nextId(order)))}`
+  );
+
+  console.log();
+  const question = await askText(bold("Enunciado"));
+  const answers = await askAnswers();
+  const topic = await askTopic();
+  const sources = await askSources();
+
+  const image = await askText(
+    `\n${bold("Imagem")} ${dim("relativa a public/, ex.: images/cat3/x.png (Enter se nenhuma)")}`,
+    { required: false }
+  );
+
+  console.log(`\n${bold("Explicação")} ${dim("— o corpo MDX. Pode ficar vazia.")}`);
+  console.log(dim(`  ${clip(question, 100)}`));
+  const explanation = await askExplanation();
+
+  return {
+    category,
+    question,
+    answers,
+    topic,
+    sources,
+    image: image.length > 0 ? image : null,
+    explanation,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Reporting                                                                   */
+/* -------------------------------------------------------------------------- */
+
+function printSummary(draft: Draft, id: number, review: ReturnType<typeof reviewDraft>): void {
+  const file = join("content", "questions", `cat${draft.category}`, questionFileName(id));
+  console.log(`\n${bold(`cat${draft.category}#${id}`)}  ${dim(file)}`);
+
+  const q = review.question;
+  if (q === null) return;
+
+  console.log(`  ${q.question}`);
+  for (const a of q.answers) {
+    console.log(`   ${a.correct ? green("✓") : dim("·")} ${clip(a.text, 100)}`);
+  }
+  const marks = [
+    q.topic ?? "sem matéria",
+    q.sources.length > 0
+      ? q.sources
+          .map((s) => `${s.pdf} pergunta ${s.question}${s.page === null ? "" : ` p.${s.page}`}`)
+          .join("; ")
+      : "sem fonte",
+    q.explanation === null ? "sem explicação" : `explicação, ${q.explanation.length} caracteres`,
+  ];
+  console.log(`  ${dim(marks.join("  |  "))}`);
+}
+
+function printFindings(findings: readonly Finding[]): void {
+  if (findings.length === 0) {
+    console.log(`\n${green("✓")} sem problemas`);
+    return;
+  }
+  console.log();
+  for (const f of findings) {
+    console.log(`${f.level === "error" ? red("✗") : yellow("!")} ${f.message}  ${dim(f.code)}`);
+    for (const d of f.detail ?? []) console.log(`    ${dim(d)}`);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Order placement                                                             */
+/* -------------------------------------------------------------------------- */
+
+const anchorId = (raw: string) => Number.parseInt(raw.replace(/^.*#/, ""), 10);
+
+function anchorFromFlags(): OrderAnchor | null {
+  if (has("end")) return { kind: "end" };
+  const after = flag("after");
+  if (after !== undefined) return { kind: "after", id: anchorId(after) };
+  const before = flag("before");
+  if (before !== undefined) return { kind: "before", id: anchorId(before) };
+  return null;
+}
+
+/**
+ * Where the question goes in the browse sequence.
+ *
+ * Left to a human on purpose: the order is by subject — cat3's 210-213 sit at
+ * positions 8, 10, 19 and 31 — so the right slot is beside the questions about
+ * the same thing, and no rule here can find it. What the tool can do is show
+ * that neighbourhood instead of quietly appending.
+ */
+async function askAnchor(category: ContentCategory, topic: string | null): Promise<OrderAnchor> {
+  const entries = category.questions.map((q, i) => ({ position: i + 1, q }));
+  const sameTopic = topic === null ? [] : entries.filter((e) => e.q.topic === topic);
+  const shown = sameTopic.length > 0 ? sameTopic.slice(-12) : entries.slice(-8);
+
+  console.log(`\n${bold("Posição no order")} ${dim("— é editorial, não numérica")}`);
+  console.log(
+    dim(
+      sameTopic.length > 0
+        ? `  ${sameTopic.length} perguntas de ${topicShortLabel(topic ?? "", "pt") ?? topic}, as últimas ${shown.length}:`
+        : "  fim do order:"
+    )
+  );
+  for (const e of shown) {
+    const position = dim(`pos ${String(e.position).padStart(3)}`);
+    console.log(`  ${position}  ${bold(`#${e.q.id}`)}  ${clip(e.q.question, 76)}`);
+  }
+
+  for (;;) {
+    const raw = (
+      await ask(`\nInserir depois de que id? ${dim("(Enter = no fim do order)")} ${dim("›")} `)
+    ).trim();
+    if (raw.length === 0) return { kind: "end" };
+    const id = anchorId(raw);
+    if (category.questions.some((q) => q.id === id)) return { kind: "after", id };
+    console.log(dim(`  ${id} não está no order de cat${category.id}`));
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Run                                                                         */
+/* -------------------------------------------------------------------------- */
+
+async function main(): Promise<void> {
+  if (has("help") || has("h")) usage();
+
+  const from = flag("from");
+  if (from === undefined && !interactive) {
+    die(
+      "stdin não é um terminal e não foi passado --from",
+      "bun run content:new --from draft.mdx --cat 3 --yes"
+    );
+  }
+
+  const catFlag = flag("cat");
+  const draft =
+    from === undefined
+      ? await askDraft()
+      : draftFromFile(
+          readDraftSource(from),
+          catFlag === undefined ? null : (catFlag.replace(/^cat/, "") as CategoryId)
+        );
+
+  const sourceDir = sourceDirOf(draft.category);
+  if (!existsSync(sourceDir)) die(`${sourceDir} não existe`);
+
+  const manifest = loadManifest(draft.category);
+  const { categories, bank } = loadAll();
+  const category = categories.find((c) => c.id === draft.category);
+  if (category === undefined) die(`cat${draft.category} não carregou`);
+
+  const id = draft.id ?? nextId(manifest.order);
+  const review = reviewDraft(
+    { ...draft, id },
+    {
+      category: draft.category,
+      anacomFile: manifest.anacomFile,
+      // The draft is not in the bank yet, so there is nothing to exclude — and
+      // it is compared against all three categories, since the duplicate that
+      // matters most is the one already examined at another level.
+      bank,
+      order: manifest.order,
+      pdfLookup,
+      imageExists,
+    }
+  );
+
+  printSummary(draft, id, review);
+  printFindings(review.findings);
+
+  const question = review.question;
+  if (question === null || hasErrors(review.findings)) {
+    console.error(`\n${red("✗")} não escrito — corrija os erros acima.`);
+    closePrompts();
+    process.exit(1);
+  }
+
+  if (review.findings.length > 0 && !force) {
+    if (!(await confirm(`\n${review.findings.length} aviso(s). Continuar?`))) {
+      console.log(
+        dim(
+          interactive || assumeYes
+            ? "cancelado"
+            : "avisos por confirmar — reveja-os e repita com --yes, ou --force"
+        )
+      );
+      closePrompts();
+      process.exit(1);
+    }
+  }
+
+  const anchor =
+    anchorFromFlags() ?? (interactive ? await askAnchor(category, question.topic) : { kind: "end" });
+  const order = insertIntoOrder(manifest.order, id, anchor);
+  const position = order.indexOf(id) + 1;
+
+  const questionFile = join(sourceDir, questionFileName(id));
+  const body = serializeQuestionFile(question);
+
+  if (dryRun) {
+    console.log(`\n${bold("--dry-run")} ${dim("— nada foi escrito")}`);
+    console.log(`\n${dim(`${questionFile.replace(`${ROOT}/`, "")}:`)}`);
+    console.log(body.replace(/^/gm, "  ").trimEnd());
+    console.log(
+      `\n${dim(
+        `category.json: order posição ${position} de ${order.length}, depois de ${
+          order[position - 2] ?? "—"
+        }`
+      )}`
+    );
+    closePrompts();
+    return;
+  }
+
+  writeFileSync(questionFile, body);
+  writeFileSync(join(sourceDir, MANIFEST_FILE), serializeManifest({ ...manifest, order }));
+
+  // Reloaded rather than reused: this parses back what was just written, so a
+  // round-trip surprise surfaces here instead of in the next `content:check`.
+  const { appJson, notes } = emitCategory(loadCategory(sourceDir), EXAMS_DIR);
+  const dataFile = join(ROOT, "public", "data", `cat${draft.category}.json`);
+  writeFileSync(dataFile, appJson);
+
+  const written = [questionFile, join(sourceDir, MANIFEST_FILE), dataFile];
+  const note = notes.get(id);
+  if (note !== undefined) {
+    const noteFile = join(ROOT, "content", "notes", `cat${draft.category}`, `${id}.mdx`);
+    mkdirSync(join(noteFile, ".."), { recursive: true });
+    writeFileSync(noteFile, note);
+    written.push(noteFile);
+  }
+
+  console.log(
+    `\n${green("✓")} cat${draft.category}#${id}, posição ${position} de ${order.length}`
+  );
+  for (const f of written) console.log(`  ${f.replace(`${ROOT}/`, "")}`);
+  console.log(dim("\n  bun run content:check    # confirma que os artefactos batem certo"));
+  closePrompts();
+}
+
+main()
+  .then(() => closePrompts())
+  .catch((error: unknown) => {
+    die(error instanceof Error ? error.message : String(error));
+  });


### PR DESCRIPTION
`docs/novas-questoes.md` opened by admitting there was no script for this: four
files, a nine-item checklist, and several mistakes nothing reports.

| Footgun | Caught by | When |
| --- | --- | --- |
| `topic: propagaçao` | nothing | never — the card silently loses its label and the browse filter silently stops matching |
| pergunta nº used as `page` | nothing | never |
| id recycled from a gap | nothing | when a stale link starts pointing at a different question |
| contradicts a question in another category | `qbank dupes`, if you remember to run it | after commit |
| missing `order` entry, dangling PDF, missing image | `content:check` | after everything is written |

Most of the machinery already existed — `serializeQuestionFile`,
`serializeManifest`, `findDuplicateGroups`, `auditAnswers`, `isTopicSlug`,
`findMissingImages`. What was missing was the write path.

## Shape

Split like `qbank`: `lib/content/author.ts` holds the rules as pure functions
(the filesystem arrives as two predicates, so the tests need no fixture tree),
and `scripts/content-new.ts` is I/O, prompting and formatting.

```bash
bun run content:new                                  # interactive
bun run content:new --from draft.mdx                 # or a file / stdin
bun run content:new --from draft.mdx --dry-run
```

The draft is **a question file with the `id` omitted** — the destination format,
so there is no second schema to learn, a rejected draft is fixed and re-fed
unchanged, and the file finally written is the file that was reviewed.

## The review runs before anything is written

```
✗ `topic: regulamentaçao` não é um slug da taxonomia — falharia em silêncio.  topic-unknown
! `cat3/2023_08_18`: page 17 igual ao número da pergunta.  page-equals-question
✗ contradiction: já existe em cat3#1.  duplicate-contradiction
    content/questions/cat3/0001.mdx — resposta certa: da UIT

✗ não escrito — corrija os erros acima.
```

- **Errors block, warnings prompt.** A duplicate is not automatically a defect —
  27 groups in the bank are the same regulatory question examined at all three
  levels — so `contradiction` blocks while `exact` across categories only asks.
  `--force` overrides warnings, `--yes` answers everything (required when stdin
  is a pipe).
- **The topic is picked from `TOPICS`, never typed**, which makes the one
  silently-failing mistake unrepresentable rather than merely detectable.
- **The two numbers in a source reference are asked as two sentences**, and
  `page == question` is flagged.
- **The id is the maximum plus one**, never a gap below it.

The `order` position stays a human decision, being editorial rather than
numeric: interactively it shows the same-topic neighbourhood with positions and
asks, otherwise `--after` / `--before` / `--end`. It never appends silently.

Afterwards it regenerates that category's artifacts from what it just wrote,
reloaded from disk, so a round-trip surprise surfaces here rather than in the
next `content:check`.

## Verified

Ran the full path for real: wrote `cat3#214` at position 112, `content:check`
passed on the result, `category.json` was the promised one-line diff, then
reverted. 18 new unit tests; suite, lint and type-check green.
