### PR TITLE
Corrigir a explicação de cat2/47: r.m.s. para tensão de pico

### DIFF
--- a/content/notes/cat2/47.mdx
+++ b/content/notes/cat2/47.mdx
@@ -1,1 +1,31 @@
-Temos Vrms = Vpp * SQRT(2), logo Vpp = Vrms / Sqrt(2) => Vpp = 34 / 0,707 = 48 V,Opção 4.
+A tensão de pico é **≈ 48 V** — opção 4.
+
+## A fórmula
+
+Um voltímetro de corrente alternada indica o valor **eficaz** (r.m.s.). Numa onda
+sinusoidal, o eficaz e o pico relacionam-se por
+
+$$
+V_{\text{rms}} = \frac{V_{\text{pico}}}{\sqrt{2}}
+\qquad\Longleftrightarrow\qquad
+V_{\text{pico}} = V_{\text{rms}} \times \sqrt{2}
+$$
+
+Procura-se o pico a partir do eficaz, pelo que se **multiplica** por
+$\sqrt{2} \approx 1{,}414$:
+
+$$
+V_{\text{pico}} = 34 \times 1{,}414 \approx 48{,}1\ \text{V}
+$$
+
+## Atenção ao pico-a-pico
+
+$V_{\text{pico}}$ conta-se do zero até ao máximo. A tensão **pico-a-pico** vai do
+mínimo ao máximo, e é o dobro:
+
+$$
+V_{\text{pp}} = 2 \times V_{\text{pico}} \approx 96\ \text{V}
+$$
+
+que é exactamente a opção 2. O enunciado pede a tensão de pico, não a
+pico-a-pico.

--- a/content/questions/cat2/0047.mdx
+++ b/content/questions/cat2/0047.mdx
@@ -17,4 +17,34 @@ sources:
     question: 34
 tutorial: AC
 ---
-Temos Vrms = Vpp * SQRT(2), logo Vpp = Vrms / Sqrt(2) => Vpp = 34 / 0,707 = 48 V,Opção 4.
+A tensão de pico é **≈ 48 V** — opção 4.
+
+## A fórmula
+
+Um voltímetro de corrente alternada indica o valor **eficaz** (r.m.s.). Numa onda
+sinusoidal, o eficaz e o pico relacionam-se por
+
+$$
+V_{\text{rms}} = \frac{V_{\text{pico}}}{\sqrt{2}}
+\qquad\Longleftrightarrow\qquad
+V_{\text{pico}} = V_{\text{rms}} \times \sqrt{2}
+$$
+
+Procura-se o pico a partir do eficaz, pelo que se **multiplica** por
+$\sqrt{2} \approx 1{,}414$:
+
+$$
+V_{\text{pico}} = 34 \times 1{,}414 \approx 48{,}1\ \text{V}
+$$
+
+## Atenção ao pico-a-pico
+
+$V_{\text{pico}}$ conta-se do zero até ao máximo. A tensão **pico-a-pico** vai do
+mínimo ao máximo, e é o dobro:
+
+$$
+V_{\text{pp}} = 2 \times V_{\text{pico}} \approx 96\ \text{V}
+$$
+
+que é exactamente a opção 2. O enunciado pede a tensão de pico, não a
+pico-a-pico.


### PR DESCRIPTION
A explicação da pergunta 47 da categoria 2 ("Se um voltímetro indicar uma tensão de 34 volt r.m.s. …") chegava à resposta certa por um caminho errado.

Estava assim:

> Temos Vrms = Vpp * SQRT(2), logo Vpp = Vrms / Sqrt(2) => Vpp = 34 / 0,707 = 48 V,Opção 4.

Três problemas:

1. **A fórmula está invertida.** A relação é `Vpico = Vrms × √2`, não `Vrms = Vpico × √2`.
2. **O passo simbólico contradiz a aritmética.** Diz "dividir por √2", mas calcula `34 / 0,707` — e como 0,707 ≈ 1/√2, isso é *multiplicar* por √2. Seguida à letra, a fórmula dá `34 / 1,414 ≈ 24 V`, que nem sequer é uma das opções. Só acerta nos 48 V porque os dois erros se anulam.
3. **`Vpp` é o símbolo errado.** Vpp é a tensão pico-a-pico, que aqui vale 96 V — que é exactamente o distrator da opção 2. A notação apontava o aluno para a resposta errada.

A resposta assinalada (48 V, opção 4) estava e continua correcta; o que muda é o raciocínio.

A nova explicação usa KaTeX — já configurado no projecto (`remark-math` + `rehype-katex` em `lib/content/render-note.ts` e `next.config.js`, CSS em `app/layout.tsx`), sem alterações necessárias. Segue a notação de `content/questions/cat1/0033.mdx`, a outra pergunta com matemática: `{,}` para a vírgula decimal e `\text{}` para as unidades. Acrescenta uma secção sobre o pico-a-pico, para explicar porque é que os 96 V não são a resposta.

## Verificação

- `content:build` regenerou `content/notes/cat2/47.mdx`; `content:check` passa (759 artefactos)
- Nota renderizada por `renderNoteToHtml`: 5 blocos de matemática, 18 spans KaTeX, zero `katex-error`, zero `$` soltos
- `type-check` limpo, 318 testes a passar