### PR TITLE
Recusar argumentos inválidos no qbank

### DIFF
--- a/__tests__/unit/test-cli-args.test.ts
+++ b/__tests__/unit/test-cli-args.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Argument parsing and validation
+ *
+ * What these pin down is that bad input is *refused*. The parser used to
+ * absorb it: `--tier inventado` reported `0 grupo(s)`, `--cat 5` printed a
+ * table of zeros, `--limt` was ignored. Every one of those reads as a clean
+ * bank — the answer you were hoping for — so a typo ended the search instead
+ * of wasting a run. That is the same class of silent-and-plausible failure the
+ * tool exists to find in the content.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  parseArgs,
+  validateFlags,
+  nearest,
+  canonicalValue,
+  type FlagSpec,
+} from "@/lib/cli/args";
+import { levenshtein } from "@/lib/content/analysis";
+
+const FLAGS: Record<string, FlagSpec> = {
+  json: { describe: "json" },
+  regex: { describe: "regex" },
+  limit: { describe: "limit", placeholder: "<n>", number: "int" },
+  "stem-min": { describe: "stem", placeholder: "<0-1>", number: "ratio" },
+  cat: { describe: "cat", placeholder: "<3,2,1>", values: ["1", "2", "3"] },
+  tier: {
+    describe: "tier",
+    placeholder: "<lista>",
+    values: ["contradiction", "typo", "exact"],
+    aliases: { gralha: "typo", exato: "exact" },
+  },
+};
+
+const problems = (argv: string[]) => {
+  const parsed = parseArgs(argv, (n) => FLAGS[n]);
+  return validateFlags(parsed.flags, FLAGS, levenshtein);
+};
+
+describe("parseArgs", () => {
+  it("takes the first non-option token as the command", () => {
+    const parsed = parseArgs(["dupes", "--limit", "5"], (n) => FLAGS[n]);
+    expect(parsed.command).toBe("dupes");
+    expect(parsed.positional).toEqual([]);
+    expect(parsed.flags.get("limit")).toBe("5");
+  });
+
+  it("keeps positionals separate from the command", () => {
+    const parsed = parseArgs(["show", "cat3#1", "cat3#2"], (n) => FLAGS[n]);
+    expect(parsed.command).toBe("show");
+    expect(parsed.positional).toEqual(["cat3#1", "cat3#2"]);
+  });
+
+  it("does not let a valueless flag swallow the next argument", () => {
+    // `search --regex termo` has to keep `termo` as the search term. The
+    // greedy parser fed it to `--regex` and then reported no search term.
+    const parsed = parseArgs(["search", "--regex", "ICO."], (n) => FLAGS[n]);
+    expect(parsed.flags.get("regex")).toBe(true);
+    expect(parsed.positional).toEqual(["ICO."]);
+  });
+
+  it("accepts --flag=value as well as --flag value", () => {
+    expect(parseArgs(["x", "--limit=5"], (n) => FLAGS[n]).flags.get("limit")).toBe("5");
+    expect(parseArgs(["x", "--limit", "5"], (n) => FLAGS[n]).flags.get("limit")).toBe("5");
+  });
+
+  it("reports no command when the first token is an option", () => {
+    expect(parseArgs(["--help"], (n) => FLAGS[n]).command).toBeUndefined();
+  });
+});
+
+describe("validateFlags", () => {
+  it("passes valid input", () => {
+    expect(problems(["dupes", "--tier", "typo", "--cat", "3", "--limit", "5"])).toEqual([]);
+    expect(problems(["dupes", "--json"])).toEqual([]);
+  });
+
+  it("rejects a value outside the accepted set", () => {
+    const [p] = problems(["dupes", "--tier", "inventado"]);
+    expect(p).toMatchObject({ kind: "unknown-value", name: "tier", value: "inventado" });
+  });
+
+  it("rejects an unknown category rather than reporting an empty bank", () => {
+    const [p] = problems(["coverage", "--cat", "5"]);
+    expect(p).toMatchObject({ kind: "unknown-value", name: "cat", value: "5" });
+  });
+
+  it("checks every item of a comma-separated list", () => {
+    const found = problems(["dupes", "--tier", "typo,inventado,exact"]);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({ value: "inventado" });
+  });
+
+  it("accepts a value's alias", () => {
+    expect(problems(["dupes", "--tier", "gralha,exato"])).toEqual([]);
+  });
+
+  it("rejects an unknown flag name and suggests the real one", () => {
+    const [p] = problems(["search", "--limt", "2"]);
+    expect(p).toMatchObject({ kind: "unknown-flag", name: "limt", suggestion: "limit" });
+  });
+
+  it("rejects a flag given no value", () => {
+    const [p] = problems(["dupes", "--tier"]);
+    expect(p).toMatchObject({ kind: "missing-value", name: "tier" });
+  });
+
+  it("rejects a non-numeric value rather than falling back", () => {
+    expect(problems(["search", "--limit", "abc"])[0]).toMatchObject({
+      kind: "not-a-number",
+      name: "limit",
+      integer: true,
+    });
+    expect(problems(["pairs", "--stem-min", "abc"])[0]).toMatchObject({
+      kind: "not-a-number",
+      integer: false,
+    });
+  });
+
+  it("rejects a value given to a valueless flag", () => {
+    const [p] = problems(["dupes", "--json=1"]);
+    expect(p).toMatchObject({ kind: "unexpected-value", name: "json", value: "1" });
+  });
+
+  it("reports every problem, not just the first", () => {
+    // Being told about one typo at a time is the interaction this replaces.
+    expect(problems(["dupes", "--tier", "inventado", "--cat", "9", "--limt", "2"])).toHaveLength(3);
+  });
+});
+
+describe("nearest", () => {
+  it("suggests a name one edit away", () => {
+    expect(nearest("ordr", ["order", "answers", "pairs"], levenshtein)).toBe("order");
+    expect(nearest("limt", ["limit", "cat", "json"], levenshtein)).toBe("limit");
+  });
+
+  it("suggests nothing for a short value, where everything is one edit away", () => {
+    // `--cat 5` must not "mean" 1: it is equally close to 2 and 3.
+    expect(nearest("5", ["1", "2", "3"], levenshtein)).toBeNull();
+  });
+
+  it("suggests nothing when nothing is close", () => {
+    expect(nearest("qwertyuiop", ["order", "pairs"], levenshtein)).toBeNull();
+  });
+});
+
+describe("canonicalValue", () => {
+  it("resolves an alias, case- and space-insensitively", () => {
+    const aliases = { gralha: "typo" };
+    expect(canonicalValue(" Gralha ", aliases)).toBe("typo");
+    expect(canonicalValue("typo", aliases)).toBe("typo");
+    expect(canonicalValue("outro", aliases)).toBe("outro");
+  });
+});

