### PR TITLE
Mostrar a posição no order: `qbank order`

### DIFF
--- a/__tests__/unit/test-content-analysis.test.ts
+++ b/__tests__/unit/test-content-analysis.test.ts
@@ -12,6 +12,8 @@ import {
   auditPapers,
   auditTopics,
   parseRef,
+  orderEntries,
+  entriesAround,
   type DuplicateTier,
 } from "@/lib/content/analysis";
 import type { ContentCategory, ContentQuestion } from "@/lib/content/schema";
@@ -29,6 +31,7 @@ function q(
     question,
     answers: options.map((text, i) => ({ text, correct: i === correctIndex })),
     topic: null,
+    disabled: null,
     sources: [],
     image: null,
     tutorial: null,
@@ -293,5 +296,46 @@ describe("Unit: parseRef", () => {
     expect(parseRef("cat1/284")).toEqual({ category: "1", id: 284 });
     expect(parseRef("nonsense")).toBeNull();
     expect(parseRef("cat4#1")).toBeNull();
+  });
+});
+
+describe("Unit: browse sequence positions", () => {
+  // `order` is editorial: ids are deliberately out of sequence, and the
+  // position is what a question's placement actually means.
+  const bank = buildBank([
+    category("3", [q(50, "a", ["x", "y"]), q(7, "b", ["x", "y"]), q(31, "c", ["x", "y"])]),
+    category("2", [q(9, "d", ["x", "y"]), q(4, "e", ["x", "y"])]),
+  ]);
+
+  it("numbers each question by its place in its own category", () => {
+    expect(orderEntries(bank).map((e) => [e.question.ref, e.position, e.total])).toEqual([
+      ["cat3#50", 1, 3],
+      ["cat3#7", 2, 3],
+      ["cat3#31", 3, 3],
+      ["cat2#9", 1, 2],
+      ["cat2#4", 2, 2],
+    ]);
+  });
+
+  it("counts a withheld question as occupying its position", () => {
+    // It stays in `order`, which is what reserves the id and holds the slot.
+    const withHeld = buildBank([
+      category("3", [
+        q(1, "a", ["x", "y"]),
+        q(2, "b", ["x", "y"], 0, { disabled: "retirada" }),
+        q(3, "c", ["x", "y"]),
+      ]),
+    ]);
+    const entries = orderEntries(withHeld);
+    expect(entries.map((e) => e.position)).toEqual([1, 2, 3]);
+    expect(entries[2]!.question.id).toBe(3);
+  });
+
+  it("windows entries around a position, clamped at the ends", () => {
+    const entries = orderEntries(bank).filter((e) => e.question.category === "3");
+    expect(entriesAround(entries, 2, 1).map((e) => e.position)).toEqual([1, 2, 3]);
+    // A window at the start cannot reach below position 1.
+    expect(entriesAround(entries, 1, 1).map((e) => e.position)).toEqual([1, 2]);
+    expect(entriesAround(entries, 2, 0).map((e) => e.position)).toEqual([2]);
   });
 });

--- a/docs/novas-questoes.md
+++ b/docs/novas-questoes.md
@@ -143,13 +143,16 @@ As categorias são `3` (iniciado), `2` e `1` (avançado) — a progressão
 portuguesa de licenciamento, por isso a ordem habitual é 3 → 2 → 1.
 
 O `id` é único **dentro da categoria**, não em todo o banco. A regra é usar o
-**máximo atual mais um**:
+**máximo atual mais um**. Não vale a pena decorar os números — mudam sempre que
+alguém acrescenta uma pergunta, e a tabela que aqui estava ficou
+desatualizada da primeira vez que isso aconteceu:
 
-| Categoria | Perguntas | `id` mais alto | Próximo `id` |
-| --- | --- | --- | --- |
-| cat3 | 209 | 213 | 214 |
-| cat2 | 418 | 422 | 423 |
-| cat1 | 389 | 390 | 391 |
+```bash
+for c in 3 2 1; do python3 -c "
+import json
+o = json.load(open('content/questions/cat$c/category.json'))['order']
+print(f'cat$c: {len(o)} perguntas, id máx {max(o)}, próximo {max(o) + 1}')"; done
+```
 
 Há lacunas na numeração — `id` 352 em cat1, por exemplo, está livre. **Não se
 reaproveitam.** A razão está no commit que adicionou a última pergunta:
