### PR TITLE
Cada commit no main vai para o ar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+name: Build
+
+# Builds the image and pushes it to GHCR. Called by release.yml (a tag) and by
+# main.yml (a push to main) so both publish exactly the same way, and returns
+# the tag it pushed for deploy.yml to roll out.
+on:
+  workflow_call:
+    outputs:
+      image_tag:
+        description: The tag that was published, to be deployed verbatim
+        value: ${{ jobs.build.outputs.image_tag }}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      # The tag metadata-action actually pushed. On a tag that is the semver
+      # with the leading v stripped (`v2.0.0` → `2.0.0`); on a push to main the
+      # semver patterns do not apply, leaving `sha-<short>`. Deploy must pull
+      # exactly this, whichever it is.
+      image_tag: ${{ steps.meta.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      # No build cache on purpose. Measured on v2.0.3: exporting to the GitHub
+      # Actions cache took 250s of a 351s build and produced *zero* cache hits,
+      # because that cache is scoped by ref and tag builds cannot read each
+      # other's entries. Worth re-measuring now that consecutive main pushes
+      # share a ref — though the ceiling is low either way, since `COPY . .`
+      # invalidates every layer after the deps stage on every commit, and that
+      # stage is only ~15s of `bun install`.
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            NEXT_PUBLIC_GAMIFICATION=${{ vars.NEXT_PUBLIC_GAMIFICATION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches: [main]
-  # Called by release.yml so a tag runs exactly the same checks a PR does.
+  # Called by main.yml and release.yml, so a push to main and a tag run exactly
+  # the same checks a PR does. No `push` trigger of its own: main.yml already
+  # runs this on every commit there, and both would be the same run twice.
   workflow_call:
 
 concurrency:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,41 @@
+name: Main
+
+# Every commit on main goes live. The image is named after the commit
+# (`sha-<short>`), so it is still an immutable artefact you can roll back to —
+# release.yml adds a friendlier name to the ones worth remembering.
+#
+# Kept separate from release.yml rather than added as a second trigger there
+# because of `paths-ignore`: path filters apply to every trigger in an `on:`
+# block, and a tag whose commit only touched docs would then quietly not
+# release. Both files call the same build and the same deploy.
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+
+# Shared with release.yml, so a tag release and a main push queue rather than
+# roll out over each other. Not cancel-in-progress: cancelling mid-rollout is
+# worse than deploying twice.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  check:
+    uses: ./.github/workflows/ci.yml
+
+  build:
+    uses: ./.github/workflows/build.yml
+
+  deploy:
+    needs: [check, build]
+    uses: ./.github/workflows/deploy.yml
+    with:
+      image_tag: ${{ needs.build.outputs.image_tag }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,23 @@
 name: Release
 
-# Tagging is the release trigger: `git tag v2.0.0 && git push origin v2.0.0`
-# builds an image, pushes it to GHCR and rolls it out to the VPS.
+# Tagging cuts a *named* release: `git tag v2.0.0 && git push origin v2.0.0`
+# builds an image called 2.0.0, pushes it to GHCR and rolls it out. Day to day
+# nothing needs tagging — main.yml already deploys every commit. Tags exist so
+# there are named points to roll back to.
 on:
   push:
     tags: ["v*.*.*"]
 
-# Never let two releases roll out at once, and never cancel one mid-deploy.
+# Shared with main.yml: never let two releases roll out at once, and never
+# cancel one mid-deploy.
 concurrency:
   group: release
   cancel-in-progress: false
 
 # A called workflow can only DOWNGRADE the caller's GITHUB_TOKEN permissions,
-# never elevate them — so this ceiling must already cover everything deploy.yml
-# asks for. With `contents: read` alone here, deploy.yml requesting
-# `packages: read` is an elevation and the whole run dies with a
+# never elevate them — so this ceiling must already cover everything build.yml
+# and deploy.yml ask for. With `contents: read` alone here, deploy.yml
+# requesting `packages: read` is an elevation and the whole run dies with a
 # startup_failure before a single job begins.
 permissions:
   contents: read
@@ -29,51 +32,10 @@ jobs:
   # case is an unused image in GHCR for a commit whose tests then failed —
   # `deploy` needs both, so nothing unverified can reach the server.
   build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    outputs:
-      # The tag metadata-action actually pushed (semver strips the leading v,
-      # so `v2.0.0` becomes `2.0.0`). Deploy must pull exactly this.
-      image_tag: ${{ steps.meta.outputs.version }}
-    steps:
-      - uses: actions/checkout@v7
+    uses: ./.github/workflows/build.yml
 
-      - uses: docker/setup-buildx-action@v4
-
-      - uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha
-
-      # No build cache on purpose. Measured on v2.0.3: exporting to the GitHub
-      # Actions cache took 250s of a 351s build and produced *zero* cache hits,
-      # because that cache is scoped by ref and tag builds cannot read each
-      # other's entries. Nothing here is worth caching anyway — `COPY . .`
-      # invalidates every layer after the deps stage on every commit, and that
-      # stage is only ~15s of `bun install`.
-      - uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            NEXT_PUBLIC_GAMIFICATION=${{ vars.NEXT_PUBLIC_GAMIFICATION }}
-
-  # The rollout itself lives in deploy.yml so the same steps back both a tag
-  # release and the manual "Run workflow" button (redeploys and rollbacks).
+  # The rollout itself lives in deploy.yml so the same steps back a tag release,
+  # a push to main, and the manual "Run workflow" button (redeploys, rollbacks).
   deploy:
     needs: [check, build]
     uses: ./.github/workflows/deploy.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,14 +21,21 @@ bun run banco        # Portuguese menu over content:new and qbank
 
 ## Deployment
 
-Tag-triggered, via GitHub Actions → GHCR → the VPS at `server.radioescola.pt`:
+**Every commit on `main` goes live**, via GitHub Actions → GHCR → the VPS at
+`server.radioescola.pt`. `.github/workflows/main.yml` runs the checks, builds
+`Dockerfile` into `ghcr.io/radioescola-pt/radioescola:sha-<short>` and calls
+`deploy.yml` to roll it out. Doc-only commits (`docs/**`, `**/*.md`) are skipped.
+
+Tagging is no longer how you ship — it cuts a *named* release, so there is
+something legible to roll back to:
 
 ```bash
 git tag -a v2.0.0 -m "Release 2.0.0" && git push origin v2.0.0
 ```
 
-`.github/workflows/release.yml` runs the checks, builds `Dockerfile`, pushes
-`ghcr.io/radioescola-pt/radioescola:2.0.0`, then calls `deploy.yml` to roll it out.
+`release.yml` then publishes the same image as `2.0.0` and deploys it. The two
+workflows share `build.yml` and `deploy.yml`, and a `release` concurrency group
+so they can never roll out over each other.
 
 `deploy.yml` also runs on its own from **Actions → Deploy → Run workflow**,
 taking an image tag — that is how you redeploy or roll back, and it beats
@@ -36,9 +43,13 @@ running `release.sh` over SSH because CI supplies the registry credentials the
 box deliberately does not keep. Full runbook in `docs/deployment.md`.
 
 - **The image tag has no leading `v`** — `docker/metadata-action` strips it, so
-  the tag `v2.0.0` publishes `2.0.0`
+  the tag `v2.0.0` publishes `2.0.0`. What gets deployed is whatever
+  `metadata-action` resolved: the semver on a tag, `sha-<short>` on a main push
+- **`paths-ignore` lives in `main.yml`, not in `release.yml`** — path filters
+  apply to every trigger in an `on:` block, so a tag whose commit only touched
+  docs would quietly not release. That is why the two triggers are two files
 - **`NEXT_PUBLIC_*` is baked into the image**, so a feature-flag change needs a
-  new tag, not an edit to the server's `app.env`
+  new build, not an edit to the server's `app.env`
 - **Two API routes read source files at request time** (`/api/notes/*` from
   `content/notes/`, `/api/study-items` from `app/study/`) using paths built from
   `process.cwd()`, which file tracing cannot follow. They are kept in the

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,22 +1,31 @@
 # Deployment
 
-Releases are cut by tagging. `git push origin v2.0.0` makes GitHub Actions run
-the test suite, build a Docker image, push it to GHCR, and roll it out to
-`server.radioescola.pt`. Nothing is built on the production box, and every
-release is an immutable image you can roll back to by name.
+Deployment follows `main`. Every commit there runs the test suite, builds a
+Docker image, pushes it to GHCR and rolls it out to `server.radioescola.pt`.
+Nothing is built on the production box, and every deploy is an immutable image
+you can roll back to.
+
+Tagging still exists, but it no longer *ships* anything new — it gives an image
+a name worth remembering, so rollback targets are legible.
 
 ```
-git tag v2.0.0  ──▶  .github/workflows/release.yml
-                        │
-                        ├─ check    type-check, lint, test, content:check
-                        ├─ build    Dockerfile ──▶ ghcr.io/radioescola-pt/radioescola:2.0.0
-                        └─ deploy ──▶ deploy.yml (also runnable on its own,
-                                      for a redeploy or a rollback)
-                                        │
-                                        scp deploy/* ──▶ ~/app ──▶ release.sh 2.0.0
-                                                                │
-                                    VPS: caddy (TLS) ──▶ app container :3000
+push to main  ──▶  .github/workflows/main.yml     ┐
+                                                  ├─ check    type-check, lint, test, content:check
+git tag v2.0.0 ──▶ .github/workflows/release.yml  ┤
+                                                  ├─ build ──▶ build.yml
+                                                  │            Dockerfile ──▶ ghcr.io/radioescola-pt/radioescola
+                                                  │            :sha-bfa2486 on a push, :2.0.0 on a tag
+                                                  └─ deploy ──▶ deploy.yml (also runnable on its own,
+                                                                for a redeploy or a rollback)
+                                                                  │
+                                                       scp deploy/* ──▶ ~/app ──▶ release.sh <tag>
+                                                                                │
+                                                     VPS: caddy (TLS) ──▶ app container :3000
 ```
+
+The two entry points differ only in their trigger and in the name the image
+gets: they call the same `build.yml` and the same `deploy.yml`, and share a
+`release` concurrency group so they queue rather than roll out over each other.
 
 ## Files
 
@@ -27,9 +36,11 @@ git tag v2.0.0  ──▶  .github/workflows/release.yml
 | `deploy/compose.yaml` | The stack: app + Caddy. Copied to the server on every deploy |
 | `deploy/Caddyfile` | Reverse proxy and automatic TLS |
 | `deploy/release.sh` | Pins an image tag and rolls it out. Also the rollback tool |
-| `.github/workflows/ci.yml` | Checks. Runs on PRs, and is reused by the release |
-| `.github/workflows/release.yml` | Tag → build → push → calls the deploy workflow |
-| `.github/workflows/deploy.yml` | The rollout. Called by a release, or run by hand for a redeploy or rollback |
+| `.github/workflows/ci.yml` | Checks. Runs on PRs, and is reused by the two entry points below |
+| `.github/workflows/main.yml` | Push to main → checks → build → deploy. The everyday path |
+| `.github/workflows/release.yml` | Tag → the same three, publishing a named image |
+| `.github/workflows/build.yml` | The image build, shared by both. Returns the tag it pushed |
+| `.github/workflows/deploy.yml` | The rollout. Called by the two above, or run by hand for a redeploy or rollback |
 
 Edit the `deploy/` files here, never on the server — the next deploy overwrites
 whatever is in `~/app`.
@@ -230,18 +241,30 @@ approval.
 Nothing needs configuring for GHCR on the CI side — `GITHUB_TOKEN` with
 `packages: write` covers the push.
 
-## Releasing
+## Shipping
+
+Merge to `main`. That is the whole procedure: the image is named `sha-<short>`
+after the commit, and the deploy step fails loudly if the new container does not
+come up healthy, with a final smoke test on `/api/health` through Caddy.
+
+Commits touching only `docs/**` or `**/*.md` are skipped — nothing in the image
+changed. The path filter lives in `main.yml` and deliberately not in
+`release.yml`: path filters apply to every trigger in an `on:` block, so a tag
+whose commit only touched docs would quietly not release.
+
+Cutting a named release is a separate, optional act:
 
 ```bash
 git tag -a v2.0.0 -m "Release 2.0.0"
 git push origin v2.0.0
 ```
 
-Watch it in the Actions tab. The deploy step fails loudly if the new container
-does not come up healthy, and a final smoke test hits `/api/health` through
-Caddy.
+That rebuilds the same commit as `2.0.0` (plus `2.0`) and deploys it, so the
+version is a name you can roll back to months later without reading SHAs. Tag
+the commits worth naming; the rest ship on merge.
 
-Only `v*.*.*` tags trigger a release. Pushes to `main` run the checks only.
+Every commit leaves an image behind, so GHCR now grows a package version per
+merge rather than per release. Prune it periodically, keeping the tagged ones.
 
 ## The repository rename
 
@@ -267,8 +290,8 @@ in GHCR, whether or not the box has it cached — and it is the same code path a
 tag release takes, because `release.yml` calls this workflow too.
 
 Note the tag has **no leading `v`**: published tags are the bare semver
-(`2.0.0`, `2.0`) plus a `sha-` tag. Check the repo's Packages page for what
-exists.
+(`2.0.0`, `2.0`) plus a `sha-` tag — and a commit that shipped without being
+tagged has only the `sha-` one. Check the repo's Packages page for what exists.
 
 Over SSH also works, but only for an image the box still has cached — it holds
 no registry credentials of its own by design:


### PR DESCRIPTION
Hoje só vai para o ar o que for etiquetado com uma tag. Passa a ir tudo o
que entrar no `main`.

## O que muda

- Um `.github/workflows/main.yml` novo: em cada commit no `main` corre os
  testes, constrói a imagem e faz o rollout — o mesmo que a tag fazia. A
  imagem chama-se `sha-<short>`, o nome do commit
- As tags continuam a funcionar e continuam a publicar `2.0.0`. Só deixam
  de ser a forma de publicar: servem para dar nome a uma imagem que vale a
  pena guardar, para haver para onde voltar atrás
- O build passa para um `build.yml` partilhado pelos dois caminhos, para
  construírem e publicarem da mesma maneira
- O `ci.yml` perde o trigger próprio de push no `main`, senão os testes
  corriam duas vezes no mesmo commit

Nada disto mexe no servidor: o `deploy.yml` e o `release.sh` já aceitavam
qualquer nome de imagem, e o botão **Actions → Deploy → Run workflow**
continua a ser a forma de voltar atrás.

## Dois pormenores

- Commits que só mexam em `docs/**` ou `**/*.md` não publicam. Esse filtro
  fica no `main.yml` e não no `release.yml`, porque os filtros de caminho
  valem para todos os triggers do mesmo bloco `on:` — uma tag cujo commit
  só mexesse em documentação deixaria de publicar sem dizer nada
- Passa a ficar uma imagem por commit no GHCR, e não uma por versão.
  Convém limpar de vez em quando, guardando as que têm tag

## O que vale a pena ver na primeira execução

Que o `image_tag` que o build devolve é mesmo `sha-<short>`. É a única
coisa aqui que depende de como o `docker/metadata-action` se comporta
fora de uma tag.