### PR TITLE
Reply to whoever submitted the exam, and record the real Resend setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,11 +20,17 @@
 # Free tier: 3000 emails/month
 RESEND_API_KEY=re_xxxxxxxxxxxx
 
-# Email address where exam submissions will be sent
+# Where submissions are delivered. This has to be a real, deliverable mailbox:
+# Resend returns a messageId as soon as it accepts the message, so the route
+# answers {success: true} and a bounce here is invisible to the app.
+# Production sends to exames@radioescola.pt.
 EXAM_SUBMISSION_EMAIL=your-email@example.com
 
-# Sender email address (must be verified in Resend)
-# Use "onboarding@resend.dev" for testing, or your own verified domain
+# Sender. Must be an address on a domain verified in Resend — production uses
+# site@radioescola.pt (radioescola.pt is verified: DKIM at
+# resend._domainkey, Return-Path under send.radioescola.pt).
+# "onboarding@resend.dev" needs no DNS but only delivers to the address that
+# owns the Resend account, so it is for local testing only.
 RESEND_FROM_EMAIL=onboarding@resend.dev
 
 # ===========================================

--- a/app/api/submit-exam/route.ts
+++ b/app/api/submit-exam/route.ts
@@ -78,7 +78,12 @@ Submitted at: ${new Date().toISOString()}
     const { data, error } = await resend.emails.send({
       from: FROM_EMAIL,
       to: RECIPIENT_EMAIL,
-      subject: `Exam Submission - Category ${metadata.category}${metadata.year ? ` (${metadata.year})` : ""}`,
+      // Reply goes to whoever submitted, not to FROM_EMAIL — that is a sending
+      // address on the verified domain, not a monitored mailbox. Spread
+      // conditionally: the contact email is optional, and an explicit
+      // `replyTo: undefined` is not something to rely on the SDK ignoring.
+      ...(metadata.email ? { replyTo: metadata.email } : {}),
+      subject: `Submissão de exame - Categoria ${metadata.category}${metadata.year ? ` (${metadata.year})` : ""}`,
       text: emailBody,
       attachments: [
         {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -165,18 +165,37 @@ that tag, or log in by hand first with a `read:packages` token.
 ### 7. Runtime secrets
 
 As `deploy`, create `~/app/app.env` — this is the only configuration that lives
-on the server:
+on the server. The initial setup leaves it in place with every line commented
+out, which reads exactly like a configured file at a glance, so check the
+values and not just the file:
 
 ```bash
 cat > ~/app/app.env <<'EOF'
 RESEND_API_KEY=re_xxxxxxxxxxxx
-EXAM_SUBMISSION_EMAIL=you@example.com
-RESEND_FROM_EMAIL=onboarding@resend.dev
+EXAM_SUBMISSION_EMAIL=exames@radioescola.pt
+RESEND_FROM_EMAIL=site@radioescola.pt
 EOF
 chmod 600 ~/app/app.env
+cd ~/app && docker compose up -d --force-recreate app
 ```
 
 The app runs fine without these; only `/submit-exam` needs them.
+
+- **`up -d`, never `docker compose restart`.** `restart` reuses the existing
+  container with the environment it was created with, so it keeps serving the
+  old values and reports success. Confirm with
+  `docker exec radioescola-app-1 env | grep -E '^RESEND|^EXAM_'` — the file
+  having the right contents is not the same as the container having them
+- **The sender must be on a domain verified in Resend.** `radioescola.pt` is
+  verified: DKIM at `resend._domainkey.radioescola.pt`, Return-Path under
+  `send.radioescola.pt`. Do **not** add `include:amazonses.com` to the root
+  SPF — SPF is checked against the Return-Path, not the `From:` header, so it
+  would spend an SPF lookup for nothing
+- **The recipient must be a real mailbox.** Resend returns a `messageId` on
+  *acceptance*, so the route answers `{success: true}` and the visitor sees a
+  success screen even if the address bounces afterwards. `exames@` is an alias
+  on mailbox.org; if it is ever removed, submissions are lost silently and only
+  the Resend dashboard shows it
 
 `~/app/.env` is a *different* file, written by `release.sh` on every deploy to
 record which image tag is live. Do not put secrets in it.


### PR DESCRIPTION
`/submit-exam` has been answering "Email service not configured" in
production since the site went up: `app.env` on the box was still the
template from the initial setup, every line commented out. That file reads
as configured at a glance, which is most of why it went unnoticed — the
failure is a warning in the container log and a polite error to the
visitor, never a crash.

With the secrets in place the route works, and two things about the mail
it sends are now wrong rather than absent.

The sender is `site@radioescola.pt`, an address on the verified domain but
not a monitored mailbox. Hitting Reply on a submission therefore answers
nobody, while the person who actually sent the exam sits in the body as a
line of text to be copy-pasted. Set `replyTo` to their address instead,
spread conditionally because the contact email is optional and an explicit
`replyTo: undefined` is not something to rely on the SDK ignoring. The body
line stays: an address that fails Resend's header validation fails that one
submission, and the text copy is what survives that.

The subject was English, in a mail with exactly one reader, in Portugal.
Hardcoded rather than routed through `next-intl` — a message key would add
a translation surface to something that should never be English.

The rest is documentation of what this cost to work out:

- `docker compose restart` reuses the container with the environment it was
  created with, so it keeps serving the old values and reports success.
  `up -d` is the one that rereads `app.env`, and the check that means
  anything is `docker exec … env`, not the file's contents.
- Resend returns a `messageId` on *acceptance*. The route answers
  `{success: true}` and the visitor sees a success screen even when the
  address bounces afterwards, so the recipient has to be a real mailbox and
  only the Resend dashboard will say otherwise.
- The root SPF does not list `amazonses` and must not: SPF is checked
  against the Return-Path under `send.radioescola.pt`, not the `From:`
  header, so adding it spends one of ten lookups on nothing.

Verified end to end against production before this change: a minimal
one-page PDF POSTed to `/api/submit-exam` returned a messageId, with no
Resend error in the container log.