@@ -159,12 +162,6 @@ reaproveitam.** A razão está no commit que adicionou a última pergunta:
 
 Uma ligação antiga para `cat1#352` passaria a mostrar uma pergunta diferente,
 sem erro nenhum.
-
-Para confirmar o máximo atual antes de escolher:
-
-```bash
-python3 -c "import json;print(max(json.load(open('content/questions/cat3/category.json'))['order']))"
-```
 
 ## 2. Criar o ficheiro da pergunta
 
@@ -317,6 +314,16 @@ O manifesto tem três campos: `id`, `anacomFile` e `order`. Só o `order` muda.
 posições 8, 10, 19 e 31, agrupadas por assunto, e é esta sequência que o
 utilizador vê ao navegar. O `id` novo entra onde a pergunta faz sentido
 tematicamente, não no fim.
+
+Para ver onde a matéria já vive, e escolher entre que duas perguntas inserir:
+
+```bash
+bun run qbank order --cat 3 --topic regulamentacao   # onde está a matéria
+bun run qbank order --around cat3#161                # os vizinhos de uma posição
+```
+
+As posições saem salteadas, e é esse o ponto: uma matéria está espalhada pela
+sequência, e o lugar da pergunta nova é entre duas destas.
 
 É por isso que o `order` vive num manifesto: inserir uma pergunta é uma
 alteração de uma linha, em vez de renumerar todos os ficheiros seguintes.

--- a/docs/qbank.md
+++ b/docs/qbank.md
@@ -81,6 +81,7 @@ duplicate question is often entirely legitimate.
 | `dupes` | Which questions duplicate each other, and do they agree? |
 | `pairs` | Which questions are *nearly* the same, and which are traps? |
 | `coverage` | What is missing — sources, pages, explanations, images? |
+| `order` | Where does a question sit in the browse sequence — and where would a new one go? |
 | `topics` | How is the taxonomy distributed, and what is misfiled? |
 | `paper [pdf]` | What cites this exam paper, and what is unclaimed? |
 | `answers` | Is the bank guessable? Are any options malformed? |
@@ -183,11 +184,11 @@ Jaccard over tokens.
 ## coverage
 
 ```
-      total  com fonte  refs  com página  explicadas  imagens  matéria
-cat3  209    60 29%   75    75 100%    209 100%   15      209 100%
-cat2  418    317 76%  893   0 0%       158 38%    8       418 100%
-cat1  389    194 50%  285   98 34%     389 100%   15      389 100%
-all   1016   571 56%  1253  173 14%    756 74%    38      1016 100%
+      total  desativadas  com fonte  refs  com página  explicadas  imagens  matéria
+cat3  211    1            66 31%     87    87 100%     209 99%     15       211 100%
+cat2  418    —            317 76%    893   0 0%        158 38%     8        418 100%
+cat1  389    —            194 50%    285   98 34%      389 100%    15       389 100%
+all   1018   1            577 57%    1265  185 15%     756 74%     38       1018 100%
 ```
 
 Reads as: 445 questions cite no exam paper at all, 1,080 of the 1,253 source
@@ -198,6 +199,38 @@ It also lists images on disk that no question references. Category covers are
 excluded, since those are referenced from `lib/config/categories.ts` rather than
 from a question. The reverse check — references with no file — belongs to
 `content:check` and is not repeated here.
