### PR TITLE
Uma porta de entrada: `bun run banco`, e o `qbank` em português

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ bun run content:build # Compile content/questions/** into shipped artifacts
 bun run content:check # Verify artifacts match their source (writes nothing)
 bun run content:new  # Add a question: review, then write all four files
 bun run qbank <cmd>  # Inspect the question bank (search, dupes, coverage, …)
+bun run banco        # Portuguese menu over content:new and qbank
 ```
 
 ## Deployment
@@ -123,6 +124,18 @@ to confirm. `bun run data:fonte-pages` is the manual equivalent.
 `search`, `show`, `dupes`, `pairs`, `coverage`, `topics`, `paper`, `answers`.
 Analysis lives in `lib/content/analysis.ts` as pure functions; the script is
 I/O and formatting. Full guide, in English and Portuguese, in `docs/qbank.md`.
+
+**Its output is Portuguese; its commands and flags are not.** `dupes` and
+`--tier` are the interface and stay English, as do the `--json` payload and the
+baseline keys — only the rendering is translated, and `--tier` accepts either
+form (`gralha` = `typo`). Do not translate a value that is serialised.
+
+`bun run banco` is a Portuguese menu over `qbank` and `content:new`, for anyone
+who would rather not remember the commands. It runs them as subprocesses rather
+than importing them: loading the bank costs ~150 ms, so sharing a process buys
+nothing, and `qbank` dispatches at module scope. It prints the command it is
+about to run, so it doubles as the way to learn the direct form. Prompting
+helpers shared by the two interactive scripts live in `scripts/prompt.ts`.
 
 It is deliberately **not** wired into CI. `content:check` owns per-file
 validity, and duplicating that here would create a second source of truth that

--- a/docs/novas-questoes.md
+++ b/docs/novas-questoes.md
@@ -4,7 +4,9 @@ A fonte de verdade é `content/questions/cat{n}/` — **um ficheiro MDX por
 pergunta**, com os campos estruturados no frontmatter YAML e a explicação no
 corpo do documento. Tudo o resto é gerado a partir daí.
 
-Há duas maneiras de acrescentar uma: com a ferramenta, ou à mão. A ferramenta é a
+Há duas maneiras de acrescentar uma: com a ferramenta, ou à mão. O
+`bun run banco` é um menu em português por cima da ferramenta e do `qbank`, se
+preferir não decorar comandos. A ferramenta é a
 recomendada — faz as mesmas alterações e verifica, **antes de escrever**, o que
 mais nada no projeto verifica. O resto do documento descreve o formato que ela
 escreve, e continua a valer para quem edite os ficheiros diretamente.
@@ -15,11 +17,12 @@ escreve, e continua a valer para quem edite os ficheiros diretamente.
 bun run content:new                                  # interativo, campo a campo
 bun run content:new --from rascunho.mdx              # a partir de um ficheiro
 bun run content:new --from rascunho.mdx --dry-run    # mostra o que escreveria
+bun run content:new --image ~/figura.png             # copia a figura para o sítio
 ```
 
 Escreve os quatro ficheiros de uma vez — a pergunta, a linha do `order` e os
-dois artefactos gerados — e deixa a árvore no estado que o `content:check`
-espera.
+dois artefactos gerados, mais a figura se houver — e deixa a árvore no estado
+que o `content:check` espera.
 
 O rascunho do `--from` é **um ficheiro de pergunta com o `id` omitido**: o
 mesmo formato do destino, para não haver um segundo formato a aprender e para