--- a/docs/qbank.md
+++ b/docs/qbank.md
@@ -89,7 +89,19 @@ duplicate question is often entirely legitimate.
 Global flags: `--cat 3,2` to restrict categories, `--limit N` for how many
 findings to print, `--json` for machine-readable output.
 
+`qbank <command> --help` lists that command's options with their accepted
+values — including the Portuguese aliases, which is where you find out that
+`--tier gralha` works.
+
 A question is addressed as `cat3#12`; `3#12` and `cat3/12` also parse.
+
+**Bad input is refused, not absorbed.** An unknown option, an unknown value, a
+misspelt name, a non-numeric `--limit` — each is an error naming what was wrong
+and, where it can, what you probably meant, and exits 1. This used to be
+silent: `--tier inventado` filtered on nothing and reported `0 grupo(s)`,
+`--cat 5` printed a coverage table of zeros, `--limt 2` was ignored. All three
+read as a clean bank, which is the answer you were hoping for, so the typo did
+not waste a run — it ended the search. The rules live in `lib/cli/args.ts`.
 
 ## search and show
 
@@ -357,8 +369,10 @@ is a filter that turns 1,016 questions into seven worth reading, not a verdict.
 | Path | What |
 | --- | --- |
 | `lib/content/analysis.ts` | Pure functions — normalisation, tiers, audits. No I/O |
-| `scripts/qbank.ts` | CLI: argument handling, file lookup, formatting |
-| `__tests__/unit/test-content-analysis.test.ts` | 23 tests over the parts that are easy to get wrong |
+| `lib/cli/args.ts` | Argument parsing and validation. No I/O |
+| `scripts/qbank.ts` | CLI: the option declarations, file lookup, formatting |
+| `__tests__/unit/test-content-analysis.test.ts` | 26 tests over the parts that are easy to get wrong |
+| `__tests__/unit/test-cli-args.test.ts` | 19 tests over what the parser refuses |
 
 The split is what makes the finders testable without a fixture tree on disk. If
 you add a check, put the logic in `analysis.ts` with a test and keep
@@ -461,7 +475,20 @@ passa — uma pergunta duplicada é muitas vezes perfeitamente legítima.
 Opções globais: `--cat 3,2` para restringir categorias, `--limit N` para o
 número de resultados a imprimir, `--json` para saída legível por máquina.
 
+`qbank <comando> --help` lista as opções desse comando com os valores aceites —
+incluindo os aliases em português, que é onde se descobre que `--tier gralha`
+funciona.
+
 Uma pergunta identifica-se por `cat3#12`; `3#12` e `cat3/12` também são aceites.
+
+**O que está mal é recusado, não absorvido.** Uma opção desconhecida, um valor
+desconhecido, um nome mal escrito, um `--limit` não numérico — cada um dá erro
+a dizer o que estava mal e, quando consegue, o que provavelmente se queria
+dizer, e sai com código 1. Antes era tudo silencioso: `--tier inventado`
+filtrava por nada e respondia `0 grupo(s)`, `--cat 5` imprimia uma tabela de
+zeros, `--limt 2` era ignorado. Os três lêem-se como um banco limpo, que é a
+resposta que se esperava — por isso a gralha não desperdiçava uma execução,
+terminava a busca. As regras vivem em `lib/cli/args.ts`.
 
 ## search e show
 