+
+The `desativadas` column counts questions withheld by `disabled`: still in the
+bank and still compared against, but not shipped. They are included in `total`,
+which is why it can exceed what the site serves.
+
+## order
+
+Answers the one question `content:new` refuses to answer on its own: where in
+the browse sequence does a new question belong? The order is editorial rather
+than numeric, so the slot is defined by neighbours, not by id.
+
+```
+$ qbank order --cat 3 --topic regulamentacao
+Regulamentação · 61 pergunta(s)
+  as posições são salteadas — o order é editorial, não agrupado
+
+    1/211  #1  O Regulamento das Radiocomunicações é uma publicação
+    3/211  #5  Qual das seguintes não constitui uma obrigação dos utilizadores de…
+    7/211  #9  Quais as sub-faixas que em VHF são permitidas para a operação de…
+```
+
+The gaps are the point: a subject is spread through the sequence, and a new
+question goes between two of these. `--around cat3#161` shows a window either
+side of one position instead (`--radius N`, default 5), which is what you want
+when inserting beside a specific question rather than into a subject.
+
+Withheld questions appear, marked `desativada` — they still hold their place in
+`order`, which is what reserves the id and keeps the slot for a return.
+
+Positions come from `orderEntries` in `lib/content/analysis.ts`, the same
+function `content:new` uses to show its neighbourhood, so the two cannot
+disagree about what position a question is in.
 
 ## topics
 
@@ -420,6 +453,7 @@ passa — uma pergunta duplicada é muitas vezes perfeitamente legítima.
 | `dupes` | Que perguntas se duplicam, e concordam entre si? |
 | `pairs` | Que perguntas são *quase* iguais, e quais são armadilhas? |
 | `coverage` | O que falta — fontes, páginas, explicações, imagens? |
+| `order` | Onde está uma pergunta na sequência de navegação — e onde entraria uma nova? |
 | `topics` | Como está distribuída a taxonomia, e o que está mal classificado? |
 | `paper [pdf]` | O que cita esta prova, e o que ficou por atribuir? |
 | `answers` | O banco é adivinhável? Há opções malformadas? |
@@ -527,11 +561,11 @@ Jaccard sobre tokens.
 ## coverage
 
 ```
-      total  com fonte  refs  com página  explicadas  imagens  matéria
-cat3  209    60 29%   75    75 100%    209 100%   15      209 100%
-cat2  418    317 76%  893   0 0%       158 38%    8       418 100%
-cat1  389    194 50%  285   98 34%     389 100%   15      389 100%
-all   1016   571 56%  1253  173 14%    756 74%    38      1016 100%
+      total  desativadas  com fonte  refs  com página  explicadas  imagens  matéria
+cat3  211    1            66 31%     87    87 100%     209 99%     15       211 100%
+cat2  418    —            317 76%    893   0 0%        158 38%     8        418 100%
+cat1  389    —            194 50%    285   98 34%      389 100%    15       389 100%
+all   1018   1            577 57%    1265  185 15%     756 74%     38       1018 100%
 ```
 
 Lê-se: 445 perguntas não citam nenhuma prova, 1080 das 1253 referências de fonte
@@ -542,6 +576,41 @@ Também lista imagens em disco que nenhuma pergunta referencia. As capas de
 categoria ficam de fora, por serem referenciadas a partir de
 `lib/config/categories.ts` e não de uma pergunta. A verificação inversa —
 referências sem ficheiro — pertence ao `content:check` e não é repetida aqui.
+
+A coluna `desativadas` conta as perguntas retidas pelo `disabled`: continuam no
+banco e continuam a ser comparadas, mas não são publicadas. Entram no `total`,
+que por isso pode ser maior do que o que o site serve.
+
+## order
+
+Responde à única pergunta que o `content:new` se recusa a responder sozinho:
+onde é que uma pergunta nova entra na sequência de navegação? A ordem é
+editorial, não numérica, por isso o lugar define-se pelos vizinhos e não pelo
+`id`.
+
+```
+$ qbank order --cat 3 --topic regulamentacao
+Regulamentação · 61 pergunta(s)
+  as posições são salteadas — o order é editorial, não agrupado
+
+    1/211  #1  O Regulamento das Radiocomunicações é uma publicação
+    3/211  #5  Qual das seguintes não constitui uma obrigação dos utilizadores de…
+    7/211  #9  Quais as sub-faixas que em VHF são permitidas para a operação de…
+```
+
+As posições saltadas são o ponto: uma matéria está espalhada pela sequência, e
+a pergunta nova entra entre duas destas. O `--around cat3#161` mostra antes uma
+janela de cada lado de uma posição (`--radius N`, por omissão 5), que é o que
+se quer quando se insere ao lado de uma pergunta concreta em vez de dentro de
+uma matéria.
+
+As perguntas desativadas aparecem, marcadas `desativada` — continuam a ocupar o
+seu lugar no `order`, que é o que reserva o `id` e guarda a posição para um
+regresso.
+
+As posições vêm do `orderEntries` em `lib/content/analysis.ts`, a mesma função
+que o `content:new` usa para mostrar a vizinhança, por isso as duas não podem
+discordar sobre a posição de uma pergunta.
 
 ## topics
 

