### PR TITLE
Um mural para quem paga a escola: /apoiantes

### DIFF
--- a/app/apoiantes/page.tsx
+++ b/app/apoiantes/page.tsx
@@ -1,0 +1,242 @@
+import React from 'react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { Heart, Radio, Server, Globe, BookOpen, ArrowRight, Sparkles, ShieldCheck } from 'lucide-react';
+import { getLocale, getTranslations } from 'next-intl/server';
+import { Button } from '@/components/ui/button';
+import { EXTERNAL_LINKS, SUPPORTERS, supportersByYear, supporterDate, firstSupportYear } from '@/lib/config';
+import type { Supporter } from '@/lib/config';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('Supporters');
+  return { title: `${t('title')} — Rádio Escola`, description: t('metaDescription') };
+}
+
+const SUSTAINS = [
+  { icon: Server, titleKey: 'sustainServer', descKey: 'sustainServerDesc' },
+  { icon: Globe, titleKey: 'sustainDomain', descKey: 'sustainDomainDesc' },
+  { icon: BookOpen, titleKey: 'sustainFree', descKey: 'sustainFreeDesc' },
+] as const;
+
+/**
+ * A supporter rendered as a QSL card — the postcard hams exchange to confirm a
+ * contact. Callsign on the plate, no amount anywhere: what is being confirmed
+ * here is the contact, not the sum.
+ */
+function QslCard({
+  supporter,
+  date,
+  t,
+}: {
+  supporter: Supporter;
+  date: string;
+  t: Awaited<ReturnType<typeof getTranslations<'Supporters'>>>;
+}) {
+  return (
+    <article className="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition-all duration-200 hover:-translate-y-1 hover:border-amber-300 hover:shadow-lg dark:border-slate-700 dark:bg-slate-800 dark:hover:border-amber-600/60">
+      {/* Card head — the amber band a QSL card prints its callsign strip on */}
+      <div className="flex items-center justify-between bg-gradient-to-r from-amber-500 to-orange-600 px-4 py-1.5">
+        <span className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-white/90">QSL</span>
+        <span className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-widest text-white/90">
+          {t('qslTag')}
+          <Heart className="h-3 w-3 fill-white/90" />
+        </span>
+      </div>
+
+      <div className="relative overflow-hidden px-5 pt-5 pb-4">
+        <Radio
+          className="pointer-events-none absolute -right-4 -top-3 h-24 w-24 text-slate-100 transition-transform duration-300 group-hover:scale-110 dark:text-slate-700/50"
+          aria-hidden
+        />
+        {supporter.callsign ? (
+          <p className="relative font-mono text-2xl font-bold tracking-tight text-slate-900 sm:text-[1.75rem] dark:text-white">
+            {supporter.callsign}
+          </p>
+        ) : (
+          <p className="relative font-mono text-lg font-semibold tracking-tight text-slate-400 dark:text-slate-500">
+            {t('noCallsign')}
+          </p>
+        )}
+        <span className="relative mt-2 block h-0.5 w-10 rounded-full bg-amber-400 transition-all duration-200 group-hover:w-16" />
+        <p className="relative mt-3 text-base font-medium text-slate-700 dark:text-slate-200">{supporter.name}</p>
+      </div>
+
+      {/* Perforation — the tear line of the real card */}
+      <div className="border-t border-dashed border-slate-200 px-5 py-3 dark:border-slate-700">
+        <p className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+          <ShieldCheck className="h-3.5 w-3.5 text-emerald-500" />
+          <span>{t('supporterSince', { date })}</span>
+        </p>
+      </div>
+    </article>
+  );
+}
+
+export default async function ApoiantesPage() {
+  const t = await getTranslations('Supporters');
+  const locale = await getLocale();
+  const monthFormat = new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric' });
+
+  const years = supportersByYear();
+  const firstYear = firstSupportYear();
+
+  return (
+    <main className="-mx-4 sm:mx-0 pb-8">
+      {/* Hero — a signal radiating outwards, because that is what the support buys */}
+      <div className="relative overflow-hidden bg-gradient-to-br from-slate-800 to-slate-900 px-6 py-12 text-center sm:rounded-2xl sm:px-8 md:py-16 dark:from-slate-900 dark:to-black">
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center" aria-hidden>
+          {/* Standing rings, so the hero reads as a signal even between pulses */}
+          {[0.4, 0.7, 1].map((scale) => (
+            <span
+              key={scale}
+              className="absolute rounded-full border border-amber-400/10"
+              style={{ height: `${420 * scale}px`, width: `${420 * scale}px` }}
+            />
+          ))}
+          {[0, 1, 2, 3].map((ring) => (
+            <span
+              key={ring}
+              className="absolute h-[420px] w-[420px] rounded-full border border-amber-400/30 opacity-0 motion-safe:animate-[wave-expand_6s_ease-out_infinite] motion-reduce:hidden"
+              style={{ animationDelay: `${ring * 1.5}s` }}
+            />
+          ))}
+        </div>
+
+        <div className="relative">
+          <div className="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-2xl bg-amber-500/20 ring-1 ring-amber-500/30">
+            <Radio className="h-8 w-8 text-amber-400" />
+          </div>
+          <p className="text-xs font-semibold uppercase tracking-[0.25em] text-amber-400">{t('heroBadge')}</p>
+          <h1 className="mx-auto mt-3 max-w-2xl text-2xl font-bold text-white sm:text-3xl md:text-4xl">
+            {t('heroTitle')}
+          </h1>
+          <p className="mx-auto mt-4 max-w-xl text-base leading-relaxed text-slate-300 sm:text-lg">
+            {t('heroSubtitle')}
+          </p>
+
+          <div className="mt-8 flex flex-wrap items-center justify-center gap-2 text-sm">
+            <span className="rounded-full bg-white/10 px-3.5 py-1.5 font-medium text-white ring-1 ring-white/15">
+              {t('statSupporters', { count: SUPPORTERS.length })}
+            </span>
+            {firstYear !== null && (
+              <span className="rounded-full bg-white/10 px-3.5 py-1.5 font-medium text-white ring-1 ring-white/15">
+                {t('statSince', { year: firstYear })}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* The wall itself — a chronological rail of QSL cards */}
+      <section className="mt-12 px-4 sm:px-0 md:mt-16">
+        <h2 className="text-xl font-semibold text-slate-900 dark:text-white">{t('timelineTitle')}</h2>
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{t('timelineSubtitle')}</p>
+
+        <ol className="relative mt-8 space-y-12">
+          {/* The rail, fading out below the last year so the open slot reads as "to be continued" */}
+          <span
+            className="absolute left-4 top-2 bottom-0 w-px bg-gradient-to-b from-amber-400 via-slate-200 to-transparent dark:via-slate-700"
+            aria-hidden
+          />
+
+          {years.map((group) => (
+            <li key={group.year} className="relative pl-12 sm:pl-14">
+              <span
+                className="absolute left-0 top-0 flex h-8 w-8 items-center justify-center rounded-full bg-amber-500/10 ring-1 ring-amber-500/40"
+                aria-hidden
+              >
+                <span className="h-2.5 w-2.5 rounded-full bg-amber-500" />
+              </span>
+
+              <div className="flex items-baseline gap-3">
+                <h3 className="font-mono text-lg font-bold text-slate-900 dark:text-white">{group.year}</h3>
+                <span className="text-xs text-slate-400 dark:text-slate-500">
+                  {t('statSupporters', { count: group.supporters.length })}
+                </span>
+              </div>
+
+              <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                {group.supporters.map((supporter) => (
+                  <QslCard
+                    key={`${supporter.name}-${supporter.since}`}
+                    supporter={supporter}
+                    date={monthFormat.format(supporterDate(supporter))}
+                    t={t}
+                  />
+                ))}
+              </div>
+            </li>
+          ))}
+
+          {/* The blank card at the end of the rail — the wall is not finished */}
+          <li className="relative pl-12 sm:pl-14">
+            <span
+              className="absolute left-0 top-0 flex h-8 w-8 items-center justify-center rounded-full border border-dashed border-slate-300 dark:border-slate-600"
+              aria-hidden
+            >
+              <Sparkles className="h-3.5 w-3.5 text-slate-400 dark:text-slate-500" />
+            </span>
+            <Link
+              href="/donativos"
+              className="group flex items-center justify-between gap-4 rounded-2xl border border-dashed border-slate-300 bg-slate-50/60 px-5 py-6 outline-none transition-all duration-200 hover:border-amber-400 hover:bg-amber-50/60 focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 sm:max-w-md dark:border-slate-600 dark:bg-slate-800/40 dark:hover:border-amber-500/60 dark:hover:bg-amber-950/20"
+            >
+              <span>
+                <span className="block font-mono text-lg font-semibold text-slate-500 dark:text-slate-400">
+                  {t('openSlotTitle')}
+                </span>
+                <span className="mt-1 block text-sm text-slate-500 dark:text-slate-400">{t('openSlotDesc')}</span>
+              </span>
+              <ArrowRight className="h-5 w-5 shrink-0 text-slate-400 transition-transform duration-200 group-hover:translate-x-1 group-hover:text-amber-600 dark:group-hover:text-amber-400" />
+            </Link>
+          </li>
+        </ol>
+      </section>
+
+      {/* What the support pays for — the honest, amount-free version */}
+      <section className="mt-16 px-4 sm:px-0">
+        <h2 className="text-xl font-semibold text-slate-900 dark:text-white">{t('sustainTitle')}</h2>
+        <div className="mt-5 grid gap-4 sm:grid-cols-3">
+          {SUSTAINS.map((item) => {
+            const Icon = item.icon;
+            return (
+              <div
+                key={item.titleKey}
+                className="rounded-2xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-800"
+              >
+                <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-amber-100 text-amber-600 dark:bg-amber-950/40 dark:text-amber-400">
+                  <Icon className="h-4.5 w-4.5" />
+                </span>
+                <p className="mt-3 text-sm font-semibold text-slate-900 dark:text-white">{t(item.titleKey)}</p>
+                <p className="mt-1 text-sm leading-relaxed text-slate-500 dark:text-slate-400">{t(item.descKey)}</p>
+              </div>
+            );
+          })}
+        </div>
+        <p className="mt-4 text-xs leading-relaxed text-slate-400 dark:text-slate-500">{t('privacyNote')}</p>
+      </section>
+
+      {/* Closing invitation */}
+      <section className="mt-12 px-4 sm:px-0">
+        <div className="flex flex-col items-center gap-4 rounded-2xl bg-gradient-to-br from-amber-50 to-orange-50 px-6 py-10 text-center ring-1 ring-amber-200/60 dark:from-amber-950/30 dark:to-orange-950/20 dark:ring-amber-800/40">
+          <Heart className="h-8 w-8 text-rose-500 animate-heartbeat" />
+          <h2 className="text-xl font-bold text-slate-900 dark:text-white">{t('ctaTitle')}</h2>
+          <p className="max-w-md text-sm leading-relaxed text-slate-600 dark:text-slate-300">{t('ctaDesc')}</p>
+          <div className="mt-1 flex flex-col items-center gap-3 sm:flex-row">
+            <Button asChild size="lg">
+              <a href={EXTERNAL_LINKS.PAYPAL_DONATE} target="_blank" rel="noopener noreferrer">
+                <Heart className="h-4 w-4" />
+                {t('ctaButton')}
+              </a>
+            </Button>
+            <Link
+              href="/donativos"
+              className="text-sm font-medium text-slate-600 underline-offset-4 hover:text-amber-600 hover:underline dark:text-slate-300 dark:hover:text-amber-400"
+            >
+              {t('ctaCosts')}
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/donativos/page.tsx
+++ b/app/donativos/page.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { Heart, Coffee, Server, Star, Sparkles, Tent, Radio, Trophy } from 'lucide-react';
+import Link from 'next/link';
+import { Heart, Coffee, Server, Star, Sparkles, Tent, Radio, Trophy, Users, ArrowRight } from 'lucide-react';
 import { getTranslations } from 'next-intl/server';
 import { EXTERNAL_LINKS } from '@/lib/config';
+import SupportersStrip from '@/components/SupportersStrip';
 
 const DONATION_TIERS = [
   { amountKey: 'coffeeAmount', labelKey: 'coffee', icon: Coffee, recommended: false },
@@ -56,6 +58,15 @@ export default async function DonativosPage() {
             />
           </div>
           <p className="mt-2 text-xs text-slate-500">{t('fundingUpdated')}</p>
+
+          <Link
+            href="/apoiantes"
+            className="mt-5 inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-sm font-medium text-white ring-1 ring-white/15 transition-colors hover:bg-white/20"
+          >
+            <Users className="h-4 w-4 text-amber-400" />
+            {t('supportersLink')}
+            <ArrowRight className="h-3.5 w-3.5" />
+          </Link>
         </div>
       </div>
 
@@ -164,6 +175,11 @@ export default async function DonativosPage() {
             })}
           </div>
         </div>
+      </div>
+
+      {/* Thank you — the people who already answered the ask above */}
+      <div className="px-4 sm:px-0 mt-10">
+        <SupportersStrip />
       </div>
     </main>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -274,6 +274,21 @@
   }
 }
 
+/* Supporters wall — signal rings radiating from the hero */
+@keyframes wave-expand {
+  0% {
+    transform: scale(0.25);
+    opacity: 0;
+  }
+  20% {
+    opacity: 0.6;
+  }
+  100% {
+    transform: scale(1.05);
+    opacity: 0;
+  }
+}
+
 /* Donations page heartbeat */
 @keyframes heartbeat {
   0%, 100% {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import Link from "next/link";
-import { BookOpen, IdCard, Radio, ExternalLink, Building2, ArrowRight, Zap, Brain, Layers, Heart, Play } from "lucide-react";
+import { BookOpen, IdCard, Radio, ExternalLink, Building2, ArrowRight, Zap, Brain, Layers, Play } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { CATEGORIES, CATEGORY_CONFIG, CATEGORY_IMAGES } from "@/lib/config";
 import { Button } from "@/components/ui/button";
 import { Testimonials, type Testimonial } from "@/components/Testimonials";
+import SupportersStrip from "@/components/SupportersStrip";
 
 type RawTestimonial = Omit<Testimonial, "categoryLabel">;
 
@@ -218,22 +219,9 @@ export default async function HomePage() {
         </div>
       </section>
 
-      {/* Donate CTA */}
+      {/* Supporters — the thank-you and the ask, in one card */}
       <section className="mt-8 md:mt-10">
-        <Link
-          href="/donativos"
-          className="flex items-center gap-4 px-5 py-4 rounded-xl bg-slate-50 border border-slate-200/60 hover:bg-slate-100 dark:bg-slate-800/40 dark:border-slate-700/40 dark:hover:bg-slate-800/70 transition-all duration-200 group"
-        >
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-rose-100 dark:bg-rose-900/30">
-            <Heart className="h-4 w-4 text-rose-500 dark:text-rose-400" />
-          </div>
-          <p className="flex-1 text-sm text-slate-600 dark:text-slate-400">
-            {t("donatePrompt")}
-          </p>
-          <span className="shrink-0 text-sm font-medium text-amber-600 dark:text-amber-400 group-hover:underline">
-            {t("donateButton")}
-          </span>
-        </Link>
+        <SupportersStrip donate={{ prompt: t("donatePrompt"), label: t("donateButton") }} />
       </section>
     </div>
   );

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Github, MessageCircle, Smartphone, Bug, Info, Radio, Zap, BarChart3, GraduationCap, School, TrendingUp, Heart } from "lucide-react";
+import { Github, MessageCircle, Smartphone, Bug, Info, Radio, Zap, BarChart3, GraduationCap, School, TrendingUp, Heart, Users } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { EXTERNAL_LINKS } from "@/lib/config";
 
@@ -13,6 +13,7 @@ const internalLinks = [
   { href: "/estado-da-escola", icon: School, labelKey: "schoolStatus" },
   { href: "/estado-da-nacao", icon: TrendingUp, labelKey: "nationStatus" },
   { href: "/donativos", icon: Heart, labelKey: "donate" },
+  { href: "/apoiantes", icon: Users, labelKey: "supporters" },
 ] as const;
 
 const externalLinks = [

--- a/components/SupportersStrip.tsx
+++ b/components/SupportersStrip.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import Link from 'next/link';
+import { ArrowRight, Heart, Users } from 'lucide-react';
+import { getTranslations } from 'next-intl/server';
+import { Button } from '@/components/ui/button';
+import { SUPPORTERS } from '@/lib/config';
+
+/** Chips beyond this collapse into a "+N" — the wall itself is the full list */
+const MAX_CHIPS = 8;
+
+interface SupportersStripProps {
+  className?: string;
+  /**
+   * Copy for the donate row, folded into the same card so the thank-you and
+   * the ask read as one gesture instead of two stacked prompts. Omitted on
+   * the donations page, where the whole page is already the ask; the caller
+   * passes the strings because they live in its own message namespace.
+   */
+  donate?: { prompt: string; label: string };
+}
+
+/**
+ * The supporters teaser: real callsigns, no amounts, linking to the wall.
+ * Shared by the home page and the donations page so the names stay in one
+ * place — adding a supporter updates every surface at once.
+ */
+export default async function SupportersStrip({ className = '', donate }: SupportersStripProps) {
+  const t = await getTranslations('Supporters');
+
+  if (SUPPORTERS.length === 0) return null;
+
+  const shown = SUPPORTERS.slice(0, MAX_CHIPS);
+  const hidden = SUPPORTERS.length - shown.length;
+
+  return (
+    <section
+      className={`rounded-xl border border-slate-200/60 bg-slate-50 p-5 dark:border-slate-700/40 dark:bg-slate-800/40 ${className}`}
+    >
+      <div className="flex items-start gap-4">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-amber-100 dark:bg-amber-950/40">
+          <Users className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+        </span>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
+            <p className="text-sm font-semibold text-slate-900 dark:text-white">{t('stripTitle')}</p>
+            <Link
+              href="/apoiantes"
+              className="group inline-flex shrink-0 items-center gap-1 rounded text-sm font-medium text-amber-600 outline-none hover:underline focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:text-amber-400"
+            >
+              {t('stripCta')}
+              <ArrowRight className="h-3.5 w-3.5 transition-transform duration-200 group-hover:translate-x-0.5" />
+            </Link>
+          </div>
+          <p className="mt-0.5 text-sm text-slate-600 dark:text-slate-400">
+            {t('stripSubtitle', { count: SUPPORTERS.length })}
+          </p>
+
+          {/* The callsigns themselves — the thank-you has to name names */}
+          <div className="mt-3 flex flex-wrap gap-2">
+            {shown.map((supporter) => (
+              <span
+                key={`${supporter.name}-${supporter.since}`}
+                className="inline-flex items-baseline gap-2 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs dark:border-slate-700 dark:bg-slate-900/60"
+              >
+                {supporter.callsign && (
+                  <span className="font-mono font-bold text-slate-900 dark:text-white">{supporter.callsign}</span>
+                )}
+                <span className="text-slate-500 dark:text-slate-400">{supporter.name}</span>
+              </span>
+            ))}
+            {hidden > 0 && (
+              <span className="inline-flex items-center rounded-full px-2 py-1 text-xs text-slate-500 dark:text-slate-400">
+                {t('stripMore', { count: hidden })}
+              </span>
+            )}
+          </div>
+
+          {donate && (
+            <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-slate-200/70 pt-4 dark:border-slate-700/50">
+              <p className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400">
+                <Heart className="h-4 w-4 shrink-0 text-rose-500 dark:text-rose-400" aria-hidden />
+                {donate.prompt}
+              </p>
+              <Button size="sm" asChild>
+                <Link href="/donativos">{donate.label}</Link>
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -9,3 +9,4 @@ export * from './topics';
 export * from './external-links';
 export * from './calculators';
 export * from './study-guides';
+export * from './supporters';

--- a/lib/config/supporters.ts
+++ b/lib/config/supporters.ts
@@ -1,0 +1,56 @@
+/**
+ * The people who have donated to Rádio Escola.
+ *
+ * Deliberately **no amounts**: the wall thanks the gesture, not the sum, and
+ * ranking donors by what they gave is the one thing that would make appearing
+ * here uncomfortable. Order is chronological, oldest first.
+ */
+export interface Supporter {
+  /** Full name, as the person wants to be thanked */
+  name: string;
+  /** Amateur callsign, if licensed — rendered as the QSL card's call plate */
+  callsign?: string;
+  /** Month of the first donation, `YYYY-MM`. Drives the timeline grouping */
+  since: string;
+}
+
+export const SUPPORTERS: Supporter[] = [
+  { name: 'Pedro Caria', callsign: 'CR7BYT', since: '2026-08' },
+  { name: 'Carlos Francisco', callsign: 'CR7CAN', since: '2026-08' },
+];
+
+export interface SupporterYear {
+  year: number;
+  supporters: Supporter[];
+}
+
+/** The `YYYY-MM` string as a local Date, for locale-aware month formatting */
+export function supporterDate(supporter: Supporter): Date {
+  const [year, month] = supporter.since.split('-').map(Number);
+  return new Date(year ?? 1970, (month ?? 1) - 1, 1);
+}
+
+/**
+ * Chronological, oldest year first, and oldest supporter first inside each
+ * year — the wall reads as a history, so the earliest believers come first.
+ */
+export function supportersByYear(supporters: Supporter[] = SUPPORTERS): SupporterYear[] {
+  const years = new Map<number, Supporter[]>();
+
+  for (const supporter of [...supporters].sort((a, b) => a.since.localeCompare(b.since))) {
+    const year = supporterDate(supporter).getFullYear();
+    const bucket = years.get(year);
+    if (bucket) bucket.push(supporter);
+    else years.set(year, [supporter]);
+  }
+
+  return [...years.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([year, list]) => ({ year, supporters: list }));
+}
+
+/** The year the first donation arrived — the "since" in the hero */
+export function firstSupportYear(supporters: Supporter[] = SUPPORTERS): number | null {
+  const years = supportersByYear(supporters);
+  return years[0]?.year ?? null;
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -53,7 +53,8 @@
     "telegram": "Telegram",
     "app": "App",
     "donate": "Support",
-    "slogan": "Made by amateur radio operators, for (future) amateur radio operators"
+    "slogan": "Made by amateur radio operators, for (future) amateur radio operators",
+    "supporters": "Supporters"
   },
   "Browse": {
     "emptyClear": "Clear search",
@@ -169,7 +170,41 @@
     "excessFairs": "Show up at ham radio fairs and events",
     "excessStickers": "Make stickers and merch to spread the word",
     "excessEquipment": "Get equipment for educational content (SDR, video)",
-    "excessPrizes": "Reward community challenges and contributors"
+    "excessPrizes": "Reward community challenges and contributors",
+    "supportersLink": "See who has already supported"
+  },
+  "Supporters": {
+    "title": "Wall of Supporters",
+    "metaDescription": "The people whose donations keep Rádio Escola on the air. No ads, no subscriptions — just community support.",
+    "heroBadge": "Thank you",
+    "heroTitle": "The people keeping us on the air",
+    "heroSubtitle": "Rádio Escola has no ads and no subscriptions. It is online because some people chose to pay for it — for everyone. This wall is how we say thank you.",
+    "statSupporters": "{count, plural, =1 {# supporter} other {# supporters}}",
+    "statSince": "since {year}",
+    "timelineTitle": "Support over time",
+    "timelineSubtitle": "In order of arrival. Every card is a thank you.",
+    "qslTag": "Thank you",
+    "qslConfirm": "Support confirmed",
+    "supporterSince": "Since {date}",
+    "noCallsign": "Friend of Rádio Escola",
+    "openSlotTitle": "Your callsign here",
+    "openSlotDesc": "There is room on the wall for the next card.",
+    "sustainTitle": "What this support sustains",
+    "sustainServer": "The server running",
+    "sustainServerDesc": "The platform reachable at any hour, with no ads.",
+    "sustainDomain": "The radioescola.pt domain",
+    "sustainDomainDesc": "The address you share with anyone just starting out.",
+    "sustainFree": "Everything free",
+    "sustainFreeDesc": "A thousand-plus questions and exam simulators, at no cost.",
+    "privacyNote": "We publish no amounts and rank nobody by what they gave. If you would rather not appear here, or want your name written differently, just tell us.",
+    "ctaTitle": "Join them",
+    "ctaDesc": "Any support, however small, keeps this school open.",
+    "ctaButton": "Support Rádio Escola",
+    "ctaCosts": "See where the money goes",
+    "stripTitle": "The people keeping us on the air",
+    "stripSubtitle": "{count, plural, =1 {# person has} other {# people have}} supported Rádio Escola so it stays free for everyone.",
+    "stripCta": "See the wall",
+    "stripMore": "+{count}"
   },
   "Study": {
     "title": "Study Library",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -53,7 +53,8 @@
     "telegram": "Telegram",
     "app": "App",
     "donate": "Apoiar",
-    "slogan": "Feito por radioamadores, para (futuros) radioamadores"
+    "slogan": "Feito por radioamadores, para (futuros) radioamadores",
+    "supporters": "Apoiantes"
   },
   "Browse": {
     "emptyClear": "Limpar pesquisa",
@@ -169,7 +170,41 @@
     "excessFairs": "Marcar presença em feiras e eventos de radioamadorismo",
     "excessStickers": "Criar autocolantes e material para divulgar o projeto",
     "excessEquipment": "Comprar equipamento para conteúdo educativo (SDR, vídeo)",
-    "excessPrizes": "Premiar desafios comunitários e contribuidores"
+    "excessPrizes": "Premiar desafios comunitários e contribuidores",
+    "supportersLink": "Ver quem já apoiou"
+  },
+  "Supporters": {
+    "title": "Mural de Apoiantes",
+    "metaDescription": "As pessoas cujos donativos mantêm a Rádio Escola no ar. Sem publicidade, sem subscrições — só apoio da comunidade.",
+    "heroBadge": "Obrigado",
+    "heroTitle": "Quem nos mantém no ar",
+    "heroSubtitle": "A Rádio Escola não tem publicidade nem subscrições. Está online porque houve quem decidisse pagar por ela — para toda a gente. Este mural é a nossa forma de dizer obrigado.",
+    "statSupporters": "{count, plural, =1 {# apoiante} other {# apoiantes}}",
+    "statSince": "desde {year}",
+    "timelineTitle": "O apoio ao longo do tempo",
+    "timelineSubtitle": "Por ordem de chegada. A cada cartão, um obrigado.",
+    "qslTag": "Obrigado",
+    "qslConfirm": "Apoio confirmado",
+    "supporterSince": "Desde {date}",
+    "noCallsign": "Amigo da Rádio Escola",
+    "openSlotTitle": "O teu indicativo aqui",
+    "openSlotDesc": "Há espaço no mural para o próximo cartão.",
+    "sustainTitle": "O que este apoio sustenta",
+    "sustainServer": "O servidor ligado",
+    "sustainServerDesc": "A plataforma acessível a qualquer hora, sem anúncios.",
+    "sustainDomain": "O domínio radioescola.pt",
+    "sustainDomainDesc": "A morada que partilhas com quem começa agora.",
+    "sustainFree": "Tudo gratuito",
+    "sustainFreeDesc": "Mais de mil questões e simuladores, sem pagar nada.",
+    "privacyNote": "Não publicamos valores nem ordenamos ninguém por quanto deu. Se preferes não aparecer aqui, ou queres o teu nome escrito de outra forma, é só dizer.",
+    "ctaTitle": "Junta-te a eles",
+    "ctaDesc": "Qualquer apoio, por mais pequeno, mantém esta escola aberta.",
+    "ctaButton": "Apoiar a Rádio Escola",
+    "ctaCosts": "Ver para onde vai o dinheiro",
+    "stripTitle": "Quem nos mantém no ar",
+    "stripSubtitle": "{count, plural, =1 {# pessoa apoiou} other {# pessoas apoiaram}} a Rádio Escola para que continue gratuita para todos.",
+    "stripCta": "Ver o mural",
+    "stripMore": "+{count}"
   },
   "Study": {
     "title": "Biblioteca de Estudo",


### PR DESCRIPTION
A página de donativos pedia; nada agradecia. `/apoiantes` é o mural das pessoas cujos donativos mantêm o servidor ligado — cartões QSL por ordem de chegada, o que o apoio sustenta, e o convite para o próximo.

## O que muda

- **`app/apoiantes/page.tsx`** — o mural: herói com contagem e ano do primeiro donativo, linha temporal por ano, o que o apoio sustenta, nota de privacidade e CTA.
- **`components/SupportersStrip.tsx`** — o mesmo cartão nos dois sítios. Na home substitui o antigo CTA de donativos (recebe `donate` e mostra o pedido); em `/donativos` aparece sem ele, porque aí o pedido já é a página inteira.
- **`lib/config/supporters.ts`** — a lista, mais `supportersByYear` / `firstSupportYear` / `supporterDate`.
- Link no rodapé e a partir do herói de `/donativos`; anel de sinal (`wave-expand`) em `globals.css`; chaves `Supporters.*` em pt e en.

## Decisões

- **Sem valores, e sem ordenação por valor.** O mural agradece o gesto, não a soma — ordenar quem deu por quanto deu é a única coisa que tornaria desconfortável aparecer aqui. A ordem é cronológica: os primeiros a acreditar primeiro.
- **`since` é `YYYY-MM`**, convertido para `Date` local em `supporterDate`, para o mês ser formatado na língua do visitante em vez de ficar fixado no ficheiro.
- **Saída a pedido**, escrito na própria página: quem preferir não aparecer, ou queira o nome de outra forma, é só dizer.

## Verificação

`type-check`, `lint` e `test` (318 testes, 27 ficheiros) passam.