@@ -29,6 +32,40 @@ descartado ao escrever. Com `--from -` lê do stdin.
 
 O `id` não se escolhe: é o máximo atual mais um, nunca uma lacuna abaixo dele
 (a razão está em [§1](#1-escolher-a-categoria-e-o-id)).
+
+## A figura, se houver
+
+Aponta-se para o ficheiro onde quer que esteja — no Ambiente de Trabalho, nas
+Transferências, onde calhar — e a ferramenta copia-o para
+`public/images/cat{n}/` ao escrever:
+
+```
+Imagem caminho do ficheiro, ou images/cat3/x.png já em public/ (Enter se nenhuma) › ~/Transferências/figura.png
+  ✓ /home/joel/Transferências/figura.png — copiada ao escrever
+```
+
+Fora do modo interativo é `--image ~/figura.png`, ou um `image:` no frontmatter
+do rascunho, que aceita as duas formas. Formatos: `.png`, `.jpg`, `.jpeg`,
+`.gif`, `.webp`, `.svg`.
+
+O caminho é validado **assim que é escrito**, e a pergunta repete-se até estar
+certo. É o único campo que se pode errar sem dar por isso — o resultado é
+uma pergunta com uma imagem partida — e descobri-lo depois do enunciado, das
+opções e da explicação já escritos seria tarde de mais.
+
+Três coisas que a ferramenta decide:
+
+- **O nome é `q{id}.{extensão}`**, não o do ficheiro de origem. `Captura de
+  ecrã 2026-08-27, 14.03.11.png` não é um nome para trazer para o repositório,
+  e um nome descritivo arrisca colidir com uma figura que outra pergunta já
+  refere — o que lhe trocaria o desenho em silêncio. O `id` é novo, por isso o
+  nome não pode estar ocupado; se ainda assim existir, recusa em vez de
+  substituir
+- **Um caminho já sob `public/images/` é referenciado onde está**, não copiado.
+  O mesmo desenho é legitimamente citado por mais do que uma pergunta
+- **A cópia acontece com as escritas**, não no momento da pergunta. Um
+  `--dry-run`, um erro que bloqueia, ou um aviso que se decide não aceitar não
+  deixam nada para trás em `public/`
 
 ## O que verifica antes de escrever
 
@@ -90,6 +127,7 @@ de escrever seja o que for.
 | `content/questions/cat{n}/category.json` | **você** — uma linha no `order` |
 | `public/data/cat{n}.json` | gerado por `content:build` |
 | `content/notes/cat{n}/{id}.mdx` | gerado por `content:build` |
+| `public/images/cat{n}/{ficheiro}` | **você** — a figura, só se a pergunta tiver uma |
 
 **Nunca editar à mão os dois últimos.** O `content:check` recompila a partir da
 origem e falha se um artefacto tiver sido alterado, e está ligado ao
@@ -247,6 +285,10 @@ volta a prefixar.
 O ficheiro tem de existir em `public/images/cat{n}/`, senão a compilação
 **falha**. Isto vale também para `<img src>` dentro da explicação.
 
+À mão, copiar o ficheiro para lá é um passo à parte, e o nome é uma decisão de
+quem escreve. O `content:new` faz as duas coisas — ver
+[A figura, se houver](#a-figura-se-houver).
+
 ### `tutorial` e `calc`
 
 `tutorial` liga a pergunta a um guia de estudo pelo slug (ex.: `codigo-q`);
@@ -380,7 +422,7 @@ relatório, para confirmação humana.
 
 ## Lista de verificação
 
-Com `bun run content:new`, os primeiros seis pontos são a própria ferramenta;
+Com `bun run content:new`, os primeiros sete pontos são a própria ferramenta;
 sobram o último e a decisão da posição no `order`.
 
 - [ ] Procurei com `qbank search` e a pergunta ainda não existe
@@ -389,6 +431,7 @@ sobram o último e a decisão da posição no `order`.
 - [ ] Exatamente uma resposta com `correct: true`
 - [ ] `topic` é um dos 12 slugs válidos (confirmado com `qbank topics`)
 - [ ] `sources` distingue o número da pergunta da página do PDF
+- [ ] Se a pergunta tem figura, o ficheiro está em `public/images/cat{n}/`
 - [ ] `id` inserido no `order` do `category.json`, na posição temática certa
 - [ ] `bun run content:build` executado e artefactos gerados incluídos no commit
 - [ ] `bun run content:check` e `bun run qbank dupes` passam

--- a/docs/qbank.md
+++ b/docs/qbank.md
@@ -13,6 +13,36 @@ It reads `content/questions/**` directly — the MDX sources, not
 file you would edit, and the JSON is a build artifact that goes stale between
 `content:build` runs.
 
+The report is in Portuguese; the commands and flags are not. `dupes`, `--tier`
+and `--json` are the interface, and this document is the reference for both.
+
+## The menu, if you would rather not remember any of this
+
+```
+bun run banco
+```
+
+A Portuguese menu over this tool and `content:new`. It asks what you want,
+collects the arguments, and then runs exactly the command documented here —
+printing it first, so the menu is also how you learn the direct form:
+
+```
+Banco de questões
+   1  Acrescentar uma pergunta  content:new
+   2  Procurar uma pergunta  por texto
+   3  Ver uma pergunta  ex.: cat3#12
+   4  Duplicados  grupos que discordam entre si
+   …
+   —  Enter para sair
+nº › 2
+Termo a procurar › dipolo
+
+  bun run scripts/qbank.ts search dipolo --cat 3
+```
+
+It adds nothing of its own: every option is one of the commands below, and both
+tools keep working on their own.
+
 ## Why it exists
 
 `content:check` already validates every question file and verifies the shipped
@@ -64,13 +94,13 @@ A question is addressed as `cat3#12`; `3#12` and `cat3/12` also parse.
 
 ```
 $ bun run qbank search "carga artificial"
-5 question(s) matching carga artificial
+5 pergunta(s) com carga artificial
 
 cat3#93  Medições  content/questions/cat3/0093.mdx:4
   Porque se deve utilizar uma carga artificial quando estamos a testar um emissor?
    · Para diminuir de forma significativa o consumo de energia
    ✓ Para evitar que eventuais emissões espúrias do emissor em teste sejam radiadas…
-  no sources
+  sem fonte
 ```
 
 Matching folds accents and case, so `propagacao` finds "propagação" and
@@ -92,7 +122,7 @@ disagree on.
 The core command. As of August 2026:
 
 ```
-126 group(s): 4 typo, 33 divergent, 64 shared-answers, 25 exact
+126 grupo(s): 4 gralha, 33 divergente, 64 respostas partilhadas, 25 exato
 ```
 
 **A duplicate is not automatically a defect.** The same regulatory question is
@@ -102,11 +132,11 @@ they are to be a real bug:
 
 | Tier | Means | Read as |
 | --- | --- | --- |
-| `contradiction` | Same question, same options, **disagreeing on which is correct** | One of them is simply wrong |
-| `typo` | Same question, options differ below an edit-distance threshold | Usually a transcription slip; sometimes a wording variant |
-| `divergent` | Same stem, materially different options | A real variant, or a stem that needs disambiguating |
-| `shared-answers` | Different stems over an identical option set | A rephrasing, or options pasted onto the wrong question |
-| `exact` | Identical throughout | Benign across categories; redundant within one |
+| `contradiction` · contradição | Same question, same options, **disagreeing on which is correct** | One of them is simply wrong |
+| `typo` · gralha | Same question, options differ below an edit-distance threshold | Usually a transcription slip; sometimes a wording variant |
+| `divergent` · divergente | Same stem, materially different options | A real variant, or a stem that needs disambiguating |
+| `shared-answers` · respostas partilhadas | Different stems over an identical option set | A rephrasing, or options pasted onto the wrong question |
+| `exact` · exato | Identical throughout | Benign across categories; redundant within one |
 
 Beyond the tier, each group reports what its members disagree on. Across the
 bank: 52 groups where one copy is sourced and its twin is not, 37 where one has
@@ -116,14 +146,17 @@ an explanation and the other does not, 12 that disagree on `topic`, 3 on
 That first number is the most actionable thing in the report. A same-category
 pair where one copy has no provenance is usually one question entered twice.
 
-`--tier contradiction,typo` narrows to the tiers worth acting on.
+`--tier contradiction,typo` narrows to the tiers worth acting on. The report
+prints the Portuguese label, and `--tier` takes either form — `--tier gralha`
+and `--tier typo` select the same groups. The English values stay canonical:
+they are what `--json` and the baseline keys carry.
 
 ## pairs
 
 Fuzzy matching, for near-duplicates that share no exact key.
 
 ```
-77 pair(s): 0 polarity flip, 77 near-stem
+77 par(es): 0 de polaridade invertida, 77 de enunciado parecido
 ```
 
 A **polarity flip** is two near-identical questions asking for opposite answers
@@ -150,7 +183,7 @@ Jaccard over tokens.
 ## coverage
 
 ```
-      total  sourced  refs  with page  explained  images  topic
+      total  com fonte  refs  com página  explicadas  imagens  matéria
 cat3  209    60 29%   75    75 100%    209 100%   15      209 100%
 cat2  418    317 76%  893   0 0%       158 38%    8       418 100%
 cat1  389    194 50%  285   98 34%     389 100%   15      389 100%
@@ -175,7 +208,7 @@ outlier:
   because `schema.ts` types the field as free text, so a misspelled slug passes
   `content:check` and then fails *invisibly*: `topicShortLabel` returns null,
   the card renders no chip, and the browse filter ignores the question
-- **untagged** — `topic: null`
+- **sem matéria** (`untagged`) — `topic: null`
 - **above entry level** — 29 category 3 questions in a chapter ANACOM's Anexo 1
   marks as starting at category 2. Strictly advisory: the annex is from 2009 and
   real 2023 category 3 papers do examine antennas, receivers and propagation.
@@ -185,10 +218,10 @@ outlier:
 
 ```
 $ bun run qbank paper
-36 paper(s) cited by the bank
+36 prova(s) citada(s) pelo banco
 
-cat1/2011_12_13           39 cited  39 with page  2 unclaimed  1 collisions
-cat1/2014_12_19           37 cited   0 with page  4 unclaimed  3 collisions  PDF absent
+cat1/2011_12_13           39 citadas  39 com página  2 por reclamar  1 colisões
+cat1/2014_12_19           37 citadas  0 com página  4 por reclamar  3 colisões  PDF ausente
 ```
 
 Naming a paper lists its perguntas in order with the question that claims each
@@ -206,13 +239,13 @@ Test-construction audit. The current numbers are healthy, which is worth keeping
 as a regression baseline rather than a one-off check:
 
 ```
-correct-answer position
+posição da resposta certa
   a   239  24%
   b   264  26%
   c   269  26%
   d   244  24%
 
-longest option is correct  267/1016 (26%)   chance is about 25%
+a opção mais longa é a certa  267/1016 (26%)  o acaso ronda os 25%
 ```
 
 A spike in either would mean the bank is guessable without knowing the material.
@@ -316,6 +349,37 @@ Lê diretamente `content/questions/**` — os ficheiros MDX de origem, não
 ficheiro que se vai editar, e o JSON é um artefacto de compilação que fica
 desatualizado entre execuções de `content:build`.
 
+O relatório é em português; os comandos e as opções não são. `dupes`, `--tier`
+e `--json` são a interface, e este documento é a referência das duas coisas.
+
+## O menu, para não ter de decorar nada disto
+
+```
+bun run banco
+```
+
+Um menu em português por cima desta ferramenta e do `content:new`. Pergunta o
+que se quer, recolhe os argumentos, e corre exatamente o comando documentado
+aqui — mostrando-o primeiro, para que o menu sirva também para aprender a forma
+direta:
+
+```
+Banco de questões
+   1  Acrescentar uma pergunta  content:new
+   2  Procurar uma pergunta  por texto
+   3  Ver uma pergunta  ex.: cat3#12
+   4  Duplicados  grupos que discordam entre si
+   …
+   —  Enter para sair
+nº › 2
+Termo a procurar › dipolo
+
+  bun run scripts/qbank.ts search dipolo --cat 3
+```
+
+Não acrescenta nada de seu: cada opção é um dos comandos abaixo, e as duas
+ferramentas continuam a funcionar sozinhas.
+
 ## Porque existe
 
 O `content:check` já valida cada ficheiro de pergunta e verifica se os
@@ -369,13 +433,13 @@ Uma pergunta identifica-se por `cat3#12`; `3#12` e `cat3/12` também são aceite
 
 ```
 $ bun run qbank search "carga artificial"
-5 question(s) matching carga artificial
+5 pergunta(s) com carga artificial
 
 cat3#93  Medições  content/questions/cat3/0093.mdx:4
   Porque se deve utilizar uma carga artificial quando estamos a testar um emissor?
    · Para diminuir de forma significativa o consumo de energia
    ✓ Para evitar que eventuais emissões espúrias do emissor em teste sejam radiadas…
-  no sources
+  sem fonte
 ```
 
 A correspondência ignora acentos e maiúsculas, por isso `propagacao` encontra
@@ -398,7 +462,7 @@ membros desses grupos discordam.
 O comando central. Em agosto de 2026:
 
 ```
-126 group(s): 4 typo, 33 divergent, 64 shared-answers, 25 exact
+126 grupo(s): 4 gralha, 33 divergente, 64 respostas partilhadas, 25 exato
 ```
 
 **Um duplicado não é automaticamente um defeito.** A mesma pergunta
@@ -408,11 +472,11 @@ níveis estão ordenados pela probabilidade de serem um erro real:
 
 | Nível | Significa | Lê-se como |
 | --- | --- | --- |
-| `contradiction` | Mesma pergunta, mesmas opções, **a discordar sobre qual está certa** | Uma delas está simplesmente errada |
-| `typo` | Mesma pergunta, opções que diferem abaixo de um limiar de distância de edição | Normalmente um lapso de transcrição; por vezes uma variante de redação |
-| `divergent` | Mesmo enunciado, opções materialmente diferentes | Uma variante real, ou um enunciado que precisa de ser desambiguado |
-| `shared-answers` | Enunciados diferentes sobre um conjunto de opções idêntico | Uma reformulação, ou opções coladas na pergunta errada |
-| `exact` | Idênticas em tudo | Inofensivo entre categorias; redundante dentro da mesma |
+| `contradiction` · contradição | Mesma pergunta, mesmas opções, **a discordar sobre qual está certa** | Uma delas está simplesmente errada |
+| `typo` · gralha | Mesma pergunta, opções que diferem abaixo de um limiar de distância de edição | Normalmente um lapso de transcrição; por vezes uma variante de redação |
+| `divergent` · divergente | Mesmo enunciado, opções materialmente diferentes | Uma variante real, ou um enunciado que precisa de ser desambiguado |
+| `shared-answers` · respostas partilhadas | Enunciados diferentes sobre um conjunto de opções idêntico | Uma reformulação, ou opções coladas na pergunta errada |
+| `exact` · exato | Idênticas em tudo | Inofensivo entre categorias; redundante dentro da mesma |
 
 Além do nível, cada grupo reporta em que é que os seus membros discordam. Em
 todo o banco: 52 grupos em que uma cópia tem fonte e a gémea não, 37 em que uma
@@ -423,7 +487,11 @@ Esse primeiro número é o mais acionável do relatório. Um par na mesma catego
 em que uma das cópias não tem proveniência é normalmente uma pergunta inserida
 duas vezes.
 
-`--tier contradiction,typo` restringe aos níveis que vale a pena tratar.
+`--tier contradiction,typo` restringe aos níveis que vale a pena tratar. O
+relatório mostra a etiqueta portuguesa, e o `--tier` aceita as duas formas —
+`--tier gralha` e `--tier typo` selecionam os mesmos grupos. Os valores
+ingleses continuam a ser os canónicos: são os que o `--json` e as chaves da
+linha de base carregam.
 
 ## pairs
 
@@ -431,7 +499,7 @@ Correspondência aproximada, para quase-duplicados que não partilham nenhuma
 chave exata.
 
 ```
-77 pair(s): 0 polarity flip, 77 near-stem
+77 par(es): 0 de polaridade invertida, 77 de enunciado parecido
 ```
 
 Uma **inversão de polaridade** (`polarity flip`) são duas perguntas quase
@@ -459,7 +527,7 @@ Jaccard sobre tokens.
 ## coverage
 
 ```
-      total  sourced  refs  with page  explained  images  topic
+      total  com fonte  refs  com página  explicadas  imagens  matéria
 cat3  209    60 29%   75    75 100%    209 100%   15      209 100%
 cat2  418    317 76%  893   0 0%       158 38%    8       418 100%
 cat1  389    194 50%  285   98 34%     389 100%   15      389 100%
@@ -495,10 +563,10 @@ anomalia:
 
 ```
 $ bun run qbank paper
-36 paper(s) cited by the bank
+36 prova(s) citada(s) pelo banco
 
-cat1/2011_12_13           39 cited  39 with page  2 unclaimed  1 collisions
-cat1/2014_12_19           37 cited   0 with page  4 unclaimed  3 collisions  PDF absent
+cat1/2011_12_13           39 citadas  39 com página  2 por reclamar  1 colisões
+cat1/2014_12_19           37 citadas  0 com página  4 por reclamar  3 colisões  PDF ausente
 ```
 
 Indicar uma prova lista as suas perguntas por ordem, com a pergunta do banco que
@@ -517,13 +585,13 @@ Auditoria à construção do teste. Os números atuais são saudáveis, o que va
 mais como linha de base contra regressões do que como verificação única:
 
 ```
-correct-answer position
+posição da resposta certa
   a   239  24%
   b   264  26%
   c   269  26%
   d   244  24%
 
-longest option is correct  267/1016 (26%)   chance is about 25%
+a opção mais longa é a certa  267/1016 (26%)  o acaso ronda os 25%
 ```
 
 Um pico em qualquer dos dois significaria que o banco é adivinhável sem saber a

--- a/lib/content/analysis.ts
+++ b/lib/content/analysis.ts
@@ -335,7 +335,7 @@ function describeIssues(members: readonly BankQuestion[]): GroupIssue[] {
   if (topics.size > 1) {
     issues.push({
       kind: "topic",
-      detail: members.map((m) => `${m.ref}=${m.topic ?? "untagged"}`).join(", "),
+      detail: members.map((m) => `${m.ref}=${m.topic ?? "sem matéria"}`).join(", "),
     });
   }
 
@@ -343,7 +343,7 @@ function describeIssues(members: readonly BankQuestion[]): GroupIssue[] {
   if (withExplanation.length > 0 && withExplanation.length < members.length) {
     issues.push({
       kind: "explanation",
-      detail: `explained: ${withExplanation.map((m) => m.ref).join(", ")}; missing: ${members
+      detail: `com explicação: ${withExplanation.map((m) => m.ref).join(", ")}; sem: ${members
         .filter((m) => m.explanation === null)
         .map((m) => m.ref)
         .join(", ")}`,
@@ -354,7 +354,7 @@ function describeIssues(members: readonly BankQuestion[]): GroupIssue[] {
   if (withSources.length > 0 && withSources.length < members.length) {
     issues.push({
       kind: "sources",
-      detail: `sourced: ${withSources.map((m) => m.ref).join(", ")}; unsourced: ${members
+      detail: `com fonte: ${withSources.map((m) => m.ref).join(", ")}; sem: ${members
         .filter((m) => m.sources.length === 0)
         .map((m) => m.ref)
         .join(", ")}`,
@@ -365,7 +365,7 @@ function describeIssues(members: readonly BankQuestion[]): GroupIssue[] {
   if (images.size > 1) {
     issues.push({
       kind: "image",
-      detail: members.map((m) => `${m.ref}=${m.image ?? "none"}`).join(", "),
+      detail: members.map((m) => `${m.ref}=${m.image ?? "nenhuma"}`).join(", "),
     });
   }
 
@@ -379,12 +379,15 @@ function describeIssues(members: readonly BankQuestion[]): GroupIssue[] {
     const rawStems = new Set(members.map((m) => m.question));
     const rawAnswers = new Set(members.map((m) => m.answers.map((a) => a.text).join(" | ")));
     if (rawStems.size > 1 || rawAnswers.size > 1) {
-      const parts = [rawStems.size > 1 ? "stem" : null, rawAnswers.size > 1 ? "options" : null]
+      const parts = [
+        rawStems.size > 1 ? "enunciado" : null,
+        rawAnswers.size > 1 ? "opções" : null,
+      ]
         .filter(Boolean)
-        .join(" and ");
+        .join(" e ");
       issues.push({
         kind: "cosmetic",
-        detail: `${parts} differ only in accents, spacing or punctuation`,
+        detail: `${parts} só diferem em acentos, espaços ou pontuação`,
       });
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "content:build": "bun run scripts/content-build.ts",
     "content:check": "bun run scripts/content-build.ts --check",
     "content:new": "bun run scripts/content-new.ts",
-    "qbank": "bun run scripts/qbank.ts"
+    "qbank": "bun run scripts/qbank.ts",
+    "banco": "bun run scripts/banco.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/banco.ts
+++ b/scripts/banco.ts
@@ -1,0 +1,222 @@
+#!/usr/bin/env bun
+/**
+ * Uma porta de entrada para o banco de questões.
+ *
+ *   bun run banco
+ *
+ * Não é uma terceira ferramenta: é um menu por cima das duas que já existem.
+ * Cada opção recolhe o que falta, em português, e depois corre o
+ * `content:new` ou o `qbank` tal como se tivessem sido escritos à mão — as
+ * duas continuam a funcionar sozinhas, e quem souber os comandos não perde
+ * nada por não passar por aqui.
+ *
+ * Corre-os como subprocessos em vez de os importar. Carregar o banco inteiro
+ * custa cerca de 150 ms, por isso não há nada a ganhar em partilhar o
+ * processo, e há a perder: o `qbank` decide o que fazer no topo do módulo, e
+ * importá-lo obrigaria a reescrevê-lo à volta de um `main()`.
+ */
+import { spawnSync } from "node:child_process";
+import { join } from "path";
+import {
+  dim,
+  red,
+  askText,
+  askChoice,
+  closePrompts,
+  interactive,
+} from "./prompt";
+
+const ROOT = process.cwd();
+const QBANK = join("scripts", "qbank.ts");
+const CONTENT_NEW = join("scripts", "content-new.ts");
+
+/* -------------------------------------------------------------------------- */
+/* Correr as ferramentas                                                       */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A interface de leitura é fechada antes de entregar o terminal.
+ *
+ * O filho herda o stdin — o `content:new` faz as suas próprias perguntas, e o
+ * `$EDITOR` que ele abre faz as dele. Dois leitores no mesmo stdin disputam as
+ * teclas, e o que se perde são as primeiras que se escrevem.
+ */
+function run(script: string, args: readonly string[]): void {
+  closePrompts();
+  const result = spawnSync("bun", ["run", script, ...args], {
+    stdio: "inherit",
+    cwd: ROOT,
+  });
+  if (result.error) {
+    console.error(`\n${red("✗")} não foi possível correr ${script}: ${result.error.message}`);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Perguntas comuns                                                            */
+/* -------------------------------------------------------------------------- */
+
+/** `--cat` aceita uma lista, mas escolher uma ou todas cobre o uso real. */
+async function askCategories(): Promise<string[]> {
+  const chosen = await askChoice<string | null>("Categorias", [
+    { value: null, label: "Todas" },
+    { value: "1", label: "Categoria 1" },
+    { value: "2", label: "Categoria 2" },
+    { value: "3", label: "Categoria 3" },
+  ]);
+  return chosen === null || chosen === undefined ? [] : ["--cat", chosen];
+}
+
+/* -------------------------------------------------------------------------- */
+/* As entradas do menu                                                         */
+/* -------------------------------------------------------------------------- */
+
+type Entry = {
+  label: string;
+  hint: string;
+  /** Devolve os argumentos, ou `null` para voltar ao menu sem correr nada. */
+  build: () => Promise<{ script: string; args: string[] } | null>;
+};
+
+const ENTRIES: Entry[] = [
+  {
+    label: "Acrescentar uma pergunta",
+    hint: "content:new",
+    build: async () => ({ script: CONTENT_NEW, args: [] }),
+  },
+  {
+    label: "Procurar uma pergunta",
+    hint: "por texto",
+    build: async () => {
+      const term = await askText("Termo a procurar", { required: false });
+      if (term.length === 0) return null;
+      const field = await askChoice<string | null>("Onde procurar", [
+        { value: null, label: "Em tudo" },
+        { value: "stem", label: "No enunciado" },
+        { value: "options", label: "Nas opções" },
+        { value: "explanation", label: "Na explicação" },
+      ]);
+      return {
+        script: QBANK,
+        args: [
+          "search",
+          term,
+          ...(field === null || field === undefined ? [] : ["--field", field]),
+          ...(await askCategories()),
+        ],
+      };
+    },
+  },
+  {
+    label: "Ver uma pergunta",
+    hint: "ex.: cat3#12",
+    build: async () => {
+      const refs = await askText("Referência(s), separadas por espaços", { required: false });
+      if (refs.length === 0) return null;
+      return { script: QBANK, args: ["show", ...refs.split(/\s+/)] };
+    },
+  },
+  {
+    label: "Duplicados",
+    hint: "grupos que discordam entre si",
+    build: async () => {
+      const tier = await askChoice<string | null>("Que tipo", [
+        { value: null, label: "Todos", hint: "o pior primeiro" },
+        { value: "contradiction", label: "Contradição", hint: "mesmas opções, resposta diferente" },
+        { value: "typo", label: "Gralha" },
+        { value: "divergent", label: "Divergente" },
+        { value: "shared-answers", label: "Respostas partilhadas" },
+        { value: "exact", label: "Exato" },
+      ]);
+      return {
+        script: QBANK,
+        args: [
+          "dupes",
+          ...(tier === null || tier === undefined ? [] : ["--tier", tier]),
+          ...(await askCategories()),
+        ],
+      };
+    },
+  },
+  {
+    label: "Pares parecidos",
+    hint: "enunciados próximos e polaridade invertida",
+    build: async () => {
+      const kind = await askChoice<string | null>("Que tipo", [
+        { value: null, label: "Todos" },
+        { value: "polarity", label: "Polaridade invertida", hint: "perguntam o contrário" },
+        { value: "near-stem", label: "Enunciado parecido" },
+      ]);
+      return {
+        script: QBANK,
+        args: ["pairs", ...(kind === null || kind === undefined ? [] : ["--kind", kind])],
+      };
+    },
+  },
+  {
+    label: "Cobertura",
+    hint: "fontes, explicações, imagens, órfãs",
+    build: async () => ({ script: QBANK, args: ["coverage", ...(await askCategories())] }),
+  },
+  {
+    label: "Matérias",
+    hint: "distribuição da taxonomia",
+    build: async () => ({ script: QBANK, args: ["topics", ...(await askCategories())] }),
+  },
+  {
+    label: "Provas",
+    hint: "o que cita cada prova oficial",
+    build: async () => {
+      const pdf = await askText("Prova (Enter para a lista de todas)", { required: false });
+      return { script: QBANK, args: ["paper", ...(pdf.length > 0 ? [pdf] : [])] };
+    },
+  },
+  {
+    label: "Auditoria das respostas",
+    hint: "posição da certa, opções repetidas",
+    build: async () => ({ script: QBANK, args: ["answers", ...(await askCategories())] }),
+  },
+];
+
+/* -------------------------------------------------------------------------- */
+/* Correr                                                                      */
+/* -------------------------------------------------------------------------- */
+
+async function main(): Promise<void> {
+  if (!interactive) {
+    console.error(`\n${red("✗")} o menu precisa de um terminal`);
+    console.error(`  Sem terminal, use as ferramentas diretamente:`);
+    console.error(`    bun run qbank <comando>`);
+    console.error(`    bun run content:new --from rascunho.mdx --yes`);
+    process.exit(1);
+  }
+
+  for (;;) {
+    const chosen = await askChoice<Entry | null>(
+      "Banco de questões",
+      ENTRIES.map((e) => ({ value: e, label: e.label, hint: e.hint })),
+      { allowNone: true, noneLabel: "Enter para sair" }
+    );
+    // Enter sai: é a mesma tecla que cancela cada uma das perguntas lá dentro,
+    // por isso não há nenhuma sequência a decorar para voltar atrás.
+    if (chosen === null || chosen === undefined) {
+      closePrompts();
+      return;
+    }
+
+    const plan = await chosen.build();
+    if (plan === null) continue;
+
+    console.log(dim(`\n  ${`bun run ${plan.script} ${plan.args.join(" ")}`.trim()}\n`));
+    run(plan.script, plan.args);
+    console.log(dim(`\n${"─".repeat(60)}`));
+  }
+}
+
+main()
+  .then(() => closePrompts())
+  .catch((error: unknown) => {
+    console.error(`\n${red("✗")} ${error instanceof Error ? error.message : String(error)}`);
+    closePrompts();
+    process.exit(1);
+  });

--- a/scripts/content-new.ts
+++ b/scripts/content-new.ts
@@ -19,10 +19,17 @@
  * draft is fixed and re-fed unchanged, and the file that is finally written is
  * the file that was reviewed.
  */
-import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from "fs";
-import { join } from "path";
-import { tmpdir } from "os";
-import readline from "node:readline";
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  unlinkSync,
+  mkdirSync,
+  copyFileSync,
+  statSync,
+} from "fs";
+import { join, resolve, extname } from "path";
+import { tmpdir, homedir } from "os";
 import { spawnSync } from "node:child_process";
 import matter from "gray-matter";
 import {
@@ -45,6 +52,19 @@ import {
   type Finding,
   type OrderAnchor,
 } from "../lib/content/author";
+import {
+  bold,
+  dim,
+  red,
+  green,
+  yellow,
+  interactive,
+  ask,
+  askText,
+  askChoice,
+  confirm as askConfirm,
+  closePrompts,
+} from "./prompt";
 import { TOPICS, topicShortLabel } from "../lib/config/topics";
 import { CATEGORIES, type CategoryId } from "../lib/config/categories";
 import type { ContentCategory } from "../lib/content/schema";
@@ -92,16 +112,6 @@ const force = has("force");
 /* Output                                                                      */
 /* -------------------------------------------------------------------------- */
 
-const ESC = "\u001b";
-const colour = process.stdout.isTTY === true;
-const paint = (code: string, text: string) =>
-  colour ? `${ESC}[${code}m${text}${ESC}[0m` : text;
-const bold = (t: string) => paint("1", t);
-const dim = (t: string) => paint("2", t);
-const red = (t: string) => paint("31", t);
-const green = (t: string) => paint("32", t);
-const yellow = (t: string) => paint("33", t);
-
 /** Truncates for a one-line summary, on a word boundary where it can. */
 function clip(text: string, width: number): string {
   const flat = text.replace(/\s+/g, " ").trim();
@@ -126,6 +136,7 @@ function usage(): never {
   console.log();
   console.log(dim("  --cat 3        categoria (perguntada se faltar)"));
   console.log(dim("  --after 107    posição no order; também --before 108 ou --end"));
+  console.log(dim("  --image fig.png  imagem a copiar para public/images/cat{n}/"));
   console.log(dim("  --dry-run      mostra o que escreveria, sem escrever nada"));
   console.log(dim("  --yes          não pergunta (obrigatório quando stdin é um pipe)"));
   console.log(dim("  --force        escreve apesar dos avisos"));
@@ -138,61 +149,9 @@ function usage(): never {
 /* Prompting                                                                   */
 /* -------------------------------------------------------------------------- */
 
-let rl: readline.Interface | null = null;
-const interactive = process.stdin.isTTY === true;
-
-function prompts(): readline.Interface {
-  if (rl === null) {
-    rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  }
-  return rl;
-}
-function closePrompts(): void {
-  rl?.close();
-  rl = null;
-}
-
-const ask = (question: string): Promise<string> =>
-  new Promise((resolve) => prompts().question(question, resolve));
-
-async function askText(label: string, { required = true } = {}): Promise<string> {
-  for (;;) {
-    const answer = (await ask(`${label} ${dim("›")} `)).trim();
-    if (answer.length > 0 || !required) return answer;
-    console.log(dim("  (obrigatório)"));
-  }
-}
-
-/**
- * A numbered list rather than an arrow-key menu: raw mode would have to be
- * handed back and forth with $EDITOR, and a number is one keystroke either way.
- */
-async function askChoice<T>(
-  label: string,
-  options: readonly { value: T; label: string; hint?: string }[],
-  { allowNone = false } = {}
-): Promise<T | null> {
-  console.log(`\n${bold(label)}`);
-  options.forEach((o, i) => {
-    console.log(`  ${String(i + 1).padStart(2)}  ${o.label}${o.hint ? `  ${dim(o.hint)}` : ""}`);
-  });
-  if (allowNone) console.log(dim("   —  Enter para nenhum"));
-
-  for (;;) {
-    const raw = (await ask(`${dim("nº ›")} `)).trim();
-    if (raw.length === 0 && allowNone) return null;
-    const chosen = options[Number.parseInt(raw, 10) - 1];
-    if (chosen) return chosen.value;
-    console.log(dim(`  1-${options.length}${allowNone ? " ou Enter" : ""}`));
-  }
-}
-
-async function confirm(question: string, fallback = false): Promise<boolean> {
-  if (assumeYes) return true;
-  if (!interactive) return fallback;
-  const answer = (await ask(`${question} ${dim("[s/N]")} `)).trim().toLowerCase();
-  return answer === "s" || answer === "sim" || answer === "y" || answer === "yes";
-}
+/** `assumeYes` is this script's flag, so every call site passes it. */
+const confirm = (question: string, fallback = false) =>
+  askConfirm(question, { fallback, assumeYes });
 
 /**
  * The explanation body, through $EDITOR.
@@ -261,6 +220,43 @@ function pdfLookup(pdf: string): { exists: boolean; alsoIn: string[] } {
 
 const imageExists = (rel: string) => existsSync(join(PUBLIC_DIR, rel));
 
+const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"]);
+
+/**
+ * What the author typed, resolved to one of the two things it can be.
+ *
+ * A figure already under `public/images/` is referenced where it lies — the
+ * same drawing is sometimes cited by more than one question. Anything else is
+ * a file somewhere on disk, to be copied in at write time.
+ */
+type ImageInput =
+  | { kind: "public"; rel: string }
+  | { kind: "file"; from: string; ext: string }
+  | { kind: "missing" }
+  | { kind: "unsupported"; ext: string };
+
+function classifyImage(input: string): ImageInput {
+  const rel = input.replace(/^\//, "");
+  if (rel.startsWith("images/") && imageExists(rel)) return { kind: "public", rel };
+
+  const from = resolve(input.startsWith("~/") ? join(homedir(), input.slice(2)) : input);
+  if (!existsSync(from) || !statSync(from).isFile()) return { kind: "missing" };
+  const ext = extname(from).toLowerCase();
+  if (!IMAGE_EXTENSIONS.has(ext)) return { kind: "unsupported", ext };
+  return { kind: "file", from, ext };
+}
+
+/**
+ * Named for the question rather than for the file it came from.
+ *
+ * `Screenshot 2026-08-27 at 14.03.11.png` is not a name to carry into the
+ * repo, and a descriptive one taken from the source risks colliding with a
+ * figure another question already references — which would silently replace
+ * that question's drawing. The id is new, so this name cannot be taken.
+ */
+const imageDestination = (category: CategoryId, id: number, ext: string) =>
+  `images/cat${category}/q${id}${ext}`;
+
 /* -------------------------------------------------------------------------- */
 /* Drafts from a file                                                          */
 /* -------------------------------------------------------------------------- */
@@ -317,13 +313,15 @@ function readDraftSource(from: string): string {
 /* -------------------------------------------------------------------------- */
 
 async function askCategory(): Promise<CategoryId> {
+  // Listed ascending, deliberately against the 3→2→1 order used everywhere
+  // else in the app. `askChoice` numbers its options by position, so listing
+  // CATEGORIES as-is made "1" select cat3 and "3" select cat1 — a prompt whose
+  // numbers are all wrong in a way that reads as right. Here the number typed
+  // is the category chosen; the beginner-first order stays a UI concern.
+  const ascending = [...CATEGORIES].sort((a, b) => Number(a) - Number(b));
   const chosen = await askChoice<CategoryId>(
     "Categoria",
-    CATEGORIES.map((c) => ({
-      value: c,
-      label: `cat${c}`,
-      hint: c === "3" ? "iniciado" : c === "1" ? "avançado" : "",
-    }))
+    ascending.map((c) => ({ value: c, label: `Categoria ${c}` }))
   );
   return chosen ?? "3";
 }
@@ -408,6 +406,41 @@ async function askSources(): Promise<Draft["sources"]> {
   }
 }
 
+/**
+ * Validated as it is typed, not at the end.
+ *
+ * The path is the one field here the author can get wrong without noticing —
+ * a typo yields a question that renders a broken image — and finding out after
+ * the enunciado, the options and the explanation have all been entered is the
+ * wrong moment.
+ */
+async function askImage(): Promise<string | null> {
+  for (;;) {
+    const input = await askText(
+      `\n${bold("Imagem")} ${dim("caminho do ficheiro, ou images/cat3/x.png já em public/ (Enter se nenhuma)")}`,
+      { required: false }
+    );
+    if (input.length === 0) return null;
+
+    const classified = classifyImage(input);
+    if (classified.kind === "public") {
+      console.log(`  ${green("✓")} ${dim("já está em public/, referenciada onde está")}`);
+      return input;
+    }
+    if (classified.kind === "file") {
+      console.log(`  ${green("✓")} ${dim(`${classified.from} — copiada ao escrever`)}`);
+      return input;
+    }
+    console.log(
+      `  ${red("✗")} ${dim(
+        classified.kind === "unsupported"
+          ? `${classified.ext} não é um formato de imagem (${[...IMAGE_EXTENSIONS].join(", ")})`
+          : "não existe, nem sob public/ nem como ficheiro"
+      )}`
+    );
+  }
+}
+
 async function askDraft(): Promise<Draft> {
   const catFlag = flag("cat");
   const category =
@@ -429,10 +462,7 @@ async function askDraft(): Promise<Draft> {
   const topic = await askTopic();
   const sources = await askSources();
 
-  const image = await askText(
-    `\n${bold("Imagem")} ${dim("relativa a public/, ex.: images/cat3/x.png (Enter se nenhuma)")}`,
-    { required: false }
-  );
+  const image = flag("image") ?? (await askImage());
 
   console.log(`\n${bold("Explicação")} ${dim("— o corpo MDX. Pode ficar vazia.")}`);
   console.log(dim(`  ${clip(question, 100)}`));
@@ -444,7 +474,7 @@ async function askDraft(): Promise<Draft> {
     answers,
     topic,
     sources,
-    image: image.length > 0 ? image : null,
+    image,
     explanation,
   };
 }
@@ -573,8 +603,44 @@ async function main(): Promise<void> {
   if (category === undefined) die(`cat${draft.category} não carregou`);
 
   const id = draft.id ?? nextId(manifest.order);
+
+  // Resolved here rather than at the prompt because the destination name is
+  // built from the id, and copied later still: a --dry-run, a blocking error
+  // or an abandoned warning must not leave a file behind in public/.
+  const rawImage = flag("image") ?? draft.image ?? null;
+  let image: string | null = null;
+  let imageCopy: { from: string; to: string } | null = null;
+  if (rawImage !== null && rawImage.length > 0) {
+    const classified = classifyImage(rawImage);
+    switch (classified.kind) {
+      case "public":
+        image = classified.rel;
+        break;
+      case "file": {
+        image = imageDestination(draft.category, id, classified.ext);
+        const to = join(PUBLIC_DIR, image);
+        // The id is new, so this can only be a leftover — and overwriting it
+        // would replace a figure that something else may already reference.
+        if (existsSync(to)) die(`${image} já existe`, "Remova-o ou mude-lhe o nome.");
+        imageCopy = { from: classified.from, to };
+        break;
+      }
+      case "unsupported":
+        die(
+          `${rawImage}: ${classified.ext} não é um formato de imagem`,
+          `Formatos: ${[...IMAGE_EXTENSIONS].join(", ")}`
+        );
+      // falls through to die; listed so the switch stays exhaustive
+      case "missing":
+        die(
+          `${rawImage} não existe`,
+          "Passe o caminho de um ficheiro, ou um images/… já sob public/."
+        );
+    }
+  }
+
   const review = reviewDraft(
-    { ...draft, id },
+    { ...draft, id, image },
     {
       category: draft.category,
       anacomFile: manifest.anacomFile,
@@ -584,7 +650,10 @@ async function main(): Promise<void> {
       bank,
       order: manifest.order,
       pdfLookup,
-      imageExists,
+      // The copy has not happened yet, so the destination has to count as
+      // present or the review reports the image it is about to write as
+      // missing.
+      imageExists: (rel: string) => imageExists(rel) || (imageCopy !== null && rel === image),
     }
   );
 
@@ -631,12 +700,19 @@ async function main(): Promise<void> {
         }`
       )}`
     );
+    if (imageCopy !== null) {
+      console.log(dim(`${imageCopy.from}  →  public/${image}`));
+    }
     closePrompts();
     return;
   }
 
   writeFileSync(questionFile, body);
   writeFileSync(join(sourceDir, MANIFEST_FILE), serializeManifest({ ...manifest, order }));
+  if (imageCopy !== null) {
+    mkdirSync(join(imageCopy.to, ".."), { recursive: true });
+    copyFileSync(imageCopy.from, imageCopy.to);
+  }
 
   // Reloaded rather than reused: this parses back what was just written, so a
   // round-trip surprise surfaces here instead of in the next `content:check`.
@@ -644,7 +720,12 @@ async function main(): Promise<void> {
   const dataFile = join(ROOT, "public", "data", `cat${draft.category}.json`);
   writeFileSync(dataFile, appJson);
 
-  const written = [questionFile, join(sourceDir, MANIFEST_FILE), dataFile];
+  const written = [
+    questionFile,
+    join(sourceDir, MANIFEST_FILE),
+    dataFile,
+    ...(imageCopy === null ? [] : [imageCopy.to]),
+  ];
   const note = notes.get(id);
   if (note !== undefined) {
     const noteFile = join(ROOT, "content", "notes", `cat${draft.category}`, `${id}.mdx`);

--- a/scripts/prompt.ts
+++ b/scripts/prompt.ts
@@ -1,0 +1,98 @@
+/**
+ * Terminal prompting, shared by the scripts that ask before they act.
+ *
+ * Extracted from `content:new` when `banco` needed the same numbered menus.
+ * Nothing here knows about questions or categories — it is the terminal half
+ * of those scripts, kept in one place so a menu looks the same wherever it is
+ * shown and the readline interface is only ever opened once per process.
+ */
+import readline from "node:readline";
+
+/* -------------------------------------------------------------------------- */
+/* Colour                                                                      */
+/* -------------------------------------------------------------------------- */
+
+const ESC = "\u001b";
+const colour = process.stdout.isTTY === true;
+
+export const paint = (code: string, text: string) =>
+  colour ? `${ESC}[${code}m${text}${ESC}[0m` : text;
+export const bold = (t: string) => paint("1", t);
+export const dim = (t: string) => paint("2", t);
+export const red = (t: string) => paint("31", t);
+export const green = (t: string) => paint("32", t);
+export const yellow = (t: string) => paint("33", t);
+export const cyan = (t: string) => paint("36", t);
+
+/* -------------------------------------------------------------------------- */
+/* Prompting                                                                   */
+/* -------------------------------------------------------------------------- */
+
+/** False when stdin is a pipe, which is what makes `--yes` obligatory there. */
+export const interactive = process.stdin.isTTY === true;
+
+let rl: readline.Interface | null = null;
+
+function prompts(): readline.Interface {
+  if (rl === null) {
+    rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  }
+  return rl;
+}
+
+/**
+ * Closed rather than paused, and re-opened on the next question.
+ *
+ * A subprocess that takes over the terminal — $EDITOR, or another script run
+ * from a menu — must not share stdin with a live readline interface: two
+ * readers on one stdin fight over the keystrokes.
+ */
+export function closePrompts(): void {
+  rl?.close();
+  rl = null;
+}
+
+export const ask = (question: string): Promise<string> =>
+  new Promise((resolve) => prompts().question(question, resolve));
+
+export async function askText(label: string, { required = true } = {}): Promise<string> {
+  for (;;) {
+    const answer = (await ask(`${label} ${dim("›")} `)).trim();
+    if (answer.length > 0 || !required) return answer;
+    console.log(dim("  (obrigatório)"));
+  }
+}
+
+/**
+ * A numbered list rather than an arrow-key menu: raw mode would have to be
+ * handed back and forth with $EDITOR, and a number is one keystroke either way.
+ */
+export async function askChoice<T>(
+  label: string,
+  options: readonly { value: T; label: string; hint?: string }[],
+  { allowNone = false, noneLabel = "Enter para nenhum" } = {}
+): Promise<T | null> {
+  console.log(`\n${bold(label)}`);
+  options.forEach((o, i) => {
+    console.log(`  ${String(i + 1).padStart(2)}  ${o.label}${o.hint ? `  ${dim(o.hint)}` : ""}`);
+  });
+  if (allowNone) console.log(dim(`   —  ${noneLabel}`));
+
+  for (;;) {
+    const raw = (await ask(`${dim("nº ›")} `)).trim();
+    if (raw.length === 0 && allowNone) return null;
+    const chosen = options[Number.parseInt(raw, 10) - 1];
+    if (chosen) return chosen.value;
+    console.log(dim(`  1-${options.length}${allowNone ? " ou Enter" : ""}`));
+  }
+}
+
+export async function confirm(
+  question: string,
+  { fallback = false, assumeYes = false } = {}
+): Promise<boolean> {
+  if (assumeYes) return true;
+  if (!interactive) return fallback;
+  const answer = (await ask(`${question} ${dim("[s/N]")} `)).trim().toLowerCase();
+  return answer === "s" || answer === "sim" || answer === "y" || answer === "yes";
+}

--- a/scripts/qbank.ts
+++ b/scripts/qbank.ts
@@ -225,16 +225,56 @@ function load(): BankQuestion[] {
 /* Rendering                                                                   */
 /* -------------------------------------------------------------------------- */
 
+/**
+ * The disagreement kinds, for reading.
+ *
+ * The values themselves stay English: they are the `--json` payload and the
+ * type in `lib/content/analysis.ts`, so only the rendering is translated.
+ */
+/**
+ * `--tier contradição` and `--tier contradiction` both select the same groups.
+ *
+ * The report says `contradição` now, and a filter that cannot be typed from
+ * what is on screen is a filter nobody reaches for. The English values stay
+ * canonical — they are what `--json`, the baseline keys and `docs/qbank.md`
+ * carry — so this only widens what is accepted.
+ */
+const TIER_ALIASES: Record<string, string> = {
+  contradição: "contradiction",
+  contradicao: "contradiction",
+  gralha: "typo",
+  divergente: "divergent",
+  "respostas-partilhadas": "shared-answers",
+  exato: "exact",
+};
+const KIND_ALIASES: Record<string, string> = {
+  polaridade: "polarity",
+  "enunciado-parecido": "near-stem",
+};
+const canonicalValue = (raw: string, aliases: Record<string, string>): string => {
+  const trimmed = raw.trim();
+  return aliases[trimmed.toLowerCase()] ?? trimmed;
+};
+
+const ISSUE_LABELS: Record<string, string> = {
+  topic: "matéria",
+  explanation: "explicação",
+  sources: "fontes",
+  image: "imagem",
+  cosmetic: "cosmético",
+};
+const issueLabel = (kind: string) => ISSUE_LABELS[kind] ?? kind;
+
 function tierLabel(tier: DuplicateTier): string {
-  if (tier === "contradiction") return red(bold("contradiction"));
-  if (tier === "typo") return yellow("typo");
-  if (tier === "divergent") return yellow("divergent");
-  if (tier === "shared-answers") return cyan("shared-answers");
-  return dim("exact");
+  if (tier === "contradiction") return red(bold("contradição"));
+  if (tier === "typo") return yellow("gralha");
+  if (tier === "divergent") return yellow("divergente");
+  if (tier === "shared-answers") return cyan("respostas partilhadas");
+  return dim("exato");
 }
 
 function renderQuestion(q: BankQuestion, needle?: string): void {
-  const topic = q.topic === null ? dim("untagged") : cyan(topicShortLabel(q.topic, "pt") ?? q.topic);
+  const topic = q.topic === null ? dim("sem matéria") : cyan(topicShortLabel(q.topic, "pt") ?? q.topic);
   say(`${bold(q.ref)}  ${topic}  ${dim(where(q, needle))}`);
   say(`  ${q.question}`);
   for (const a of q.answers) {
@@ -246,10 +286,10 @@ function renderQuestion(q: BankQuestion, needle?: string): void {
       ? q.sources
           .map((s) => `${s.pdf} pergunta ${s.question}${s.page === null ? "" : ` p.${s.page}`}`)
           .join("; ")
-      : "no sources"
+      : "sem fonte"
   );
-  if (q.explanation === null) marks.push("no explanation");
-  if (q.image !== null) marks.push(`image ${q.image}`);
+  if (q.explanation === null) marks.push("sem explicação");
+  if (q.image !== null) marks.push(`imagem ${q.image}`);
   say(`  ${dim(marks.join("  |  "))}`);
 }
 
@@ -260,7 +300,7 @@ function renderQuestion(q: BankQuestion, needle?: string): void {
 function cmdSearch(): void {
   const term = positional[1] ?? "";
   if (term.trim().length === 0) {
-    say("usage: qbank search <term> [--field stem|options|explanation] [--regex] [--cat 3]");
+    say("uso: qbank search <termo> [--field stem|options|explanation] [--regex] [--cat 3]");
     return flush([]);
   }
 
@@ -287,15 +327,15 @@ function cmdSearch(): void {
   }
 
   say(
-    `${bold(String(bank.length))} question(s) matching ${cyan(term)}` +
-      `${field === "all" ? "" : ` in ${field}`}`
+    `${bold(String(bank.length))} pergunta(s) com ${cyan(term)}` +
+      `${field === "all" ? "" : ` em ${field}`}`
   );
   say();
   for (const q of bank.slice(0, limit)) {
     renderQuestion(q, term);
     say();
   }
-  if (bank.length > limit) say(dim(`…and ${bank.length - limit} more (--limit ${bank.length})`));
+  if (bank.length > limit) say(dim(`…e mais ${bank.length - limit} (--limit ${bank.length})`));
   flush();
 }
 
@@ -303,7 +343,7 @@ function cmdShow(): void {
   const bank = load();
   const refs = positional.slice(1);
   if (refs.length === 0) {
-    say("usage: qbank show cat3#12 [cat2#255 …]");
+    say("uso: qbank show cat3#12 [cat2#255 …]");
     return flush([]);
   }
 
@@ -312,7 +352,7 @@ function cmdShow(): void {
     const parsed = parseRef(raw);
     const q = parsed && bank.find((b) => b.category === parsed.category && b.id === parsed.id);
     if (!q) {
-      say(red(`no such question: ${raw}`));
+      say(red(`não existe a pergunta ${raw}`));
       continue;
     }
     found.push(q);
@@ -331,8 +371,8 @@ function cmdShow(): void {
     for (const g of groups.filter((group) => group.members.some((m) => m.ref === q.ref))) {
       const others = g.members.filter((m) => m.ref !== q.ref).map((m) => m.ref);
       say();
-      say(`  ${tierLabel(g.tier)} with ${others.join(", ")}`);
-      for (const issue of g.issues) say(`    ${yellow(issue.kind)}: ${issue.detail}`);
+      say(`  ${tierLabel(g.tier)} com ${others.join(", ")}`);
+      for (const issue of g.issues) say(`    ${yellow(issueLabel(issue.kind))}: ${issue.detail}`);
     }
     say();
   }
@@ -348,7 +388,7 @@ function cmdDupes(): void {
       ...findPairFindings(bank).map((p) => p.key),
     ];
     writeBaseline(keys);
-    say(`${green("baselined")} ${keys.length} finding(s) into ${BASELINE_FILE}`);
+    say(`${green("registados")} ${keys.length} achado(s) em ${BASELINE_FILE}`);
     return flush({ baselined: keys.length });
   }
 
@@ -356,7 +396,7 @@ function cmdDupes(): void {
 
   const wanted = flag("tier");
   if (wanted !== undefined) {
-    const set = new Set(wanted.split(","));
+    const set = new Set(wanted.split(",").map((t) => canonicalValue(t, TIER_ALIASES)));
     groups = groups.filter((g) => set.has(g.tier));
   }
   if (has("new")) {
@@ -379,7 +419,7 @@ function cmdDupes(): void {
   const counts = new Map<DuplicateTier, number>();
   for (const g of groups) counts.set(g.tier, (counts.get(g.tier) ?? 0) + 1);
   say(
-    `${bold(String(groups.length))} group(s): ` +
+    `${bold(String(groups.length))} grupo(s): ` +
       DUPLICATE_TIERS.filter((t) => counts.has(t))
         .map((t) => `${counts.get(t)} ${tierLabel(t)}`)
         .join(", ")
@@ -387,7 +427,7 @@ function cmdDupes(): void {
   say();
 
   for (const g of groups.slice(0, limit)) {
-    const scope = g.crossCategory ? dim("across categories") : yellow("same category");
+    const scope = g.crossCategory ? dim("entre categorias") : yellow("na mesma categoria");
     say(`${tierLabel(g.tier)}  ${g.members.map((m) => bold(m.ref)).join(" ≡ ")}  ${scope}`);
     const first = g.members[0];
     if (first) say(`  ${clip(first.question, 110)}`);
@@ -414,12 +454,12 @@ function cmdDupes(): void {
         }
       }
     }
-    for (const issue of g.issues) say(`    ${yellow(issue.kind)}: ${issue.detail}`);
+    for (const issue of g.issues) say(`    ${yellow(issueLabel(issue.kind))}: ${issue.detail}`);
     say(dim(`    ${g.members.map((m) => where(m)).join("  ")}`));
     say();
   }
   if (groups.length > limit) {
-    say(dim(`…and ${groups.length - limit} more (--limit ${groups.length})`));
+    say(dim(`…e mais ${groups.length - limit} (--limit ${groups.length})`));
   }
   flush();
 }
@@ -445,7 +485,10 @@ function cmdPairs(): void {
   }
 
   const kind = flag("kind");
-  if (kind !== undefined) findings = findings.filter((f) => f.kind === kind);
+  if (kind !== undefined) {
+    const want = canonicalValue(kind, KIND_ALIASES);
+    findings = findings.filter((f) => f.kind === want);
+  }
   if (has("new")) {
     const baseline = loadBaseline();
     findings = findings.filter((f) => !baseline.has(f.key));
@@ -466,21 +509,21 @@ function cmdPairs(): void {
 
   const flips = findings.filter((f) => f.kind === "polarity").length;
   say(
-    `${bold(String(findings.length))} pair(s): ${flips} ${red("polarity flip")}, ` +
-      `${findings.length - flips} ${yellow("near-stem")}`
+    `${bold(String(findings.length))} par(es): ${flips} ${red("de polaridade invertida")}, ` +
+      `${findings.length - flips} ${yellow("de enunciado parecido")}`
   );
   say(
     dim(
-      "A polarity flip is two near-identical questions asking for opposite answers — verify, never merge."
+      "Polaridade invertida são duas perguntas quase iguais a pedir respostas opostas — confirmar, nunca fundir."
     )
   );
   say();
 
   for (const f of findings.slice(0, limit)) {
-    const label = f.kind === "polarity" ? red(bold("polarity")) : yellow("near-stem");
+    const label = f.kind === "polarity" ? red(bold("polaridade")) : yellow("enunciado parecido");
     say(
       `${label}  ${bold(f.a.ref)} ↔ ${bold(f.b.ref)}  ` +
-        dim(`stem ${f.stemSimilarity.toFixed(2)} · answers ${f.answerSimilarity.toFixed(2)}`)
+        dim(`enunciado ${f.stemSimilarity.toFixed(2)} · respostas ${f.answerSimilarity.toFixed(2)}`)
     );
     say(`    ${dim(pad(f.a.ref, 9))} ${clip(f.a.question, 92)}`);
     say(`    ${dim(pad(f.b.ref, 9))} ${clip(f.b.question, 92)}`);
@@ -488,7 +531,7 @@ function cmdPairs(): void {
     say();
   }
   if (findings.length > limit) {
-    say(dim(`…and ${findings.length - limit} more (--limit ${findings.length})`));
+    say(dim(`…e mais ${findings.length - limit} (--limit ${findings.length})`));
   }
   flush();
 }
@@ -530,7 +573,7 @@ function cmdCoverage(): void {
 
   const pct = (n: number, total: number) =>
     total === 0 ? "—" : `${Math.round((n / total) * 100)}%`;
-  const head = ["", "total", "sourced", "refs", "with page", "explained", "images", "topic"];
+  const head = ["", "total", "com fonte", "refs", "com página", "explicadas", "imagens", "matéria"];
   const table = rows.map((r) => [
     r.label,
     String(r.total),
@@ -550,9 +593,9 @@ function cmdCoverage(): void {
 
   if (orphans.length > 0) {
     say();
-    say(`${yellow(String(orphans.length))} image(s) on disk that no question references:`);
+    say(`${yellow(String(orphans.length))} imagem(ns) em disco que nenhuma pergunta refere:`);
     for (const o of orphans.slice(0, limit)) say(`  public/${o}`);
-    if (orphans.length > limit) say(dim(`  …and ${orphans.length - limit} more`));
+    if (orphans.length > limit) say(dim(`  …e mais ${orphans.length - limit}`));
   }
   flush();
 }
@@ -570,7 +613,7 @@ function cmdTopics(): void {
     });
   }
 
-  const head = ["topic", "cat3", "cat2", "cat1", "total"];
+  const head = ["matéria", "cat3", "cat2", "cat1", "total"];
   const table = audit.distribution.map((d) => [
     d.slug,
     ...(["3", "2", "1"] as CategoryId[]).map((c) => String(d.counts[c])),
@@ -585,25 +628,25 @@ function cmdTopics(): void {
   if (audit.invalid.length > 0) {
     say();
     say(
-      red(`${audit.invalid.length} question(s) with a topic that is not a slug in lib/config/topics.ts:`)
+      red(`${audit.invalid.length} pergunta(s) com uma matéria que não é um slug de lib/config/topics.ts:`)
     );
     for (const q of audit.invalid) say(`  ${q.ref} = ${q.topic}  ${dim(where(q))}`);
   }
   if (audit.untagged.length > 0) {
     say();
     say(
-      `${yellow(String(audit.untagged.length))} untagged question(s): ` +
+      `${yellow(String(audit.untagged.length))} pergunta(s) sem matéria: ` +
         audit.untagged.slice(0, 20).map((q) => q.ref).join(", ")
     );
   }
   if (audit.aboveEntryLevel.length > 0) {
     say();
     say(
-      `${audit.aboveEntryLevel.length} category 3 question(s) in a chapter Anexo 1 marks as ` +
-        "starting above entry level:"
+      `${audit.aboveEntryLevel.length} pergunta(s) de categoria 3 num capítulo que o Anexo 1 ` +
+        "marca como começando acima do nível de entrada:"
     );
     say(
-      dim("  Advisory — real 2023 cat 3 papers do examine these. See examinedFrom in lib/config/topics.ts.")
+      dim("  Indicativo — as provas reais de cat 3 de 2023 examinam-nas. Ver examinedFrom em lib/config/topics.ts.")
     );
     for (const q of audit.aboveEntryLevel.slice(0, limit)) {
       say(`  ${pad(q.ref, 9)} ${dim(pad(q.topic ?? "", 16))} ${clip(q.question, 70)}`);
@@ -630,17 +673,17 @@ function cmdPaper(): void {
         }))
       );
     }
-    say(bold(`${papers.length} paper(s) cited by the bank`));
+    say(bold(`${papers.length} prova(s) citada(s) pelo banco`));
     say();
     for (const p of papers) {
       const disk = existsSync(join("public", "exams", `${p.pdf}.pdf`));
       const resolved = p.cited.filter((c) => c.page !== null).length;
       say(
-        `${bold(pad(p.pdf, 24))} ${String(p.cited.length).padStart(3)} cited  ` +
-          `${dim(`${resolved} with page`)}  ` +
-          `${p.gaps.length > 0 ? yellow(`${p.gaps.length} unclaimed`) : green("complete")}` +
-          `${p.collisions.length > 0 ? red(`  ${p.collisions.length} collisions`) : ""}` +
-          `${disk ? "" : red("  PDF absent")}`
+        `${bold(pad(p.pdf, 24))} ${String(p.cited.length).padStart(3)} citadas  ` +
+          `${dim(`${resolved} com página`)}  ` +
+          `${p.gaps.length > 0 ? yellow(`${p.gaps.length} por reclamar`) : green("completa")}` +
+          `${p.collisions.length > 0 ? red(`  ${p.collisions.length} colisões`) : ""}` +
+          `${disk ? "" : red("  PDF ausente")}`
       );
     }
     return flush();
@@ -648,12 +691,12 @@ function cmdPaper(): void {
 
   const paper = papers.find((p) => p.pdf === wanted || p.pdf.endsWith(`/${wanted}`));
   if (!paper) {
-    say(red(`no question cites ${wanted}`));
+    say(red(`nenhuma pergunta cita ${wanted}`));
     return flush(null);
   }
   if (asJson) return flush(paper);
 
-  say(`${bold(paper.pdf)}  ${paper.cited.length} pergunta(s) cited`);
+  say(`${bold(paper.pdf)}  ${paper.cited.length} pergunta(s) citada(s)`);
   say();
   for (const c of paper.cited) {
     const q = bank.find((b) => b.ref === c.ref);
@@ -665,12 +708,12 @@ function cmdPaper(): void {
   }
   if (paper.gaps.length > 0) {
     say();
-    say(`${yellow("unclaimed perguntas")}: ${paper.gaps.join(", ")}`);
-    say(dim("  Either not in the bank yet, or in it without a source reference."));
+    say(`${yellow("perguntas por reclamar")}: ${paper.gaps.join(", ")}`);
+    say(dim("  Ou ainda não estão no banco, ou estão nele sem referência à fonte."));
   }
   for (const c of paper.collisions) {
     say();
-    say(red(`pergunta ${c.question} claimed by ${c.refs.join(", ")} — at most one can be right`));
+    say(red(`pergunta ${c.question} reclamada por ${c.refs.join(", ")} — no máximo uma pode estar certa`));
   }
   flush();
 }
@@ -687,7 +730,7 @@ function cmdAnswers(): void {
   }
 
   const total = audit.total;
-  say(bold("correct-answer position"));
+  say(bold("posição da resposta certa"));
   audit.correctIndexCounts.forEach((count, i) => {
     const share = Math.round((count / total) * 100);
     say(
@@ -697,7 +740,7 @@ function cmdAnswers(): void {
   });
   say(
     dim(
-      `  Uniform is ${Math.round(100 / audit.correctIndexCounts.length)}%; a spike means the bank is guessable.`
+      `  O uniforme seria ${Math.round(100 / audit.correctIndexCounts.length)}%; um pico significa que o banco se adivinha.`
     )
   );
 
@@ -705,46 +748,46 @@ function cmdAnswers(): void {
   const longestShare = Math.round((audit.longestIsCorrect / total) * 100);
   const chance = Math.round(100 / (audit.correctIndexCounts.length || 4));
   say(
-    `${bold("longest option is correct")}  ${audit.longestIsCorrect}/${total} (${longestShare}%)  ` +
-      dim(`chance is about ${chance}%`)
+    `${bold("a opção mais longa é a certa")}  ${audit.longestIsCorrect}/${total} (${longestShare}%)  ` +
+      dim(`o acaso ronda os ${chance}%`)
   );
 
   say();
-  say(bold("options per question"));
+  say(bold("opções por pergunta"));
   for (const [count, n] of [...audit.optionCount.entries()].sort((a, b) => a[0] - b[0])) {
-    say(`  ${count} options  ${n}`);
+    say(`  ${count} opções  ${n}`);
   }
 
   if (audit.duplicateOptions.length > 0) {
     say();
-    say(red(`${audit.duplicateOptions.length} question(s) with two identical options:`));
+    say(red(`${audit.duplicateOptions.length} pergunta(s) com duas opções iguais:`));
     for (const d of audit.duplicateOptions.slice(0, limit)) {
       say(`  ${bold(d.ref)}  ${clip(d.text, 70)}  ${dim(d.file)}`);
     }
   }
   if (audit.misplacedCatchAll.length > 0) {
     say();
-    say(`${yellow(String(audit.misplacedCatchAll.length))} catch-all option(s) not in last position:`);
+    say(`${yellow(String(audit.misplacedCatchAll.length))} opção(ões) de fecho fora da última posição:`);
     for (const m of audit.misplacedCatchAll.slice(0, limit)) {
-      say(`  ${bold(m.ref)}  position ${m.index + 1} of ${m.count}  ${dim(m.file)}`);
+      say(`  ${bold(m.ref)}  posição ${m.index + 1} de ${m.count}  ${dim(m.file)}`);
     }
   }
   flush();
 }
 
 function usage(): void {
-  say(bold("qbank — question-bank inspection"));
+  say(bold("qbank — inspeção do banco de questões"));
   say();
-  say("  search <term>    find questions by text  [--field stem|options|explanation] [--regex]");
-  say("  show <ref…>      one question in full, with its duplicates");
-  say("  dupes            duplicate groups, worst tier first  [--tier] [--new] [--update-baseline]");
-  say("  pairs            fuzzy near-duplicates and polarity flips  [--kind] [--new]");
-  say("  coverage         sources, explanations, images, orphans");
-  say("  topics           taxonomy distribution and outliers");
-  say("  paper [pdf]      what cites an exam paper, and what is unclaimed");
-  say("  answers          answer-construction audit");
+  say("  search <termo>   procura perguntas por texto  [--field stem|options|explanation] [--regex]");
+  say("  show <ref…>      uma pergunta por inteiro, com os seus duplicados");
+  say("  dupes            grupos de duplicados, o pior primeiro  [--tier] [--new] [--update-baseline]");
+  say("  pairs            quase-duplicados e inversões de polaridade  [--kind] [--new]");
+  say("  coverage         fontes, explicações, imagens, órfãs");
+  say("  topics           distribuição da taxonomia e casos fora do nível");
+  say("  paper [pdf]      o que cita uma prova, e o que ficou por reclamar");
+  say("  answers          auditoria à construção das respostas");
   say();
-  say(dim("  global: --cat 3,2   --limit N   --json"));
+  say(dim("  globais: --cat 3,2   --limit N   --json"));
   flush(null);
 }
 


### PR DESCRIPTION
Três coisas que só se notam a usar as ferramentas.

O menu da categoria estava numerado ao contrário. `askChoice` numera as
opções pela posição e `CATEGORIES` é `['3','2','1']`, por isso a opção 1
escolhia a cat3 e a opção 3 a cat1 — um menu cujos números estão todos
errados de uma maneira que se lê como certa. A ordem 3→2→1 continua certa
como ordem de apresentação (a cat3 é a de entrada); o que não sobrevive é
numerá-la por posição. Aqui é listada por ordem crescente, e as opções
passam a chamar-se "Categoria 1", sem as etiquetas de nível.

A imagem já se podia declarar, mas só se o ficheiro já estivesse em
`public/images/cat{n}/` — copiá-lo para lá e escolher-lhe o nome eram um
passo à parte, feito à mão, fora da ferramenta que faz todo o resto.
Agora aponta-se para o ficheiro onde ele estiver e a ferramenta copia-o.
O nome é `q{id}.{extensão}` e não o de origem: `Captura de ecrã 2026-08-27,
14.03.11.png` não é um nome para trazer para o repositório, e um nome
descritivo arrisca colidir com uma figura que outra pergunta já refere, o
que lhe trocaria o desenho em silêncio. Um caminho já sob `public/images/`
continua a ser referenciado onde está, porque o mesmo desenho é citado por
mais do que uma pergunta. A cópia acontece com as escritas, para que um
`--dry-run`, um erro que bloqueia ou um aviso recusado não deixem nada para
trás; o `imageExists` da revisão passa a contar o destino pendente, senão a
ferramenta acusaria de ausente a imagem que está prestes a escrever.

E era preciso saber que as ferramentas existem, e como se chamam. O
`bun run banco` é um menu português por cima das duas: pergunta o que se
quer, recolhe os argumentos, e corre exatamente o comando que o
`docs/qbank.md` documenta — mostrando-o primeiro, por isso serve também
para aprender a forma direta. Não absorve nada: as duas continuam a
funcionar sozinhas.

Corre-as como subprocessos em vez de as importar. Carregar o banco inteiro
custa cerca de 150 ms — medido, incluindo o `dupes` — por isso partilhar o
processo não compra nada, e custava: o `qbank` decide o que fazer no topo
do módulo, e importá-lo obrigava a reescrevê-lo à volta de um `main()`,
numa ferramenta que não está ligada ao CI e falharia em silêncio. O que
sai do `content:new` para `scripts/prompt.ts` são as perguntas do
terminal, que o menu precisava de usar tal e qual.

O relatório do `qbank` passa a português; os comandos e as opções não.
`dupes`, `--tier`, as chaves do `--json` e as da linha de base são a
interface e ficam como estavam — traduzir um valor que é serializado é
como uma linha de base deixa de bater certo sem ninguém reparar. Só a
apresentação muda. Como o ecrã passa a dizer `gralha` onde se escreve
`typo`, o `--tier` aceita as duas formas: um filtro que não se consegue
escrever a partir do que está no ecrã é um filtro que ninguém usa.