--- a/lib/content/analysis.ts
+++ b/lib/content/analysis.ts
@@ -227,6 +227,58 @@ function groupBy<T>(items: readonly T[], key: (item: T) => string): Map<string, 
 }
 
 /* -------------------------------------------------------------------------- */
+/* The browse sequence                                                         */
+/* -------------------------------------------------------------------------- */
+
+export type OrderEntry = {
+  question: BankQuestion;
+  /** 1-based position in its category's `order`. */
+  position: number;
+  /** How many questions that category's `order` holds. */
+  total: number;
+};
+
+/**
+ * Pairs every question with its position in the browse sequence.
+ *
+ * `order` is editorial, not numeric — cat3's 210-213 sit at positions 8, 10,
+ * 19 and 31, grouped by subject — so "where does a new question go?" is a
+ * question about neighbours, not about ids, and it cannot be answered without
+ * seeing the positions. `content:new` computed this inline to show the
+ * neighbourhood it asks about; `qbank order` needs the same numbers, and two
+ * copies of "position" would be two chances to disagree about it.
+ *
+ * Takes the bank as `load()` builds it: whole categories, each already in
+ * `order`. Positions are counted per category, so a `--cat` filter is fine but
+ * an arbitrary subset would number the survivors rather than locate them.
+ */
+export function orderEntries(bank: readonly BankQuestion[]): OrderEntry[] {
+  const totals = new Map<CategoryId, number>();
+  for (const q of bank) totals.set(q.category, (totals.get(q.category) ?? 0) + 1);
+
+  const seen = new Map<CategoryId, number>();
+  return bank.map((question) => {
+    const position = (seen.get(question.category) ?? 0) + 1;
+    seen.set(question.category, position);
+    return { question, position, total: totals.get(question.category) ?? 0 };
+  });
+}
+
+/**
+ * A window of `radius` entries either side of one position.
+ *
+ * What you want when inserting beside a specific question rather than into a
+ * subject: the slot is defined by what sits on both sides of it.
+ */
+export function entriesAround(
+  entries: readonly OrderEntry[],
+  position: number,
+  radius: number
+): OrderEntry[] {
+  return entries.filter((e) => Math.abs(e.position - position) <= radius);
+}
+
+/* -------------------------------------------------------------------------- */
 /* Duplicate groups                                                            */
 /* -------------------------------------------------------------------------- */
 

--- a/scripts/content-new.ts
+++ b/scripts/content-new.ts
@@ -41,7 +41,7 @@ import {
   type CategoryManifest,
 } from "../lib/content/build";
 import { serializeQuestionFile, questionFileName } from "../lib/content/source";
