### PR TITLE
Desativar perguntas sem as apagar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,30 @@ the same split as `qbank`.
   numeric. Interactively it shows the same-topic neighbourhood and asks;
   otherwise `--after`/`--before`/`--end`. It never appends silently
 
+**Withdrawing a question**: set `disabled: <reason>` in its frontmatter and
+rebuild. `emitCategory` is the only place the flag is applied — the question is
+dropped from `public/data/cat{n}.json` and its generated note is deleted, so it
+vanishes from the whole site with no consumer-side filtering. It stays in its
+source file, in `category.json`'s `order` (so the id is never reissued and the
+editorial position survives), and in everything `qbank` and `content:new`
+compare against, so it goes on blocking an accidental re-add.
+
+- **The reason is a string, never `true`.** `disabled: true` was tried once and
+  did nothing at all: the schema was non-strict, so Zod discarded the unknown
+  key and the build shipped the question anyway. `QuestionSchema` is now
+  `.strict()` — any unknown or mistyped frontmatter key fails the build — and
+  `disabled` takes prose so the flag cannot parse and mean nothing
+- **Use `isWithheld()` from `lib/content/schema.ts`**, not `disabled === null`.
+  Hand-built questions (test fixtures, `legacy.ts`) omit the field, and
+  `undefined === null` is false, which reads as withheld-with-no-reason
+- **Never withhold by moving the file** into a subdirectory. `loadCategory`
+  reads the directory non-recursively so it does work, but it hides the
+  question from `qbank` and from the duplicate review, and forces the id out of
+  `order` where it can be reissued
+- **`content:build` sweeps orphaned notes.** `/api/notes` reads
+  `content/notes/` straight from disk without consulting the bank, so a note
+  left behind by a withdrawn question would still be served
+
 Adding a question by hand is still documented in `docs/novas-questoes.md`
 (pt-PT); the topic taxonomy in `docs/topicos.md` (pt-PT).
 

--- a/__tests__/unit/test-content-build.test.ts
+++ b/__tests__/unit/test-content-build.test.ts
@@ -31,6 +31,7 @@ import {
   MANIFEST_FILE,
 } from "@/lib/content/build";
 import { questionFileName, serializeQuestionFile } from "@/lib/content/source";
+import { isWithheld } from "@/lib/content/schema";
 
 const ROOT = resolve(__dirname, "../../");
 
@@ -91,11 +92,29 @@ describe.each(MIGRATED)("cat%s content build", (categoryId) => {
       const notePath = join(notesDir, `${q.id}.mdx`);
       if (existsSync(notePath)) {
         expect(q.explanation).toBe(readFileSync(notePath, "utf-8").trim());
+      } else if (isWithheld(q)) {
+        // A withheld question keeps its explanation in source — it is not
+        // deleted, only withdrawn — but emits no note, because /api/notes
+        // reads straight from disk and would otherwise still serve it.
+        expect(artifacts.notes.has(q.id)).toBe(false);
       } else {
         // cat1 and cat2 have questions with no explanation at all.
         expect(q.explanation).toBeNull();
       }
     }
+  });
+
+  it("withholds disabled questions from the shipped JSON but not from the bank", () => {
+    const shipped = new Set(
+      (JSON.parse(artifacts.appJson) as { questions: { id: number }[] }).questions.map((q) => q.id)
+    );
+    for (const q of category.questions) {
+      // `order` keeps the id either way: that is what reserves it against
+      // `nextId` and preserves the editorial position for a later return.
+      expect(manifest.order).toContain(q.id);
+      expect(shipped.has(q.id)).toBe(!isWithheld(q));
+    }
+    expect(artifacts.withheld).toEqual(category.questions.filter(isWithheld).map((q) => q.id));
   });
 });
 