@@ -742,8 +769,10 @@ vale a pena ler, não um veredicto.
 | Caminho | O que é |
 | --- | --- |
 | `lib/content/analysis.ts` | Funções puras — normalização, níveis, auditorias. Sem I/O |
-| `scripts/qbank.ts` | CLI: tratamento de argumentos, localização de ficheiros, formatação |
-| `__tests__/unit/test-content-analysis.test.ts` | 23 testes sobre as partes fáceis de errar |
+| `lib/cli/args.ts` | Tratamento e validação de argumentos. Sem I/O |
+| `scripts/qbank.ts` | CLI: a declaração das opções, localização de ficheiros, formatação |
+| `__tests__/unit/test-content-analysis.test.ts` | 26 testes sobre as partes fáceis de errar |
+| `__tests__/unit/test-cli-args.test.ts` | 19 testes sobre o que o tratamento de argumentos recusa |
 
 Esta separação é o que torna os detetores testáveis sem uma árvore de fixtures em
 disco. Ao acrescentar uma verificação, ponha-se a lógica em `analysis.ts` com um

--- a/lib/cli/args.ts
+++ b/lib/cli/args.ts
@@ -1,0 +1,218 @@
+/**
+ * Command-line argument parsing and validation
+ *
+ * Split out of `scripts/qbank.ts` for the same reason the finders live in
+ * `lib/content/analysis.ts`: the rules are worth testing, and the script is
+ * I/O and formatting.
+ *
+ * The problem this exists to solve is that a hand-rolled parser absorbs bad
+ * input by default. `--tier inventado` filtered on a value nothing matched and
+ * reported `0 grupo(s)`; `--cat 5` produced a coverage table of zeros; a
+ * misspelt `--limt` was ignored. All three read as a clean bank — the answer
+ * you were hoping for — so a typo did not waste a run, it ended the search.
+ *
+ * Every accepted option is therefore declared, and anything undeclared is a
+ * problem rather than a default. Problems are returned as data, not printed:
+ * the caller owns the colours and the wording.
+ */
+
+export type FlagSpec = {
+  describe: string;
+  /** Accepted values. Anything else is a problem. */
+  values?: readonly string[];
+  /** Extra spellings for those values, e.g. `gralha` = `typo`. */
+  aliases?: Record<string, string>;
+  /** Shown in help, e.g. `<slug>`. Absent means the flag takes no value. */
+  placeholder?: string;
+  /** How to read the value, and how to complain when it does not parse. */
+  number?: "int" | "ratio";
+};
+
+export type CommandSpec = {
+  describe: string;
+  /** Positional part of the usage line, e.g. `<termo>`. */
+  args?: string;
+  flags?: Record<string, FlagSpec>;
+  example?: string;
+};
+
+export type ParsedArgs = {
+  /** First token, when it is not an option. Never a flag value. */
+  command: string | undefined;
+  /** Positional arguments *after* the command. */
+  positional: string[];
+  /** `true` for a flag given without a value. */
+  flags: Map<string, string | true>;
+};
+
+/** Resolves a value through its alias table. */
+export function canonicalValue(raw: string, aliases: Record<string, string>): string {
+  const trimmed = raw.trim();
+  return aliases[trimmed.toLowerCase()] ?? trimmed;
+}
+
+/**
+ * Closest candidate by edit distance, or null when nothing is close enough.
+ *
+ * Nothing shorter than three characters gets a suggestion: every one-letter
+ * value is one edit from every other, so `--cat 5` would "mean" 1, 2 and 3
+ * equally and the guess would be noise. Above that, half the length allows a
+ * transposition or a dropped letter while keeping `--xyz` from "meaning"
+ * `--cat`.
+ */
+export function nearest(
+  input: string,
+  candidates: readonly string[],
+  distance: (a: string, b: string) => number
+): string | null {
+  if (input.length < 3) return null;
+
+  let best: { name: string; d: number } | null = null;
+  for (const name of candidates) {
+    const d = distance(input.toLowerCase(), name.toLowerCase());
+    if (best === null || d < best.d) best = { name, d };
+  }
+  if (best === null) return null;
+  return best.d <= Math.floor(input.length / 2) ? best.name : null;
+}
+
+/**
+ * Splits argv into a command, positionals and flags.
+ *
+ * `known` decides whether a flag consumes what follows it: a flag declared
+ * without a `placeholder` takes no value, so `search --regex termo` keeps
+ * `termo` as the search term instead of feeding it to `--regex`. An undeclared
+ * flag is assumed to take a value — it is already a problem, and swallowing
+ * the next token keeps the complaint about the flag rather than producing a
+ * second, confusing one about a stray positional.
+ */
+export function parseArgs(
+  argv: readonly string[],
+  known: (flag: string) => FlagSpec | undefined
+): ParsedArgs {
+  const first = argv[0];
+  const command = first !== undefined && !first.startsWith("--") ? first : undefined;
+
+  const positional: string[] = [];
+  const flags = new Map<string, string | true>();
+
+  for (let i = command === undefined ? 0 : 1; i < argv.length; i++) {
+    const arg = argv[i] ?? "";
+    if (!arg.startsWith("--")) {
+      positional.push(arg);
+      continue;
+    }
+
+    const [name, inline] = arg.slice(2).split("=", 2);
+    if (!name) continue;
+    if (inline !== undefined) {
+      flags.set(name, inline);
+      continue;
+    }
+
+    const spec = known(name);
+    const takesValue = spec === undefined || spec.placeholder !== undefined;
+    const next = argv[i + 1];
+    if (takesValue && next !== undefined && !next.startsWith("--")) {
+      flags.set(name, next);
+      i++;
+    } else {
+      flags.set(name, true);
+    }
+  }
+
+  return { command, positional, flags };
+}
+
+export type ArgProblem =
+  | { kind: "unknown-flag"; name: string; suggestion: string | null; known: string[] }
+  | { kind: "unexpected-value"; name: string; value: string }
+  | { kind: "missing-value"; name: string; placeholder: string }
+  | { kind: "not-a-number"; name: string; value: string; integer: boolean }
+  | {
+      kind: "unknown-value";
+      name: string;
+      value: string;
+      suggestion: string | null;
+      values: readonly string[];
+      aliases: string[];
+    };
+
+/**
+ * Every way the given flags fail their declarations, in the order given.
+ *
+ * All of them, not just the first: fixing one typo only to be told about the
+ * next is the interaction this is meant to replace.
+ */
+export function validateFlags(
+  flags: ReadonlyMap<string, string | true>,
+  known: Readonly<Record<string, FlagSpec>>,
+  distance: (a: string, b: string) => number
+): ArgProblem[] {
+  const problems: ArgProblem[] = [];
+  const knownNames = Object.keys(known);
+
+  for (const [name, value] of flags) {
+    const spec = known[name];
+    if (spec === undefined) {
+      problems.push({
+        kind: "unknown-flag",
+        name,
+        suggestion: nearest(name, knownNames, distance),
+        known: knownNames,
+      });
+      continue;
+    }
+
+    if (spec.placeholder === undefined) {
+      // Declared valueless. Only `--flag=x` can reach this, since the parser
+      // will not have consumed a following token for it.
+      if (typeof value === "string") {
+        problems.push({ kind: "unexpected-value", name, value });
+      }
+      continue;
+    }
+
+    if (value === true) {
+      problems.push({ kind: "missing-value", name, placeholder: spec.placeholder });
+      continue;
+    }
+
+    if (spec.number !== undefined) {
+      const parsed =
+        spec.number === "int" ? Number.parseInt(value, 10) : Number.parseFloat(value);
+      if (Number.isNaN(parsed)) {
+        problems.push({
+          kind: "not-a-number",
+          name,
+          value,
+          integer: spec.number === "int",
+        });
+      }
+      continue;
+    }
+
+    if (spec.values === undefined) continue;
+
+    // Values are comma-separated lists wherever they are a filter, so each
+    // item is checked: `--tier gralha,inventado` names one real problem.
+    const accepted = new Set(spec.values);
+    const aliases = Object.keys(spec.aliases ?? {});
+    for (const raw of value.split(",")) {
+      const item = raw.trim();
+      if (item.length === 0) continue;
+      const resolved = spec.aliases === undefined ? item : canonicalValue(item, spec.aliases);
+      if (accepted.has(resolved)) continue;
+      problems.push({
+        kind: "unknown-value",
+        name,
+        value: item,
+        suggestion: nearest(item, [...spec.values, ...aliases], distance),
+        values: spec.values,
+        aliases,
+      });
+    }
+  }
+
+  return problems;
+}