-import { buildBank, type BankQuestion } from "../lib/content/analysis";
+import { buildBank, orderEntries, type BankQuestion } from "../lib/content/analysis";
 import {
   reviewDraft,
   insertIntoOrder,
@@ -543,8 +543,10 @@ function anchorFromFlags(): OrderAnchor | null {
  * that neighbourhood instead of quietly appending.
  */
 async function askAnchor(category: ContentCategory, topic: string | null): Promise<OrderAnchor> {
-  const entries = category.questions.map((q, i) => ({ position: i + 1, q }));
-  const sameTopic = topic === null ? [] : entries.filter((e) => e.q.topic === topic);
+  // Positions come from `orderEntries`, the same function `qbank order` uses,
+  // so the neighbourhood shown here and the one shown there cannot disagree.
+  const entries = orderEntries(buildBank([category]));
+  const sameTopic = topic === null ? [] : entries.filter((e) => e.question.topic === topic);
   const shown = sameTopic.length > 0 ? sameTopic.slice(-12) : entries.slice(-8);
 
   console.log(`\n${bold("Posição no order")} ${dim("— é editorial, não numérica")}`);
@@ -557,7 +559,7 @@ async function askAnchor(category: ContentCategory, topic: string | null): Promi
   );
   for (const e of shown) {
     const position = dim(`pos ${String(e.position).padStart(3)}`);
-    console.log(`  ${position}  ${bold(`#${e.q.id}`)}  ${clip(e.q.question, 76)}`);
+    console.log(`  ${position}  ${bold(`#${e.question.id}`)}  ${clip(e.question.question, 76)}`);
   }
 
   for (;;) {

--- a/scripts/qbank.ts
+++ b/scripts/qbank.ts
@@ -31,6 +31,8 @@ import {
   findDuplicateGroups,
   findPairFindings,
   coverage,
+  orderEntries,
+  entriesAround,
   auditTopics,
   auditPapers,
   auditAnswers,
@@ -613,6 +615,91 @@ function cmdCoverage(): void {
   flush();
 }
 
+/**
+ * Where questions sit in the browse sequence, and therefore where a new one
+ * would go. The one decision `content:new` refuses to take on its own, and
+ * until now the only way to see it was to run `content:new` interactively.
+ */
+function cmdOrder(): void {
+  const bank = load();
+  const entries = orderEntries(bank);
+
+  const topic = flag("topic");
+  const around = flag("around");
+
+  let shown = entries;
+  let heading: string;
+
+  if (around !== undefined) {
+    const parsed = parseRef(around) ?? parseRef(`cat3#${around}`);
+    const anchor = parsed
+      ? entries.find((e) => e.question.category === parsed.category && e.question.id === parsed.id)
+      : undefined;
+    if (!anchor) {
+      say(red(`não existe a pergunta ${around}`));
+      return flush([]);
+    }
+    const radius = num("radius", 5);
+    shown = entriesAround(entries, anchor.position, radius).filter(
+      (e) => e.question.category === anchor.question.category
+    );
+    heading =
+      `cat${anchor.question.category} · à volta de ${bold(anchor.question.ref)} ` +
+      `(posição ${anchor.position} de ${anchor.total})`;
+  } else if (topic !== undefined) {
+    const slug = topic.trim();
+    shown = entries.filter((e) => e.question.topic === slug);
+    if (shown.length === 0) {
+      say(red(`nenhuma pergunta com a matéria "${slug}"`));
+      say(dim("  as matérias válidas estão em docs/topicos.md e em `qbank topics`"));
+      return flush([]);
+    }
+    heading = `${topicShortLabel(slug, "pt") ?? slug} · ${shown.length} pergunta(s)`;
+  } else {
+    heading = `${shown.length} pergunta(s) na sequência de navegação`;
+  }
+
+  if (asJson) {
+    return flush(
+      shown.map((e) => ({
+        ref: e.question.ref,
+        position: e.position,
+        total: e.total,
+        topic: e.question.topic,
+        disabled: e.question.disabled,
+        question: e.question.question,
+      }))
+    );
+  }
+
+  say(bold(heading));
+  if (topic !== undefined && around === undefined) {
+    // The gaps are the point, not a defect: a subject is spread through the
+    // sequence, and the slot for a new question is between two of these.
+    say(dim("  as posições são salteadas — o order é editorial, não agrupado"));
+  }
+  say();
+
+  const clipped = shown.slice(0, limit);
+  const width = Math.max(...clipped.map((e) => String(e.total).length));
+  for (const e of clipped) {
+    const pos = dim(`${String(e.position).padStart(width)}/${e.total}`);
+    const mark = isWithheld(e.question) ? ` ${red("desativada")}` : "";
+    const label =
+      topic === undefined && e.question.topic !== null
+        ? `  ${cyan(topicShortLabel(e.question.topic, "pt") ?? e.question.topic)}`
+        : "";
+    say(`  ${pos}  ${bold(`#${e.question.id}`)}${mark}  ${clip(e.question.question, 74)}${label}`);
+  }
+  if (shown.length > clipped.length) {
+    say(dim(`  …e mais ${shown.length - clipped.length} (--limit ${shown.length} para ver todas)`));
+  }
+
+  say();
+  say(dim("  inserir uma pergunta nova aqui: content:new --after <id>, --before <id> ou --end"));
+  flush();
+}
+
 function cmdTopics(): void {
   const bank = load();
   const audit = auditTopics(bank);
@@ -796,6 +883,7 @@ function usage(): void {
   say("  dupes            grupos de duplicados, o pior primeiro  [--tier] [--new] [--update-baseline]");
   say("  pairs            quase-duplicados e inversões de polaridade  [--kind] [--new]");
   say("  coverage         fontes, explicações, imagens, órfãs");
+  say("  order            a sequência de navegação e a posição de cada pergunta  [--topic slug] [--around ref] [--radius N]");
   say("  topics           distribuição da taxonomia e casos fora do nível");
   say("  paper [pdf]      o que cita uma prova, e o que ficou por reclamar");
   say("  answers          auditoria à construção das respostas");
@@ -812,6 +900,7 @@ const commands: Record<string, () => void> = {
   duplicates: cmdDupes,
   pairs: cmdPairs,
   coverage: cmdCoverage,
+  order: cmdOrder,
   topics: cmdTopics,
   paper: cmdPaper,
   papers: cmdPaper,


### PR DESCRIPTION
A ordem de navegação é editorial, não numérica — em cat3 as perguntas 210-213 estão nas posições 8, 10, 19 e 31 — por isso o lugar de uma pergunta nova define-se pelos vizinhos, não pelo `id`. A regra estava documentada nos dois caminhos do `docs/novas-questoes.md`, mas só o `content:new` interativo mostrava a vizinhança. Quem escrevesse o ficheiro à mão sabia o que decidir sem ter como consultar nada.

## `qbank order`

```
qbank order [--cat 3] [--topic slug] [--around ref] [--radius N] [--limit N] [--json]
```

```
$ bun run qbank order --cat 3 --topic regulamentacao
Regulamentação · 61 pergunta(s)
  as posições são salteadas — o order é editorial, não agrupado

    1/211  #1  O Regulamento das Radiocomunicações é uma publicação
    3/211  #5  Qual das seguintes não constitui uma obrigação dos utilizadores de…
    7/211  #9  Quais as sub-faixas que em VHF são permitidas para a operação de…
```

As posições saltadas são a resposta, não um defeito: a matéria está espalhada pela sequência e a pergunta nova entra entre duas destas.

`--around cat3#161` mostra antes uma janela de cada lado de uma posição (`--radius`, por omissão 5), para inserir ao lado de uma pergunta concreta. As desativadas aparecem marcadas — continuam a ocupar o seu lugar no `order`.

## Uma só definição de "posição"

As posições passam a vir do `orderEntries`, em `lib/content/analysis.ts`, que o `askAnchor` do `content:new` também usa. Duas cópias de "posição" eram duas oportunidades para discordarem.

Verificado ponta a ponta: `qbank order --around cat3#161` põe a 161 na posição 163, e `content:new --after 161` responde "posição 164 de 212".

## De caminho

O comando explica a cat3#161: aparece imediatamente acima da #162 com um enunciado quase igual, e o `qbank pairs` confirma — `cat3#161 ↔ cat3#162, enunciado 0.90`. Foi retirada por duplicar a vizinha, que é precisamente o caso para a manter no banco em vez de a apagar.

## Documentação

- A tabela de ids em `docs/novas-questoes.md` dá lugar ao comando que a gera. Estava errada desde a primeira pergunta acrescentada depois de ter sido escrita (dizia cat3 209/213/214; é 211/215/216) e voltaria a estar.
- Os exemplos de `coverage` no `docs/qbank.md` eram anteriores à coluna `desativadas`.
- O `order` fica documentado nas duas metades, inglesa e portuguesa.

## Estado

`lint`, `type-check` e 344 testes passam. Três testes novos sobre o `orderEntries`/`entriesAround`, incluindo que uma pergunta desativada continua a ocupar a sua posição.