@@ -131,6 +150,58 @@ describe("source directory validation", () => {
         serializeManifest({ id: "3", anacomFile: 90, order: [1] })
       );
       expect(() => loadCategory(dir)).toThrow(/file but not in order: 4/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("withholds a disabled question while keeping it loaded and in order", () => {
+    // The whole mechanism on a two-question category, independent of whatever
+    // the real bank currently has withheld.
+    const dir = makeSourceDir();
+    try {
+      const [first, second] = reference.questions;
+      writeFileSync(
+        join(dir, questionFileName(second!.id)),
+        serializeQuestionFile({ ...second!, disabled: "retirada pela ANACOM" })
+      );
+      writeFileSync(
+        join(dir, MANIFEST_FILE),
+        serializeManifest({ id: "3", anacomFile: 90, order: [first!.id, second!.id] })
+      );
+
+      const category = loadCategory(dir);
+      // Still loaded: qbank and the authoring review must go on seeing it, so
+      // a withdrawn question keeps blocking an accidental re-add.
+      expect(category.questions.map((q) => q.id)).toEqual([first!.id, second!.id]);
+      expect(category.questions[1]!.disabled).toBe("retirada pela ANACOM");
+
+      const { appJson, notes, withheld } = emitCategory(category);
+      expect(withheld).toEqual([second!.id]);
+      const shipped = JSON.parse(appJson) as { questions: { id: number }[] };
+      expect(shipped.questions.map((q) => q.id)).toEqual([first!.id]);
+      expect(notes.has(second!.id)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("round-trips a withheld question through the file format", () => {
+    // Serialization used to list fields explicitly, so a new field that was
+    // not added here would be silently dropped on the next rewrite.
+    const q = { ...reference.questions[0]!, disabled: "retirada pela ANACOM" };
+    const dir = makeSourceDir();
+    try {
+      writeFileSync(join(dir, questionFileName(q.id)), serializeQuestionFile(q));
+      writeFileSync(
+        join(dir, MANIFEST_FILE),
+        serializeManifest({
+          id: "3",
+          anacomFile: 90,
+          order: [q.id, reference.questions[1]!.id],
+        })
+      );
+      expect(loadCategory(dir).questions[0]).toEqual(q);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/__tests__/unit/test-content-schema.test.ts
+++ b/__tests__/unit/test-content-schema.test.ts
@@ -8,7 +8,7 @@
  * the wrong answer marked correct.
  */
 import { describe, it, expect } from "vitest";
-import { safeParseCategory, parseCategory } from "@/lib/content/schema";
+import { safeParseCategory, parseCategory, isWithheld } from "@/lib/content/schema";
 
 /** A minimal valid category; each test breaks one thing. */
 function validCategory() {
@@ -127,6 +127,44 @@ describe("canonical schema", () => {
     const zero = validCategory();
     zero.questions[0]!.sources = [{ pdf: "cat3/2023_08_18", question: 0 }];
     expect(safeParseCategory(zero).success).toBe(false);
+  });
+
+  it("defaults a question to live and carries a withheld reason through", () => {
+    expect(parseCategory(validCategory()).questions[0]!.disabled).toBeNull();
+    expect(isWithheld(parseCategory(validCategory()).questions[0]!)).toBe(false);
+
+    const withheld = validCategory() as Record<string, any>;
+    withheld.questions[0]!.disabled = "retirada pela ANACOM";
+    const q = parseCategory(withheld).questions[0]!;
+    expect(q.disabled).toBe("retirada pela ANACOM");
+    expect(isWithheld(q)).toBe(true);
+  });
+
+  it("rejects `disabled: true`, so the flag cannot parse and mean nothing", () => {
+    // A boolean is what somebody actually wrote once. Zod stripped it as an
+    // unknown key, the build shipped the question anyway, and nothing said so.
+    // The reason is required precisely so that mistake is now loud.
+    const input = validCategory() as Record<string, any>;
+    input.questions[0]!.disabled = true;
+    expect(safeParseCategory(input).success).toBe(false);
+  });
+
+  it("rejects an unknown frontmatter key rather than discarding it", () => {
+    // The general form of the same bug: a mistyped or invented field used to
+    // vanish silently, so the author saw no effect and no error.
+    const input = validCategory() as Record<string, any>;
+    input.questions[0]!.disbaled = "retirada";
+    const result = safeParseCategory(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.map((i) => i.message).join(" ")).toMatch(/disbaled/);
+    }
+  });
+
+  it("treats a question that omits `disabled` entirely as live", () => {
+    // Hand-built questions reach the analysis helpers from test fixtures and
+    // the legacy importer without going through the schema.
+    expect(isWithheld({ disabled: undefined as unknown as string | null })).toBe(false);
   });
 
   it("trims surrounding whitespace rather than preserving it", () => {

--- a/__tests__/unit/test-exam-replay.test.ts
+++ b/__tests__/unit/test-exam-replay.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Exam replay URL round-trip
+ *
+ * The property that matters is that `a` stays pinned to `q` by position, even
+ * when the bank has moved on since the link was made. Withholding a question
+ * is what makes that reachable: an id in an old replay URL stops resolving,
+ * and the reader used to walk the answer string against the questions it could
+ * resolve, silently reassigning every later answer to the wrong question.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  encodeReplayAnswers,
+  decodeReplayIds,
+  decodeReplayAnswers,
+} from "@/lib/exam/replay";
+
+const all = () => true;
+
+describe("exam replay", () => {
+  it("round-trips answers through the URL format", () => {
+    const ids = [10, 20, 30, 40];
+    const answers = { 10: 0, 20: 3, 40: 1 };
+    const a = encodeReplayAnswers(ids, answers);
+
+    expect(a).toBe("03x1");
+    expect(decodeReplayAnswers(ids, a, all)).toEqual(answers);
+  });
+
+  it("parses ids and ignores junk in q", () => {
+    expect(decodeReplayIds("10-20-30")).toEqual([10, 20, 30]);
+    expect(decodeReplayIds("10--x-30")).toEqual([10, 30]);
+  });
+
+  it("encodes an option index above 9 in base36", () => {
+    expect(encodeReplayAnswers([1], { 1: 11 })).toBe("b");
+    expect(decodeReplayAnswers([1], "b", all)).toEqual({ 1: 11 });
+  });
+
+  it("keeps later answers on their own questions when one is withdrawn", () => {
+    // The regression. Question 20 has been withheld since the link was made.
+    const ids = [10, 20, 30, 40];
+    const a = encodeReplayAnswers(ids, { 10: 0, 20: 3, 30: 1, 40: 2 });
+    const available = (id: number) => id !== 20;
+
+    const decoded = decodeReplayAnswers(ids, a, available);
+
+    // 30 and 40 keep their own answers rather than inheriting 20's and 30's.
+    expect(decoded).toEqual({ 10: 0, 30: 1, 40: 2 });
+    expect(decoded[20]).toBeUndefined();
+  });
+
+  it("treats a missing or short answer string as unanswered", () => {
+    expect(decodeReplayAnswers([1, 2], null, all)).toEqual({});
+    expect(decodeReplayAnswers([1, 2, 3], "0", all)).toEqual({ 1: 0 });
+    // More characters than ids: the extras have nothing to attach to.
+    expect(decodeReplayAnswers([1], "012", all)).toEqual({ 1: 0 });
+  });
+});

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { CATEGORIES, CATEGORY_CONFIG, GAMIFICATION_ENABLED } from "@/lib/config"
 import type { CategoryId } from "@/lib/config/categories";
 import { EXAM_CONFIG } from "@/lib/config/exam";
 import { loadData } from "@/lib/data";
+import { encodeReplayAnswers } from "@/lib/exam/replay";
 import type { Data, Question } from "@/lib/types";
 import { useEffect, useMemo, useState } from "react";
 import {
@@ -83,12 +84,7 @@ function parseWeakKey(key: string): { category: string; questionId: number } | n
 function buildReplayHref(exam: ExamAttempt): string | null {
   if (exam.questionIds.length === 0) return null;
   const q = exam.questionIds.join('-');
-  const a = exam.questionIds
-    .map((id) => {
-      const answer = exam.answers[id];
-      return answer === undefined ? 'x' : answer.toString(36);
-    })
-    .join('');
+  const a = encodeReplayAnswers(exam.questionIds, exam.answers);
   return `/exam/${exam.category}?q=${q}&a=${a}&t=0`;
 }
 

--- a/app/exam/[category]/page.tsx
+++ b/app/exam/[category]/page.tsx
@@ -4,6 +4,7 @@ import { useParams, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { Category } from '@/lib/types';
 import { loadData } from '@/lib/data';
+import { decodeReplayIds, decodeReplayAnswers } from '@/lib/exam/replay';
 import { EXAM_CONFIG, DEFAULT_CATEGORY } from '@/lib/config';
 import { ExamResults } from '@/components/ExamResults';
 import { PageLoading } from '@/components/shared/Loading';
@@ -192,24 +193,11 @@ export default function ExamPage() {
       // If a replay URL is present, reconstruct exact exam/order/answers
       if (qParam) {
         isReplayRef.current = true;
-        const ids = qParam.split('-').map((s) => parseInt(s, 10)).filter((n) => !Number.isNaN(n));
+        const ids = decodeReplayIds(qParam);
         const byId = new Map(base.questions.map((q) => [q.id, q] as const));
         const chosen = ids.map((id) => byId.get(id)).filter((q): q is NonNullable<typeof q> => Boolean(q));
         setCategory({ id: base.id, name: base.name, questions: chosen });
-        // Parse answers compact string (base36 for index, 'x' for unanswered)
-        const ans: Record<number, number> = {};
-        if (aParam) {
-          const chars = aParam.split('');
-          for (let i = 0; i < Math.min(chars.length, chosen.length); i++) {
-            const ch = chars[i];
-            const chosenQuestion = chosen[i];
-            if (ch && ch !== 'x' && chosenQuestion) {
-              const idx = parseInt(ch, 36);
-              if (!Number.isNaN(idx)) ans[chosenQuestion.id] = idx;
-            }
-          }
-        }
-        setAnswers(ans);
+        setAnswers(decodeReplayAnswers(ids, aParam, (id) => byId.has(id)));
         const t = tParam ? parseInt(tParam, 10) : 0;
         setTimeLeft(Number.isFinite(t) ? t : 0);
         setQuizEnded(true);

--- a/content/notes/cat3/161.mdx
+++ b/content/notes/cat3/161.mdx
@@ -1,5 +1,0 @@
-**O acesso à categoria 2 faz-se mediante exame, ao qual podem candidatar-se amadores maiores de 16 anos que tenham o tempo mínimo de permanência na categoria 3, ou os amadores da categoria C.**
-
-A ideia por trás desta regra é a progressão: a categoria 3 é a porta de entrada no radioamadorismo, e a categoria 2 é o passo seguinte. Antes de subir, o amador tem de mostrar duas coisas: alguma experiência prática (daí o tempo mínimo de permanência na categoria 3) e conhecimentos suficientes (daí o exame). A categoria C pertence ao sistema de categorias anterior, pelo que quem já a tinha pode também candidatar-se diretamente ao exame.
-
-As outras opções alteram as condições reais: a idade mínima não é 18 nem 12 anos, mas sim 16, e a regulamentação não exige nenhum certificado de escolaridade, como o 9º ano. Basta a idade, a experiência na categoria 3 (ou ser amador da categoria C) e a aprovação no exame.

--- a/content/questions/cat3/0161.mdx
+++ b/content/questions/cat3/0161.mdx
@@ -1,5 +1,6 @@
 ---
 id: 161
+disabled: Retirada do banco a pedido da revisão de conteúdo (2026-08-29).
 question: >-
   Para além do reconhecimento de títulos habilitantes válidos emitidos por
   outras Administrações, como é feito o acesso à categoria 2?

--- a/docs/novas-questoes.md
+++ b/docs/novas-questoes.md
@@ -198,6 +198,7 @@ A classe de funcionamento é definida pelo ângulo de condução…
 | `question` | texto não vazio | **sim** | erro |
 | `answers` | lista, mínimo 2 | **sim** | erro |
 | `topic` | slug da taxonomia | não | `null` |
+| `disabled` | motivo, em texto | não | `null` (pergunta ativa) |
 | `sources` | lista de referências | não | `[]` |
 | `image` | caminho relativo a `public/` | não | `null` |
 | `tutorial` | slug de um guia de estudo | não | `null` |
@@ -205,6 +206,11 @@ A classe de funcionamento é definida pelo ângulo de condução…
 
 O texto é sempre aparado (`trim`), e uma cadeia vazia num campo opcional é
 tratada como `null` (`lib/content/schema.ts:22,30-37`).
+
+**Não há mais campos.** O schema é estrito: um campo inventado ou mal escrito
+faz a compilação falhar com `Unrecognized key: "disbaled"`, em vez de ser
+descartado em silêncio. Antes era descartado, e quem o tinha escrito não via
+erro nenhum nem efeito nenhum.
 
 ### As respostas
 
@@ -366,6 +372,45 @@ O `qbank dupes` é o que apanha uma pergunta que já existe noutra categoria com
 uma resposta diferente — nada no schema consegue ver isso, porque cada ficheiro
 é válido isoladamente.
 
+## Desativar uma pergunta sem a apagar
+
+Quando uma pergunta deixa de servir — foi retirada pelo regulador, está errada,
+ou aguarda revisão — **não se apaga o ficheiro nem se tira o `id` do `order`**.
+Acrescenta-se o motivo:
+
+```yaml
+---
+id: 161
+disabled: Retirada do banco a pedido da revisão de conteúdo (2026-08-29).
+question: >-
+  …
+```
+
+E compila-se: `bun run content:build`. A partir daí a pergunta
+
+- **sai** de `public/data/cat{n}.json`, portanto desaparece do site inteiro —
+  consultar, exame, treino, cartões, contagens do painel
+- **perde** o ficheiro em `content/notes/`, porque a `/api/notes` lê do disco
+  sem consultar o banco e continuaria a servi-lo
+- **fica** no ficheiro de origem e no `order`, portanto o `id` nunca é
+  reatribuído e a posição editorial espera por ela se voltar
+- **continua** a ser comparada pelo `qbank` e pelo `content:new`, portanto
+  ninguém a volta a escrever por engano como se fosse nova
+
+O motivo é **texto, não `true`**. `disabled: true` dá erro de schema, de
+propósito: obriga a dizer porquê, e a versão anterior deste campo era um
+booleano que o schema descartava sem dizer nada — a pergunta continuava no ar.
+
+Para reativar, apaga-se a linha e compila-se outra vez.
+
+Ver quais estão desativadas:
+
+```bash
+bun run content:build          # lista-as no fim
+bun run qbank coverage         # coluna "desativadas"
+bun run qbank show cat3#161    # mostra o motivo
+```
+
 ## Erros comuns
 
 | Mensagem | Causa | Solução |
@@ -378,6 +423,9 @@ uma resposta diferente — nada no schema consegue ver isso, porque cada ficheir
 | `referenced image(s) missing from public/` | `image` aponta para ficheiro inexistente | acrescentar o ficheiro ou remover a referência |
 | `References point at N exam PDF(s) that are not on disk` | `pdf` sem ficheiro em `public/exams/` | ver a secção seguinte |
 | `content check failed … differs from compiled output` | artefacto gerado editado à mão, ou esquecimento do `content:build` | executar `bun run content:build` |
+| `Unrecognized key: "…"` | campo inventado ou mal escrito no frontmatter | corrigir o nome; a lista completa está na tabela acima |
+| `disabled: expected string, received boolean` | `disabled: true` | escrever o motivo em texto |
+| `orphaned — no question generates it` | nota gerada sem pergunta que a produza | executar `bun run content:build`, que a remove |
 
 ## Citar uma prova que não está no repositório
 

--- a/lib/content/analysis.ts
+++ b/lib/content/analysis.ts
@@ -24,6 +24,7 @@
  */
 import { fold } from "../utils/search";
 import { questionFileName } from "./source";
+import { isWithheld } from "./schema";
 import type { ContentCategory, ContentQuestion } from "./schema";
 import type { CategoryId } from "../config/categories";
 import { ABOVE_ENTRY_LEVEL, isTopicSlug } from "../config/topics";
@@ -540,6 +541,8 @@ export function findPairFindings(
 export type CoverageRow = {
   label: string;
   total: number;
+  /** Of `total`, how many are withheld from the build by `disabled`. */
+  withheld: number;
   withSources: number;
   sourceRefs: number;
   refsWithPage: number;
@@ -553,6 +556,7 @@ function coverageRow(label: string, questions: readonly BankQuestion[]): Coverag
   return {
     label,
     total: questions.length,
+    withheld: questions.filter(isWithheld).length,
     withSources: questions.filter((q) => q.sources.length > 0).length,
     sourceRefs: refs.length,
     refsWithPage: refs.filter((s) => s.page !== null).length,

--- a/lib/content/author.ts
+++ b/lib/content/author.ts
@@ -20,7 +20,7 @@
  * - `warning` — legitimate often enough that only a human can say. The bank
  *   examines the same regulatory question at all three levels on purpose.
  */
-import { QuestionSchema, type ContentQuestion } from "./schema";
+import { QuestionSchema, isWithheld, type ContentQuestion } from "./schema";
 import {
   auditAnswers,
   buildBank,
@@ -52,6 +52,8 @@ export type Draft = {
   id?: number;
   question: string;
   answers: DraftAnswer[];
+  /** Reason the question is withheld, for one that arrives already withdrawn. */
+  disabled?: string | null;
   topic?: string | null;
   sources?: { pdf: string; question: number; page?: number | null }[];
   image?: string | null;
@@ -257,6 +259,7 @@ export function reviewDraft(draft: Draft, ctx: ReviewContext): Review {
     id,
     question: draft.question,
     answers: draft.answers,
+    disabled: draft.disabled,
     topic: draft.topic,
     sources: draft.sources,
     image: draft.image,
@@ -329,14 +332,23 @@ export function reviewDraft(draft: Draft, ctx: ReviewContext): Review {
 
   for (const group of duplicates) {
     const others = group.members.filter((m) => m.ref !== draftBank.ref);
-    // A contradiction is the one tier that is never legitimate: same stem,
-    // same options, disagreeing on which option is right. One of the two is
-    // simply wrong, and writing the second one hides it.
+    // Withheld questions stay in the bank precisely so they go on blocking an
+    // accidental re-add. But a contradiction with one is not the defect a
+    // contradiction with a live question is: withdrawing the wrong version and
+    // writing the corrected one is the intended repair, and it would produce
+    // exactly this. So it is still reported, as a warning rather than a block.
+    const live = others.filter((m) => !isWithheld(m));
     findings.push({
-      level: group.tier === "contradiction" ? "error" : "warning",
+      level: group.tier === "contradiction" && live.length > 0 ? "error" : "warning",
       code: `duplicate-${group.tier}`,
-      message: `${group.tier}: já existe em ${others.map((m) => m.ref).join(", ")}.`,
-      detail: others.map((m) => `${m.file} — resposta certa: ${m.correctText}`),
+      message:
+        `${group.tier}: já existe em ${others.map((m) => m.ref).join(", ")}` +
+        (live.length === 0 ? " (desativada)." : "."),
+      detail: others.map(
+        (m) =>
+          `${m.file} — resposta certa: ${m.correctText}` +
+          (isWithheld(m) ? ` [desativada: ${m.disabled}]` : "")
+      ),
     });
   }
 

--- a/lib/content/build.ts
+++ b/lib/content/build.ts
@@ -19,7 +19,7 @@
 import { existsSync, readFileSync, readdirSync } from "fs";
 import { join } from "path";
 import { z } from "zod";
-import { CategorySchema, type ContentCategory, type ContentQuestion } from "./schema";
+import { CategorySchema, isWithheld, type ContentCategory, type ContentQuestion } from "./schema";
 import { parseQuestionFile, questionFileName, idFromFileName } from "./source";
 
 export const CategoryManifestSchema = z.object({
@@ -78,6 +78,8 @@ export type CategoryArtifacts = {
   appJson: string;
   /** Contents of `content/notes/cat{n}/{id}.mdx`, keyed by question id. */
   notes: Map<number, string>;
+  /** Ids withheld from the artifacts by `disabled`, in `order`. */
+  withheld: number[];
 };
 
 /**
@@ -133,14 +135,30 @@ function toAppQuestion(
   return out;
 }
 
-/** Compiles a validated category into the files the app ships. */
+/**
+ * Compiles a validated category into the files the app ships.
+ *
+ * This is the **only** place `disabled` is applied. Withholding a question by
+ * omitting it from the artifact — rather than shipping it with a flag for the
+ * client to filter on — is deliberate: every consumer reads
+ * `category.questions` directly and `lib/data.ts` does no transformation, so a
+ * flag would need the same filter repeated across browse, exam, drill, flash,
+ * smart-practice and the dashboard counts, and the first one to forget it
+ * would show a question that was deliberately withdrawn.
+ *
+ * The note is dropped with the question: there is no point serving an
+ * explanation for something nothing can link to.
+ */
 export function emitCategory(
   category: ContentCategory,
   examsDir = join("public", "exams")
 ): CategoryArtifacts {
   const pdfExists = (pdf: string) => existsSync(join(examsDir, `${pdf}.pdf`));
+  const live = category.questions.filter((q) => !isWithheld(q));
+  const withheld = category.questions.filter(isWithheld).map((q) => q.id);
+
   const notes = new Map<number, string>();
-  for (const q of category.questions) {
+  for (const q of live) {
     if (q.explanation !== null) {
       notes.set(q.id, `${q.explanation}\n`);
     }
@@ -149,12 +167,13 @@ export function emitCategory(
   const app = {
     category: category.id,
     anacomFile: category.anacomFile,
-    questions: category.questions.map((q) => toAppQuestion(q, category.id, pdfExists)),
+    questions: live.map((q) => toAppQuestion(q, category.id, pdfExists)),
   };
 
   return {
     appJson: `${JSON.stringify(app, null, 2)}\n`,
     notes,
+    withheld,
   };
 }
 

--- a/lib/content/schema.ts
+++ b/lib/content/schema.ts
@@ -79,6 +79,20 @@ export const QuestionSchema = z
      * taxonomy is applied — legacy `materia` is empty on every question.
      */
     topic: OptionalText,
+    /**
+     * Why this question is withheld from the build; null when it is live.
+     *
+     * A withheld question stays in its file and keeps its place in the
+     * category's `order`, so the id is never reissued and the question is
+     * still compared against by `qbank` and by `content:new` — a withdrawn
+     * question must go on blocking an accidental re-add of the same thing.
+     * `emitCategory` is the single point that drops it from the artifacts.
+     *
+     * A reason string rather than a boolean on purpose: `disabled: true`
+     * is then a schema error rather than something that parses and means
+     * nothing, and the next reader learns why without a git archaeology dig.
+     */
+    disabled: OptionalText,
     /** Official exam papers this question appears in. */
     sources: z.array(SourceRefSchema).default([]),
     /** Public-relative image path, e.g. "images/cat3/foo.png". */
@@ -88,6 +102,12 @@ export const QuestionSchema = z
     /** Prose explanation. Becomes the MDX body once questions own their notes. */
     explanation: OptionalText,
   })
+  // Unknown keys are an error, not something to discard. Zod strips them by
+  // default, which made an invented frontmatter field (`disabled: true`, once)
+  // parse cleanly and do nothing at all — the silent-typo failure that `topic`
+  // being free text already causes. Nothing in the bank uses a key outside
+  // this list, so the strictness costs nothing and catches the next one.
+  .strict()
   // superRefine rather than refine: Zod 4 takes a static object as refine's
   // second argument, so this is the way to keep the offending question's id
   // and values in the message.
@@ -130,6 +150,18 @@ export const CategorySchema = z.object({
 export type Answer = z.infer<typeof AnswerSchema>;
 export type ContentQuestion = z.infer<typeof QuestionSchema>;
 export type ContentCategory = z.infer<typeof CategorySchema>;
+
+/**
+ * Whether a question is withheld from the build.
+ *
+ * One name for the concept, used by the compiler, `qbank` and the authoring
+ * review alike, and `!= null` rather than `=== null` so a hand-built question
+ * that simply omits the field — a test fixture, a legacy import — reads as
+ * live rather than as withheld-with-an-undefined-reason.
+ */
+export function isWithheld(q: Pick<ContentQuestion, "disabled">): boolean {
+  return q.disabled != null;
+}
 
 /** Parses and validates a category, throwing a readable error on bad data. */
 export function parseCategory(input: unknown): ContentCategory {

--- a/lib/content/source.ts
+++ b/lib/content/source.ts
@@ -58,6 +58,9 @@ export function parseQuestionFile(raw: string, filename: string): ContentQuestio
 export function serializeQuestionFile(q: ContentQuestion): string {
   const frontmatter: Record<string, unknown> = {
     id: q.id,
+    // Second, right under the id: a withheld question should announce itself
+    // in the first two lines rather than hide behind the options.
+    ...(q.disabled === null ? {} : { disabled: q.disabled }),
     question: q.question,
     answers: q.answers.map((a) =>
       // `correct` is omitted on wrong answers: with exactly one correct answer

--- a/lib/exam/replay.ts
+++ b/lib/exam/replay.ts
@@ -1,0 +1,70 @@
+/**
+ * Exam replay URL format
+ *
+ * A finished exam is reconstructed from three query params rather than from
+ * server state: `q` the question ids in order, `a` the answers, `t` the time
+ * left. Nothing is stored anywhere, so the link survives without a database.
+ *
+ * `a` is positional against `q` — one character per id, base36 for the chosen
+ * option index and `x` for unanswered. That pairing is the whole format, and
+ * it used to be written in the dashboard and read in the exam page with no
+ * shared definition between them. They drifted: the reader walked `a` against
+ * the questions it had managed to *resolve*, so a single id it could not find
+ * — a question withdrawn since the link was made — shifted every later answer
+ * onto the wrong question and presented the result as the user's own.
+ *
+ * Hence one module: the two directions are one format and have to move
+ * together.
+ */
+
+/** Unanswered marker. Base36 digits never collide with it. */
+const UNANSWERED = "x";
+
+/** Encodes `a` from the exam's question ids and the answers keyed by id. */
+export function encodeReplayAnswers(
+  questionIds: readonly number[],
+  answers: Readonly<Record<number, number>>
+): string {
+  return questionIds
+    .map((id) => {
+      const answer = answers[id];
+      return answer === undefined ? UNANSWERED : answer.toString(36);
+    })
+    .join("");
+}
+
+/** Parses `q` into ids, dropping anything that is not a number. */
+export function decodeReplayIds(q: string): number[] {
+  return q
+    .split("-")
+    .map((s) => Number.parseInt(s, 10))
+    .filter((n) => !Number.isNaN(n));
+}
+
+/**
+ * Decodes `a` into answers keyed by question id.
+ *
+ * Indexed against `ids` — every id in the URL, including ones no longer in the
+ * bank — because that is what the encoder wrote. `isAvailable` then drops the
+ * answers belonging to questions that cannot be shown, rather than letting
+ * them slide onto their neighbours.
+ */
+export function decodeReplayAnswers(
+  ids: readonly number[],
+  a: string | null,
+  isAvailable: (id: number) => boolean
+): Record<number, number> {
+  const answers: Record<number, number> = {};
+  if (a === null) return answers;
+
+  const chars = [...a];
+  for (let i = 0; i < Math.min(chars.length, ids.length); i++) {
+    const ch = chars[i];
+    const id = ids[i];
+    if (ch === undefined || ch === UNANSWERED || id === undefined) continue;
+    if (!isAvailable(id)) continue;
+    const index = Number.parseInt(ch, 36);
+    if (!Number.isNaN(index)) answers[id] = index;
+  }
+  return answers;
+}

--- a/public/data/cat3.json
+++ b/public/data/cat3.json
@@ -2629,19 +2629,6 @@
       "materia": "regulamentacao"
     },
     {
-      "id": 161,
-      "question": "Para além do reconhecimento de títulos habilitantes válidos emitidos por outras Administrações, como é feito o acesso à categoria 2?",
-      "options": [
-        "Mediante exame ao qual podem candidatar-se amadores maiores de 18 anos, que tenham o tempo mínimo de permanência na categoria 3",
-        "Mediante exame ao qual podem candidatar-se amadores maiores de 16 anos, que tenham o tempo mínimo de permanência na categoria 3 e com certificado do 9º ano emitido por um estabelecimento de ensino reconhecido",
-        "Mediante exame ao qual podem candidatar-se amadores maiores de 12 anos da categoria 3 ou da categoria C",
-        "Mediante exame ao qual podem candidatar-se amadores maiores de 16 anos, que tenham o tempo mínimo de permanência na categoria 3 ou os amadores da categoria C"
-      ],
-      "correctIndex": 3,
-      "hasNotesMdx": true,
-      "materia": "regulamentacao"
-    },
-    {
       "id": 162,
       "question": "Para além do reconhecimento de títulos habilitantes válidos emitidos por outras Administrações, como é feito o acesso à categoria 1?",
       "options": [

--- a/scripts/content-build.ts
+++ b/scripts/content-build.ts
@@ -12,7 +12,7 @@
  * Only categories that have a source directory are touched, so cat1 and cat2
  * keep shipping their hand-maintained JSON until they are migrated too.
  */
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, rmSync } from "fs";
 import { join } from "path";
 import {
   loadCategory,
@@ -29,7 +29,9 @@ const check = process.argv.includes("--check");
 
 let changed = 0;
 let checked = 0;
+let removed = 0;
 const problems: string[] = [];
+const withheld: { category: string; ids: number[] }[] = [];
 
 function compare(path: string, expected: string) {
   checked++;
@@ -47,6 +49,29 @@ function compare(path: string, expected: string) {
   changed++;
 }
 
+/**
+ * Deletes generated notes that no question claims any more.
+ *
+ * `compare` only ever writes the files it is given, so withholding or removing
+ * a question used to leave its note behind — and `/api/notes` reads straight
+ * from disk without consulting the bank, so that stale file stayed publicly
+ * readable for a question nothing links to. Sweeping is the other half of
+ * generating.
+ */
+function sweepNotes(dir: string, keep: ReadonlySet<string>) {
+  if (!existsSync(dir)) return;
+  for (const name of readdirSync(dir)) {
+    if (!/^\d+\.mdx$/.test(name) || keep.has(name)) continue;
+    const path = join(dir, name);
+    if (check) {
+      problems.push(`${path}: orphaned — no question generates it`);
+      continue;
+    }
+    rmSync(path);
+    removed++;
+  }
+}
+
 const loaded: ContentCategory[] = [];
 
 for (const category of CATEGORIES) {
@@ -55,12 +80,15 @@ for (const category of CATEGORIES) {
 
   const parsed = loadCategory(sourceDir);
   loaded.push(parsed);
-  const { appJson, notes } = emitCategory(parsed);
+  const { appJson, notes, withheld: ids } = emitCategory(parsed);
+  if (ids.length > 0) withheld.push({ category, ids });
 
   compare(join("public", "data", `cat${category}.json`), appJson);
+  const notesDir = join("content", "notes", `cat${category}`);
   for (const [id, body] of notes) {
-    compare(join("content", "notes", `cat${category}`, `${id}.mdx`), body);
+    compare(join(notesDir, `${id}.mdx`), body);
   }
+  sweepNotes(notesDir, new Set([...notes.keys()].map((id) => `${id}.mdx`)));
 }
 
 if (checked === 0) {
@@ -123,6 +151,12 @@ if (dangling.length > 0) {
   }
 }
 
+if (withheld.length > 0) {
+  const total = withheld.reduce((sum, w) => sum + w.ids.length, 0);
+  console.log(`\n${total} question(s) withheld by \`disabled\` — in the bank, not in the artifacts:`);
+  for (const w of withheld) console.log(`  cat${w.category}: ${w.ids.join(", ")}`);
+}
+
 if (check) {
   if (problems.length > 0) {
     console.error(`content check failed (${problems.length} of ${checked} files):`);
@@ -133,5 +167,8 @@ if (check) {
   }
   console.log(`content check passed — ${checked} artifacts match their source`);
 } else {
-  console.log(`content build complete — ${changed} of ${checked} artifacts written`);
+  console.log(
+    `content build complete — ${changed} of ${checked} artifacts written` +
+      (removed > 0 ? `, ${removed} orphaned note(s) removed` : "")
+  );
 }

--- a/scripts/content-new.ts
+++ b/scripts/content-new.ts
@@ -293,6 +293,7 @@ function draftFromFile(raw: string, category: CategoryId | null): Draft {
     id: typeof fields.id === "number" ? fields.id : undefined,
     question: fields.question as string,
     answers: fields.answers as Draft["answers"],
+    disabled: (fields.disabled ?? null) as string | null,
     topic: (fields.topic ?? null) as string | null,
     sources: fields.sources as Draft["sources"],
     image: (fields.image ?? null) as string | null,

--- a/scripts/qbank.ts
+++ b/scripts/qbank.ts
@@ -24,6 +24,7 @@
 import { existsSync, readFileSync, readdirSync, writeFileSync, statSync } from "fs";
 import { join } from "path";
 import { loadCategory } from "../lib/content/build";
+import { isWithheld } from "../lib/content/schema";
 import { fold } from "../lib/utils/search";
 import {
   buildBank,
@@ -275,7 +276,12 @@ function tierLabel(tier: DuplicateTier): string {
 
 function renderQuestion(q: BankQuestion, needle?: string): void {
   const topic = q.topic === null ? dim("sem matéria") : cyan(topicShortLabel(q.topic, "pt") ?? q.topic);
-  say(`${bold(q.ref)}  ${topic}  ${dim(where(q, needle))}`);
+  // A withheld question is still compared against everything else — that is the
+  // point of keeping it in the bank — so it has to be obvious at a glance that
+  // what you are reading is not what the site is serving.
+  const mark = isWithheld(q) ? `  ${red(bold("desativada"))}` : "";
+  say(`${bold(q.ref)}  ${topic}${mark}  ${dim(where(q, needle))}`);
+  if (isWithheld(q)) say(`  ${red(`desativada: ${q.disabled}`)}`);
   say(`  ${q.question}`);
   for (const a of q.answers) {
     say(`   ${a.correct ? green("✓") : dim("·")} ${clip(a.text, 100)}`);
@@ -322,7 +328,13 @@ function cmdSearch(): void {
 
   if (asJson) {
     return flush(
-      bank.map((q) => ({ ref: q.ref, file: q.file, question: q.question, topic: q.topic }))
+      bank.map((q) => ({
+        ref: q.ref,
+        file: q.file,
+        question: q.question,
+        topic: q.topic,
+        disabled: q.disabled,
+      }))
     );
   }
 
@@ -573,10 +585,11 @@ function cmdCoverage(): void {
 
   const pct = (n: number, total: number) =>
     total === 0 ? "—" : `${Math.round((n / total) * 100)}%`;
-  const head = ["", "total", "com fonte", "refs", "com página", "explicadas", "imagens", "matéria"];
+  const head = ["", "total", "desativadas", "com fonte", "refs", "com página", "explicadas", "imagens", "matéria"];
   const table = rows.map((r) => [
     r.label,
     String(r.total),
+    r.withheld === 0 ? dim("—") : red(String(r.withheld)),
     `${r.withSources} ${dim(pct(r.withSources, r.total))}`,
     String(r.sourceRefs),
     `${r.refsWithPage} ${dim(pct(r.refsWithPage, r.sourceRefs))}`,


### PR DESCRIPTION
Não havia forma de tirar uma pergunta do ar. Tentou-se duas, nenhuma funcionou: mover o ficheiro para `disabled/` (funciona por acidente, mas esconde a pergunta do `qbank` e obriga a tirar o `id` do `order`) e `disabled: true` no frontmatter, que o schema descartava em silêncio — sem erro, sem efeito, a pergunta continuava publicada.

## Como se desativa agora

```yaml
---
id: 161
disabled: Retirada do banco a pedido da revisão de conteúdo (2026-08-29).
```

`bun run content:build`, e a partir daí a pergunta:

- **sai** do `public/data/cat{n}.json` — desaparece de consultar, exame, treino, cartões e contagens do painel
- **perde** a nota gerada, porque a `/api/notes` lê do disco sem consultar o banco e continuaria a servir a explicação
- **fica** no ficheiro de origem e no `order`, portanto o `id` nunca é reatribuído e a posição editorial espera por ela
- **continua** a ser comparada pelo `qbank` e pelo `content:new`, portanto ninguém a volta a escrever por engano

O `emitCategory` é o único sítio onde a flag é aplicada. Todos os consumidores leem `category.questions` diretamente e o `lib/data.ts` não transforma nada, por isso uma flag enviada ao cliente teria de ser filtrada em dez sítios e bastava um esquecer-se.

## Schema estrito

`QuestionSchema` passa a `.strict()`: um campo inventado ou mal escrito falha a compilação a dizer qual é, em vez de ser descartado. É a causa de raiz — sem isto, a próxima pessoa escreve outro campo que não existe e não vê nada acontecer.

O motivo é **texto, não `true`**: obriga a dizer porquê, e faz com que a flag não possa ser válida e não significar nada. Verificado que nenhuma das 1016 perguntas usa um campo fora do schema, por isso a estritez não parte nada.

## Pelo caminho

- **Notas órfãs**: o `content:build` varre-as, o `content:check` denuncia-as.
- **Reconstrução de exames antigos**: o `a=` era escrito contra todos os ids e lido contra os que o cliente conseguia resolver, pelo que um id em falta deslocava todas as respostas seguintes para a pergunta errada e mostrava o resultado como se fosse do utilizador. Já era um bug; desativar perguntas é o que o passava a acionar. As duas direções passam a viver em `lib/exam/replay.ts`.

## Duas decisões discutíveis

- Uma contradição com uma pergunta **desativada** é aviso, não erro: retirar a versão errada e escrever a corrigida é a reparação pretendida, e um erro bloqueava-a.
- As verificações de imagens e PDFs continuam a aplicar-se às desativadas, para que reativar uma nunca parta a compilação de surpresa.

## Estado

`lint`, `type-check`, 341 testes e `bun run build` passam. A cat3#161 fica desativada — a cat3 publica 210 perguntas em vez de 211.