--- a/scripts/qbank.ts
+++ b/scripts/qbank.ts
@@ -38,45 +38,163 @@ import {
   auditAnswers,
   canonical,
   comparisonKey,
+  levenshtein,
   parseRef,
   DUPLICATE_TIERS,
   type BankQuestion,
   type DuplicateTier,
 } from "../lib/content/analysis";
+import {
+  parseArgs,
+  validateFlags,
+  nearest,
+  canonicalValue,
+  type ArgProblem,
+  type FlagSpec,
+  type CommandSpec,
+} from "../lib/cli/args";
 import { topicShortLabel } from "../lib/config/topics";
 import type { CategoryId } from "../lib/config/categories";
 
 const BASELINE_FILE = join("content", "qbank-baseline.json");
 const CATEGORIES = ["3", "2", "1"] as const;
 
+/**
+ * `--tier contradição` and `--tier contradiction` both select the same groups.
+ *
+ * The report says `contradição` now, and a filter that cannot be typed from
+ * what is on screen is a filter nobody reaches for. The English values stay
+ * canonical — they are what `--json`, the baseline keys and `docs/qbank.md`
+ * carry — so this only widens what is accepted.
+ */
+const TIER_ALIASES: Record<string, string> = {
+  contradição: "contradiction",
+  contradicao: "contradiction",
+  gralha: "typo",
+  divergente: "divergent",
+  "respostas-partilhadas": "shared-answers",
+  exato: "exact",
+};
+const KIND_ALIASES: Record<string, string> = {
+  polaridade: "polarity",
+  "enunciado-parecido": "near-stem",
+};
 /* -------------------------------------------------------------------------- */
 /* Argument handling                                                           */
 /* -------------------------------------------------------------------------- */
 
 const argv = process.argv.slice(2);
-const positional: string[] = [];
-const flags = new Map<string, string | true>();
 
-for (let i = 0; i < argv.length; i++) {
-  const arg = argv[i] ?? "";
-  if (!arg.startsWith("--")) {
-    positional.push(arg);
-    continue;
-  }
-  const [name, inline] = arg.slice(2).split("=", 2);
-  if (!name) continue;
-  if (inline !== undefined) {
-    flags.set(name, inline);
-    continue;
-  }
-  const next = argv[i + 1];
-  if (next !== undefined && !next.startsWith("--")) {
-    flags.set(name, next);
-    i++;
-  } else {
-    flags.set(name, true);
-  }
-}
+/**
+ * What each option is, so bad input can be refused rather than absorbed.
+ *
+ * Every accessor here used to fall back silently: an unknown value produced
+ * `0 grupo(s)`, an unknown category produced a table of zeros, a misspelt name
+ * was ignored entirely. All three read as a clean bank, which is the answer you
+ * were hoping for — so a typo did not waste a run, it ended the search.
+ *
+ * That is the same failure this tool exists to find in the content: something
+ * individually valid that quietly means nothing. The declaration is what lets
+ * the parser refuse it, and what `--help` renders, so the two cannot drift.
+ */
+const GLOBAL_FLAGS: Record<string, FlagSpec> = {
+  cat: {
+    describe: "só estas categorias",
+    placeholder: "<3,2,1>",
+    values: ["1", "2", "3"],
+  },
+  limit: { describe: "quantos resultados imprimir", placeholder: "<n>", number: "int" },
+  json: { describe: "saída legível por máquina" },
+  help: { describe: "esta ajuda" },
+};
+
+const SPECS: Record<string, CommandSpec> = {
+  search: {
+    describe: "procura perguntas por texto",
+    args: "<termo>",
+    flags: {
+      field: {
+        describe: "onde procurar",
+        placeholder: "<campo>",
+        values: ["stem", "options", "explanation", "all"],
+      },
+      regex: { describe: "tratar o termo como expressão regular" },
+    },
+    example: "qbank search ICOA --field stem --cat 3",
+  },
+  show: {
+    describe: "uma pergunta por inteiro, com os seus duplicados",
+    args: "<ref…>",
+    example: "qbank show cat3#161 cat3#162",
+  },
+  dupes: {
+    describe: "grupos de duplicados, o pior primeiro",
+    flags: {
+      tier: {
+        describe: "só estes tipos",
+        placeholder: "<lista>",
+        values: ["contradiction", "typo", "divergent", "shared-answers", "exact"],
+        aliases: TIER_ALIASES,
+      },
+      new: { describe: `só o que não está em ${BASELINE_FILE}` },
+      "update-baseline": { describe: "registar os achados atuais na linha de base" },
+    },
+    example: "qbank dupes --tier contradição,gralha",
+  },
+  pairs: {
+    describe: "quase-duplicados e inversões de polaridade",
+    flags: {
+      kind: {
+        describe: "só este tipo",
+        placeholder: "<tipo>",
+        values: ["polarity", "near-stem"],
+        aliases: KIND_ALIASES,
+      },
+      new: { describe: `só o que não está em ${BASELINE_FILE}` },
+      all: { describe: "incluir pares que o `dupes` já agrupa" },
+      "stem-min": { describe: "semelhança mínima do enunciado", placeholder: "<0-1>", number: "ratio" },
+      "answer-min": { describe: "semelhança mínima das opções", placeholder: "<0-1>", number: "ratio" },
+    },
+    example: "qbank pairs --kind polaridade",
+  },
+  coverage: { describe: "fontes, explicações, imagens, órfãs" },
+  order: {
+    describe: "a sequência de navegação e a posição de cada pergunta",
+    flags: {
+      topic: { describe: "só esta matéria", placeholder: "<slug>" },
+      around: { describe: "uma janela à volta desta pergunta", placeholder: "<ref>" },
+      radius: { describe: "tamanho da janela do --around (5)", placeholder: "<n>", number: "int" },
+    },
+    example: "qbank order --around cat3#161 --radius 8",
+  },
+  topics: { describe: "distribuição da taxonomia e casos fora do nível" },
+  paper: { describe: "o que cita uma prova, e o que ficou por reclamar", args: "[pdf]" },
+  answers: { describe: "auditoria à construção das respostas" },
+};
+
+/** Commands that are the same command under another name. */
+const COMMAND_ALIASES: Record<string, string> = {
+  duplicates: "dupes",
+  papers: "paper",
+};
+
+/** Positional arguments *after* the command, which is parsed out separately. */
+const knownFlagsFor = (command: string | undefined): Record<string, FlagSpec> => ({
+  ...GLOBAL_FLAGS,
+  ...(command === undefined ? {} : SPECS[command]?.flags ?? {}),
+});
+
+// The command has to be resolved before the options can be parsed, because
+// whether `--regex foo` swallows `foo` depends on `--regex` taking no value.
+const rawCommand = argv[0] !== undefined && !argv[0].startsWith("--") ? argv[0] : undefined;
+const commandName =
+  rawCommand === undefined ? undefined : COMMAND_ALIASES[rawCommand] ?? rawCommand;
+const knownFlags = knownFlagsFor(commandName);
+
+const parsed = parseArgs(argv, (name) => knownFlags[name]);
+/** Positional arguments *after* the command, which is parsed out separately. */
+const positional = parsed.positional;
+const flags = parsed.flags;
 
 function flag(name: string): string | undefined {
   const value = flags.get(name);
@@ -130,6 +248,19 @@ function flush(payload?: unknown) {
   process.stdout.write(`${out.join("\n")}\n`);
 }
 
+/**
+ * Reports bad input and stops.
+ *
+ * On stderr and around `flush`, because `--json` would otherwise render the
+ * complaint as `null` on stdout — a caller piping to `jq` would see an empty
+ * result rather than the reason for it, which is the silent-failure this whole
+ * change is about.
+ */
+function die(lines: readonly string[]): never {
+  process.stderr.write(`${lines.join("\n")}\n`);
+  process.exit(1);
+}
+
 /** Truncates for a one-line summary, on a word boundary where it can. */
 function clip(text: string, width: number): string {
   const flat = text.replace(/\s+/g, " ").trim();
@@ -137,6 +268,39 @@ function clip(text: string, width: number): string {
   const cut = flat.slice(0, width - 1);
   const space = cut.lastIndexOf(" ");
   return `${space > width * 0.6 ? cut.slice(0, space) : cut}…`;
+}
+
+/** Renders one argument problem as the lines to print. */
+function renderProblem(p: ArgProblem): string[] {
+  const flagName = bold(`--${p.name}`);
+  const guess = (name: string | null, prefix = "") =>
+    name === null ? [] : [dim(`  queria dizer ${prefix}${name}?`)];
+
+  switch (p.kind) {
+    case "unknown-flag":
+      return [
+        red(`opção desconhecida: ${flagName}`),
+        ...guess(p.suggestion, "--"),
+        dim(`  opções aqui: ${p.known.map((f) => `--${f}`).join(" ")}`),
+      ];
+    case "unexpected-value":
+      return [red(`${flagName} não leva valor, recebeu ${cyan(p.value)}`)];
+    case "missing-value":
+      return [red(`${flagName} precisa de um valor ${dim(p.placeholder)}`)];
+    case "not-a-number":
+      return [
+        red(
+          `${flagName} precisa de um número${p.integer ? " inteiro" : ""}, recebeu ${cyan(p.value)}`
+        ),
+      ];
+    case "unknown-value":
+      return [
+        red(`${flagName}: valor desconhecido ${cyan(p.value)}`),
+        ...guess(p.suggestion),
+        dim(`  valores: ${p.values.join(", ")}`),
+        ...(p.aliases.length === 0 ? [] : [dim(`  também aceita: ${p.aliases.join(", ")}`)]),
+      ];
+  }
 }
 
 /* -------------------------------------------------------------------------- */
@@ -234,31 +398,6 @@ function load(): BankQuestion[] {
  * The values themselves stay English: they are the `--json` payload and the
  * type in `lib/content/analysis.ts`, so only the rendering is translated.
  */
-/**
- * `--tier contradição` and `--tier contradiction` both select the same groups.
- *
- * The report says `contradição` now, and a filter that cannot be typed from
- * what is on screen is a filter nobody reaches for. The English values stay
- * canonical — they are what `--json`, the baseline keys and `docs/qbank.md`
- * carry — so this only widens what is accepted.
- */
-const TIER_ALIASES: Record<string, string> = {
-  contradição: "contradiction",
-  contradicao: "contradiction",
-  gralha: "typo",
-  divergente: "divergent",
-  "respostas-partilhadas": "shared-answers",
-  exato: "exact",
-};
-const KIND_ALIASES: Record<string, string> = {
-  polaridade: "polarity",
-  "enunciado-parecido": "near-stem",
-};
-const canonicalValue = (raw: string, aliases: Record<string, string>): string => {
-  const trimmed = raw.trim();
-  return aliases[trimmed.toLowerCase()] ?? trimmed;
-};
-
 const ISSUE_LABELS: Record<string, string> = {
   topic: "matéria",
   explanation: "explicação",
@@ -306,7 +445,7 @@ function renderQuestion(q: BankQuestion, needle?: string): void {
 /* -------------------------------------------------------------------------- */
 
 function cmdSearch(): void {
-  const term = positional[1] ?? "";
+  const term = positional[0] ?? "";
   if (term.trim().length === 0) {
     say("uso: qbank search <termo> [--field stem|options|explanation] [--regex] [--cat 3]");
     return flush([]);
@@ -355,7 +494,7 @@ function cmdSearch(): void {
 
 function cmdShow(): void {
   const bank = load();
-  const refs = positional.slice(1);
+  const refs = [...positional];
   if (refs.length === 0) {
     say("uso: qbank show cat3#12 [cat2#255 …]");
     return flush([]);
@@ -758,7 +897,7 @@ function cmdTopics(): void {
 function cmdPaper(): void {
   const bank = load();
   const papers = auditPapers(bank);
-  const wanted = positional[1];
+  const wanted = positional[0];
 
   if (wanted === undefined) {
     if (asJson) {
@@ -875,38 +1014,91 @@ function cmdAnswers(): void {
   flush();
 }
 
+/** The command list. Rendered from `SPECS`, so a new command appears here. */
 function usage(): void {
   say(bold("qbank — inspeção do banco de questões"));
   say();
-  say("  search <termo>   procura perguntas por texto  [--field stem|options|explanation] [--regex]");
-  say("  show <ref…>      uma pergunta por inteiro, com os seus duplicados");
-  say("  dupes            grupos de duplicados, o pior primeiro  [--tier] [--new] [--update-baseline]");
-  say("  pairs            quase-duplicados e inversões de polaridade  [--kind] [--new]");
-  say("  coverage         fontes, explicações, imagens, órfãs");
-  say("  order            a sequência de navegação e a posição de cada pergunta  [--topic slug] [--around ref] [--radius N]");
-  say("  topics           distribuição da taxonomia e casos fora do nível");
-  say("  paper [pdf]      o que cita uma prova, e o que ficou por reclamar");
-  say("  answers          auditoria à construção das respostas");
+  const names = Object.keys(SPECS);
+  const width = Math.max(...names.map((n) => `${n} ${SPECS[n]?.args ?? ""}`.trim().length));
+  for (const name of names) {
+    const entry = SPECS[name]!;
+    const head = `${name} ${entry.args ?? ""}`.trim();
+    say(`  ${bold(pad(head, width))}  ${entry.describe}`);
+  }
   say();
   say(dim("  globais: --cat 3,2   --limit N   --json"));
+  say(dim("  `qbank <comando> --help` para as opções de cada um"));
   flush(null);
 }
 
-const command = positional[0] ?? "help";
+/** Everything one command takes, with the accepted values spelled out. */
+function commandHelp(name: string): void {
+  const entry = SPECS[name]!;
+  const own = Object.entries(entry.flags ?? {});
+
+  say(`${bold(`qbank ${name}`)} — ${entry.describe}`);
+  say();
+  const optional = own.map(([f, v]) => `[--${f}${v.placeholder === undefined ? "" : ` ${v.placeholder}`}]`);
+  say(`  ${dim("uso:")} qbank ${name}${entry.args === undefined ? "" : ` ${entry.args}`} ${optional.join(" ")}`.trimEnd());
+
+  if (own.length > 0) {
+    say();
+    const labels = own.map(([f, v]) => `--${f}${v.placeholder === undefined ? "" : ` ${v.placeholder}`}`);
+    const width = Math.max(...labels.map((l) => l.length));
+    own.forEach(([, v], i) => {
+      say(`  ${bold(pad(labels[i]!, width))}  ${v.describe}`);
+      if (v.values !== undefined) {
+        say(`  ${" ".repeat(width)}  ${dim(`valores: ${v.values.join(", ")}`)}`);
+      }
+      if (v.aliases !== undefined) {
+        say(`  ${" ".repeat(width)}  ${dim(`também aceita: ${Object.keys(v.aliases).join(", ")}`)}`);
+      }
+    });
+  }
+
+  say();
+  say(dim("  globais: --cat 3,2   --limit N   --json"));
+  if (entry.example !== undefined) {
+    say();
+    say(`  ${dim("exemplo:")} ${cyan(entry.example)}`);
+  }
+  flush(null);
+}
+
 const commands: Record<string, () => void> = {
   search: cmdSearch,
   show: cmdShow,
   dupes: cmdDupes,
-  duplicates: cmdDupes,
   pairs: cmdPairs,
   coverage: cmdCoverage,
   order: cmdOrder,
   topics: cmdTopics,
   paper: cmdPaper,
-  papers: cmdPaper,
   answers: cmdAnswers,
 };
 
-const run = commands[command];
-if (run) run();
-else usage();
+if (commandName === undefined) {
+  usage();
+} else if (SPECS[commandName] === undefined) {
+  // Not the same as printing the help: a typo and a forgotten command used to
+  // produce identical output and an exit code of 0, so neither was visible.
+  const guess = nearest(commandName, Object.keys(SPECS), levenshtein);
+  die([
+    red(`comando desconhecido: ${bold(commandName)}`),
+    ...(guess === null ? [] : [dim(`  queria dizer \`${guess}\`?`)]),
+    "",
+    dim(`  comandos: ${Object.keys(SPECS).join(", ")}`),
+  ]);
+} else if (has("help")) {
+  commandHelp(commandName);
+} else {
+  const problems = validateFlags(flags, knownFlags, levenshtein);
+  if (problems.length > 0) {
+    die([
+      ...problems.flatMap(renderProblem),
+      "",
+      dim(`  \`qbank ${commandName} --help\` para as opções deste comando`),
+    ]);
+  }
+  commands[commandName]!();
+}


### PR DESCRIPTION
O tratamento de argumentos absorvia tudo o que estivesse mal, e o resultado lia-se sempre como um banco limpo:

| Comando | Respondia | Parecia |
| --- | --- | --- |
| `qbank dupes --tier inventado` | `0 grupo(s):` | um banco limpo |
| `qbank pairs --kind inventado` | `0 par(es)` | um banco limpo |
| `qbank coverage --cat 5` | tabela de zeros | um banco vazio |
| `qbank coverage --cat 3,9` | só cat3, o `9` desaparecia | correto |
| `qbank search x --field inventado` | procurava no campo por omissão | plausível |
| `qbank search x --limt 2` | 30 resultados, nome ignorado | plausível |
| `qbank order --topic` | filtro descartado, 1018 perguntas | plausível |
| `qbank search x --limit abc` | 30, em silêncio | plausível |

É a mesma falha que a ferramenta existe para encontrar no conteúdo — algo individualmente válido que não quer dizer nada — e que o `CLAUDE.md` já nomeia duas vezes: o `topic` em texto livre e o `disabled: true`. E o formato da resposta errada é o pior possível: **`0 grupo(s)` é o resultado que se esperava**. A gralha não desperdiçava uma execução, terminava a busca.

## O que muda

```
$ qbank dupes --tier inventado
--tier: valor desconhecido inventado
  valores: contradiction, typo, divergent, shared-answers, exact
  também aceita: contradição, gralha, divergente, respostas-partilhadas, exato

$ qbank search x --limt 2
opção desconhecida: --limt
  queria dizer --limit?
  opções aqui: --cat --limit --json --help --field --regex
```

Todos os problemas de uma vez, não um por execução, e com código de saída 1.

**`--help` por comando**, gerado das mesmas declarações que o validador usa, para que a ajuda e o comportamento não possam divergir. É também onde se descobre que `--tier gralha` funciona:

```
$ qbank dupes --help
qbank dupes — grupos de duplicados, o pior primeiro

  uso: qbank dupes [--tier <lista>] [--new] [--update-baseline]

  --tier <lista>     só estes tipos
                     valores: contradiction, typo, divergent, shared-answers, exact
                     também aceita: contradição, gralha, divergente, ...
```

**Comando desconhecido** deixa de imprimir a ajuda com código 0 — antes uma gralha e um comando esquecido produziam exatamente o mesmo:

```
$ qbank ordr
comando desconhecido: ordr
  queria dizer `order`?
```

A sugestão usa o `levenshtein` do `analysis.ts`, a mesma função que encontra enunciados quase iguais.

## Duas coisas que apareceram a construir

- **Os erros vão para stderr.** A primeira versão passava pelo `flush`, e com `--json` a queixa saía como `null` no stdout: quem canalizasse para o `jq` via um resultado vazio em vez do motivo. Era o mesmo silêncio noutro sítio.
- **A sugestão precisa de um mínimo de comprimento.** `--cat 5` sugeria "queria dizer 1?" — qualquer valor de uma letra está a uma edição de todos os outros. Abaixo de três caracteres não há sugestão.

## De caminho

O parser passa a saber que opções levam valor, por isso `qbank search --regex "ICO."` funciona. Antes o `--regex` engolia o termo e a ferramenta dizia que faltava o termo de procura.

## Estrutura

As regras ficam em `lib/cli/args.ts`, puras e a devolver os problemas como dados; o `scripts/qbank.ts` fica com as declarações e a formatação. É a separação que o próprio `docs/qbank.md` prescreve, e é o que permite 19 testes sem lançar subprocessos.

## Estado

`lint`, `type-check` e 363 testes passam. Documentado nas duas metades do `docs/qbank.md`, incluindo o mapa do código. Nenhum comando existente muda de comportamento com argumentos válidos — verificados os onze, aliases incluídos.