### PR TITLE
Acrescentar o `content:edit`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ bun run type-check   # tsc --noEmit
 bun run content:build # Compile content/questions/** into shipped artifacts
 bun run content:check # Verify artifacts match their source (writes nothing)
 bun run content:new  # Add a question: review, then write all four files
+bun run content:edit # Change a question already in the bank
 bun run qbank <cmd>  # Inspect the question bank (search, dupes, coverage, …)
 bun run banco        # Portuguese menu over content:new and qbank
 ```
@@ -142,8 +143,31 @@ compare against, so it goes on blocking an accidental re-add.
   `content/notes/` straight from disk without consulting the bank, so a note
   left behind by a withdrawn question would still be served
 
+`bun run content:edit` is the same review applied to a question that already
+exists — `content:new` had no counterpart, so an edit meant opening the MDX by
+hand with no duplicate check and no validation until the next build. It takes a
+ref (`cat3#86`), `--editor` for the whole file, `--from` for a prepared one, or
+a queue selector (`--sem-explicacao`, `--sem-fonte`, `--desativadas`) to work
+through a gap. `--disable <motivo>` / `--enable` are the scripted form of
+withholding.
+
+- **It never touches `order`.** Moving a question is an editorial decision
+  about the browse sequence, not a change to the question; `qbank order` is
+  where you find the slot, and `category.json` is where you write it
+- **`reviewDraft` takes `editing`**, which inverts two rules: the id is
+  expected to be in `order`, and the question is filtered out of the bank so it
+  is not reported as an exact duplicate of itself. Both are handled inside
+  `reviewDraft`, since a caller that forgets either gets a confident, wrong review
+- **Changing the correct answer, or withholding, is confirmed separately** and
+  shown red by `diffQuestions`. `--yes` still covers it: making it unskippable
+  would break `--disable "motivo" --yes` in a script
+- **`scripts/content-io.ts` is the shared I/O** — loading, image resolution,
+  the field prompts, and the one write path. Two tools writing the same four
+  files need one definition of how
+
 Adding a question by hand is still documented in `docs/novas-questoes.md`
-(pt-PT); the topic taxonomy in `docs/topicos.md` (pt-PT).
+(pt-PT), editing in `docs/editar-conteudo.md` (pt-PT); the topic taxonomy in
+`docs/topicos.md` (pt-PT).
 
 **Linking questions to exam PDFs**: `bun run data:ocr-exams` OCRs the scanned
 papers in `public/exams/` and matches them back to the bank (needs `poppler`

--- a/__tests__/unit/test-content-author.test.ts
+++ b/__tests__/unit/test-content-author.test.ts
@@ -13,6 +13,8 @@
 import { describe, it, expect } from "vitest";
 import {
   reviewDraft,
+  diffQuestions,
+  isWithheldReason,
   insertIntoOrder,
   nextId,
   hasErrors,
@@ -253,5 +255,124 @@ describe("reviewDraft", () => {
   it("warns about an explanation-less question without blocking it", () => {
     const review = reviewDraft(draft({ explanation: null }), context());
     expect(codes(review.findings)).toEqual(["explanation-missing"]);
+  });
+});
+
+describe("reviewDraft when editing", () => {
+  // The bank fixture holds cat2#255. Editing it must not report it as a
+  // duplicate of itself, and its id being in `order` is what makes it an edit.
+  const editing = (overrides: Partial<Draft> = {}) =>
+    reviewDraft(
+      draft({
+        category: "2",
+        id: 255,
+        question: "O Regulamento das Radiocomunicações é uma publicação",
+        answers: [
+          { text: "da IARU" },
+          { text: "da CEPT" },
+          { text: "da UIT", correct: true },
+          { text: "da NATO" },
+        ],
+        topic: "regulamentacao",
+        ...overrides,
+      }),
+      context({ category: "2", order: [255], editing: 255 })
+    );
+
+  it("does not report the question as a duplicate of itself", () => {
+    expect(codes(editing().findings)).not.toContain("duplicate-exact");
+    expect(editing().duplicates).toEqual([]);
+  });
+
+  it("does not report the id as taken", () => {
+    expect(codes(editing().findings)).not.toContain("id-taken");
+  });
+
+  it("still reports a real problem in the edited question", () => {
+    const review = editing({ topic: "matéria-inventada" });
+    expect(codes(review.findings)).toContain("topic-unknown");
+  });
+
+  it("still reports the id as taken when an edit changes it onto another", () => {
+    const review = reviewDraft(
+      draft({ category: "2", id: 255 }),
+      context({ category: "2", order: [255, 300], editing: 300 })
+    );
+    expect(codes(review.findings)).toContain("id-taken");
+  });
+});
+
+describe("diffQuestions", () => {
+  const base = {
+    id: 1,
+    question: "Enunciado",
+    answers: [
+      { text: "a", correct: true },
+      { text: "b", correct: false },
+    ],
+    topic: "regulamentacao",
+    disabled: null,
+    sources: [],
+    image: null,
+    tutorial: null,
+    calc: null,
+    explanation: null,
+  };
+
+  it("reports nothing when nothing changed", () => {
+    expect(diffQuestions(base, { ...base })).toEqual([]);
+  });
+
+  it("names the option that changed, not all of them", () => {
+    const changes = diffQuestions(base, {
+      ...base,
+      answers: [
+        { text: "a", correct: true },
+        { text: "B corrigido", correct: false },
+      ],
+    });
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toMatchObject({ label: "opção 2", before: "b", after: "B corrigido" });
+  });
+
+  it("marks a changed correct answer as critical", () => {
+    const changes = diffQuestions(base, {
+      ...base,
+      answers: [
+        { text: "a", correct: false },
+        { text: "b", correct: true },
+      ],
+    });
+    const correct = changes.find((c) => c.label === "resposta certa");
+    expect(correct?.critical).toBe(true);
+    expect(correct?.before).toBe("opção 1 — a");
+    expect(correct?.after).toBe("opção 2 — b");
+  });
+
+  it("marks withholding as critical", () => {
+    const [change] = diffQuestions(base, { ...base, disabled: "retirada" });
+    expect(change).toMatchObject({ label: "desativada", after: "retirada", critical: true });
+  });
+
+  it("summarises an explanation rather than printing it", () => {
+    const [change] = diffQuestions(base, { ...base, explanation: "doze caracte" });
+    expect(change).toMatchObject({ label: "explicação", before: "—", after: "12 caracteres" });
+  });
+
+  it("says so when a rewrite keeps the same length", () => {
+    // "412 caracteres → 412 caracteres" would look like nothing happened.
+    const [change] = diffQuestions(
+      { ...base, explanation: "aaaa" },
+      { ...base, explanation: "bbbb" }
+    );
+    expect(change?.after).toBe("4 caracteres (texto alterado)");
+  });
+});
+
+describe("isWithheldReason", () => {
+  it("rejects a blank reason, which the schema would read as published", () => {
+    expect(isWithheldReason("")).toBe(false);
+    expect(isWithheldReason("   ")).toBe(false);
+    expect(isWithheldReason("retirada pela ANACOM")).toBe(true);
   });
 });

--- a/content/questions/cat3/0086.mdx
+++ b/content/questions/cat3/0086.mdx
@@ -1,6 +1,6 @@
 ---
 id: 86
-question: Qua a validade das licenças de amador de uso comum?
+question: Qual a validade das licenças de amador de uso comum?
 answers:
   - text: 1 ano
   - text: 5 anos

--- a/docs/editar-conteudo.md
+++ b/docs/editar-conteudo.md
@@ -1,0 +1,217 @@
+# Alterar perguntas do banco de questões
+
+Para **acrescentar** uma pergunta, veja [`novas-questoes.md`](novas-questoes.md).
+Este documento é sobre mudar uma que já existe.
+
+```bash
+bun run content:edit cat3#86                     # interativo, campo a campo
+bun run content:edit cat3#86 --editor            # o ficheiro inteiro no $EDITOR
+bun run content:edit cat3#86 --from correcao.mdx # substitui a partir de um ficheiro
+bun run content:edit --sem-explicacao --cat 2    # percorre a fila
+bun run content:edit cat3#86 --disable "motivo"  # retira do site sem apagar
+```
+
+## Porque existe
+
+Havia o `content:new` e não havia nada para o outro lado. Alterar uma pergunta
+era abrir o MDX à mão: sem revisão de duplicados, sem escolha da matéria a
+partir da lista, sem validação nenhuma até ao `content:build` seguinte.
+
+Isso pesa sobretudo nas **260 perguntas sem explicação**, quase todas da
+categoria 2 — a maior lacuna que resta no banco, e um trabalho inteiramente de
+edição.
+
+## O que faz por si
+
+Cada gravação passa pela mesma revisão que o `content:new` corre:
+
+- **duplicados e contradições** contra as três categorias — se a alteração
+  fizer a pergunta colidir com outra, é dito antes de escrever
+- **matéria escolhida de uma lista**, nunca escrita à mão
+- **fontes verificadas** contra `public/exams/`
+- **imagens verificadas** contra `public/`
+- o **schema** — um campo inventado ou mal escrito dá erro com o nome do campo
+
+E, ao gravar, escreve tudo o que a pergunta possui e recompila os artefactos da
+categoria, deixando a árvore no estado que o `content:check` espera:
+
+```
+✓ cat3#86
+  content/questions/cat3/0086.mdx
+  content/questions/cat3/category.json
+  public/data/cat3.json
+  content/notes/cat3/86.mdx
+```
+
+Se a explicação for apagada, ou a pergunta desativada, a nota gerada é
+**removida** — a `/api/notes` lê do disco sem consultar o banco e continuaria a
+servi-la.
+
+## O que **não** faz
+
+**Não mexe na posição no `order`.** Mudar uma pergunta de lugar é uma decisão
+editorial sobre a sequência de navegação, não uma alteração à pergunta. Para
+isso veja onde a matéria vive e escolha os vizinhos:
+
+```bash
+bun run qbank order --cat 3 --topic regulamentacao
+bun run qbank order --around cat3#161
+```
+
+e depois edite o `order` no `category.json` à mão. A validação é feita nos dois
+sentidos, por isso um engano não passa despercebido.
+
+## As alterações são mostradas antes de gravar
+
+```
+Alterações
+  enunciado  Qua a validade das licenças de amador de uso comum?
+             → Qual a validade das licenças de amador de uso comum?
+```
+
+As opções são comparadas uma a uma, e não em bloco: uma correção de uma palavra
+na opção 3 lê-se como uma correção de uma palavra, não como quatro opções
+reescritas.
+
+Duas alterações aparecem **a vermelho** e pedem confirmação à parte:
+
+| Alteração | Porquê |
+| --- | --- |
+| `resposta certa` | torna certa uma resposta que estava errada, para toda a gente que consulta |
+| `desativada` | retira a pergunta do site inteiro |
+
+A explicação é resumida em número de caracteres em vez de impressa — um corpo
+de 2000 caracteres enterrava todas as outras linhas, e o editor já a mostrou.
+Uma reescrita que por acaso mantenha o comprimento diz `(texto alterado)`, para
+não se ler como se nada tivesse acontecido.
+
+## Modos
+
+### Interativo — campo a campo
+
+```bash
+bun run content:edit cat3#86
+```
+
+Um menu, não uma sequência fixa: quase todas as alterações mexem num campo só, e
+percorrer todos para corrigir uma gralha no enunciado é o que leva as pessoas a
+editar o MDX à mão.
+
+```
+O que alterar?
+   1  enunciado      Qual a validade das licenças de amador de uso comum?
+   2  opções         4 opções, certa: 3
+   3  matéria        regulamentacao
+   4  explicação     261 caracteres
+   5  fontes         1 referência(s)
+   6  imagem         sem imagem
+   7  desativação    publicada
+   8  terminar       rever e gravar
+```
+
+Pode alterar vários campos seguidos; a revisão e o resumo só acontecem no fim.
+
+Nas **opções**, Enter mantém a que já lá está — só escreve as que quer mudar. A
+opção correta atual aparece marcada `(atual)`.
+
+Na **explicação**, abre o `$EDITOR` já com o texto que existe. Sem `$EDITOR`
+definido, escreve-se no terminal e uma linha só com `=` mantém a atual.
+
+### `--editor` — o ficheiro inteiro
+
+```bash
+bun run content:edit cat3#86 --editor
+```
+
+Abre o ficheiro no formato em que está guardado, com o frontmatter todo. É o
+modo mais rápido para quem já conhece o formato, e o resultado é validado ao
+gravar — ao contrário de abrir o ficheiro no editor diretamente.
+
+### `--from` — a partir de um ficheiro
+
+```bash
+bun run content:edit cat3#86 --from correcao.mdx
+cat correcao.mdx | bun run content:edit cat3#86 --from - --yes
+```
+
+O formato é o mesmo dos ficheiros do banco, tal como no `content:new`. Serve
+para alterações preparadas noutro lado, ou para repetir a mesma correção em
+várias perguntas a partir de um guião.
+
+### Desativar e reativar
+
+```bash
+bun run content:edit cat3#161 --disable "Duplica a cat3#162."
+bun run content:edit cat3#161 --enable
+```
+
+A pergunta sai do site mas fica no ficheiro, no `order` e nas comparações do
+`qbank` — os detalhes estão em [`novas-questoes.md`](novas-questoes.md#desativar-uma-pergunta-sem-a-apagar).
+
+O motivo é obrigatório. `--disable ""` dá erro em vez de passar: o schema
+converte texto vazio em `null`, por isso um motivo em branco **publicaria** a
+pergunta em vez de a retirar — o contrário do que foi pedido, comunicado como
+sucesso.
+
+## Filas de trabalho
+
+O `qbank coverage` conta as lacunas; estas opções transformam a contagem numa
+lista para percorrer:
+
+```bash
+bun run content:edit --sem-explicacao --cat 2 --limit 10
+bun run content:edit --sem-fonte --cat 3
+bun run content:edit --desativadas
+```
+
+Entre perguntas pergunta se quer continuar, por isso pode parar a meio sem
+perder o que já gravou. Cada pergunta é revista contra o que a anterior
+escreveu, não contra o banco no início da execução.
+
+Combinam-se: `--sem-explicacao --sem-fonte` seleciona as que não têm nem uma
+coisa nem outra.
+
+## Opções
+
+| Opção | O que faz |
+| --- | --- |
+| `--editor` | abre o ficheiro inteiro no `$EDITOR` |
+| `--from <ficheiro>` | substitui a partir de um ficheiro (`-` para stdin) |
+| `--disable <motivo>` | retira a pergunta do site sem a apagar |
+| `--enable` | volta a publicá-la |
+| `--sem-explicacao` | seleciona as perguntas sem explicação |
+| `--sem-fonte` | seleciona as que não citam prova |
+| `--desativadas` | seleciona as desativadas |
+| `--cat 3` | restringe a seleção a uma categoria |
+| `--limit 10` | quantas perguntas da fila percorrer |
+| `--dry-run` | mostra o que escreveria, sem escrever nada |
+| `--yes` | não pergunta (obrigatório quando o stdin é um pipe) |
+| `--force` | escreve apesar dos avisos |
+
+O `--yes` cobre também a confirmação das alterações a vermelho. Torná-la
+impossível de saltar inutilizaria `--disable "motivo" --yes` num guião; a
+segurança está em a alteração ser dita antes de acontecer, não em prender
+alguém a uma pergunta. Sem `--yes` e sem terminal, falha fechado.
+
+## Erros comuns
+
+| Mensagem | Causa | Solução |
+| --- | --- | --- |
+| `não existe a pergunta cat3#999` | referência inexistente | `bun run qbank search` para a encontrar |
+| `cat3#86 não é uma referência` | formato errado | `cat3#86`, `3#86` ou `cat3/86` |
+| `--disable precisa de um motivo em texto` | `--disable ""` | escrever o motivo |
+| `nada selecionado` | sem referência nem filtro | passar `cat3#86` ou `--sem-explicacao` |
+| `stdin não é um terminal e não foi passado --from…` | corrido num pipe sem modo não interativo | `--from`, `--editor`, `--disable` ou `--enable` |
+| `nada alterado` | a edição não mudou nada | nenhuma — não foi escrito |
+
+## Onde está o código
+
+| Caminho | O que é |
+| --- | --- |
+| `lib/content/author.ts` | As regras: `reviewDraft`, `diffQuestions`. Puras, testadas |
+| `scripts/content-io.ts` | Leitura, escrita e perguntas, partilhadas com o `content:new` |
+| `scripts/content-edit.ts` | O ciclo e os menus |
+| `__tests__/unit/test-content-author.test.ts` | O que a revisão recusa e o que a comparação relata |
+
+A separação é a mesma do resto do repositório: o que uma pergunta *é* e o que é
+*permitido* vivem em `lib/content/`; os scripts são terminal e ficheiros.

--- a/docs/novas-questoes.md
+++ b/docs/novas-questoes.md
@@ -1,5 +1,7 @@
 # Adicionar perguntas ao banco de questões
 
+*Para **alterar** uma pergunta que já existe, ver [`editar-conteudo.md`](editar-conteudo.md).*
+
 A fonte de verdade é `content/questions/cat{n}/` — **um ficheiro MDX por
 pergunta**, com os campos estruturados no frontmatter YAML e a explicação no
 corpo do documento. Tudo o resto é gerado a partir daí.
@@ -393,7 +395,13 @@ question: >-
   …
 ```
 
-E compila-se: `bun run content:build`. A partir daí a pergunta
+E compila-se: `bun run content:build`. Ou, numa linha só:
+
+```bash
+bun run content:edit cat3#161 --disable "Retirada pela ANACOM."
+```
+
+A partir daí a pergunta
 
 - **sai** de `public/data/cat{n}.json`, portanto desaparece do site inteiro —
   consultar, exame, treino, cartões, contagens do painel

--- a/lib/content/author.ts
+++ b/lib/content/author.ts
@@ -23,6 +23,7 @@
 import { QuestionSchema, isWithheld, type ContentQuestion } from "./schema";
 import {
   auditAnswers,
+  bankRef,
   buildBank,
   findDuplicateGroups,
   findPairFindings,
@@ -93,6 +94,16 @@ export type ReviewContext = {
   bank: readonly BankQuestion[];
   /** The category's current `order`, for the id collision check. */
   order: readonly number[];
+  /**
+   * The id being *edited* rather than created.
+   *
+   * Two rules invert for an edit. The id is expected to be in `order` — that
+   * is what makes it an edit — and the question is already in the bank, where
+   * it would otherwise report itself as an exact duplicate of itself. Both are
+   * handled here rather than by the caller, since a caller that forgets either
+   * one gets a confident, wrong review.
+   */
+  editing?: number;
   pdfLookup: PdfLookup;
   /** Takes a public-relative path, e.g. "images/cat3/x.png". */
   imageExists: (publicRelative: string) => boolean;
@@ -107,6 +118,17 @@ export type ReviewContext = {
  */
 export function nextId(order: readonly number[]): number {
   return order.reduce((max, id) => Math.max(max, id), 0) + 1;
+}
+
+/**
+ * Whether a `disabled` value is a real reason.
+ *
+ * The schema trims optional text and turns an empty string into `null`, so
+ * `--disable ""` would quietly *publish* the question rather than withhold it
+ * — the opposite of what was asked, reported as success.
+ */
+export function isWithheldReason(reason: string): boolean {
+  return reason.trim().length > 0;
 }
 
 export function hasErrors(findings: readonly Finding[]): boolean {
@@ -281,8 +303,10 @@ export function reviewDraft(draft: Draft, ctx: ReviewContext): Review {
   }
 
   const question = parsed.data;
+  const editingRef = ctx.editing === undefined ? null : bankRef(ctx.category, ctx.editing);
+  const bank = editingRef === null ? ctx.bank : ctx.bank.filter((q) => q.ref !== editingRef);
 
-  if (ctx.order.includes(question.id)) {
+  if (ctx.editing !== question.id && ctx.order.includes(question.id)) {
     findings.push({
       level: "error",
       code: "id-taken",
@@ -322,7 +346,7 @@ export function reviewDraft(draft: Draft, ctx: ReviewContext): Review {
     });
   }
 
-  const withDraft = [...ctx.bank, draftBank];
+  const withDraft = [...bank, draftBank];
   const duplicates = findDuplicateGroups(withDraft).filter((g) =>
     g.members.some((m) => m.ref === draftBank.ref)
   );
@@ -366,6 +390,89 @@ export function reviewDraft(draft: Draft, ctx: ReviewContext): Review {
   }
 
   return { question, findings, duplicates, pairs };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Editing                                                                     */
+/* -------------------------------------------------------------------------- */
+
+export type FieldChange = {
+  /** Field name as an author would say it, in pt-PT. */
+  label: string;
+  before: string;
+  after: string;
+  /**
+   * Changing which option is correct. Called out separately because it is the
+   * highest-stakes edit in the bank — it silently turns a right answer wrong
+   * for every reader — and because it is the edit a legislative change
+   * actually requires, so it must never scroll past unnoticed.
+   */
+  critical?: true;
+};
+
+const NONE = "—";
+
+function describeSources(q: ContentQuestion): string {
+  if (q.sources.length === 0) return NONE;
+  return q.sources
+    .map((s) => `${s.pdf} pergunta ${s.question}${s.page === null ? "" : ` p.${s.page}`}`)
+    .join("; ");
+}
+
+/**
+ * What changed between two versions of a question, for review before writing.
+ *
+ * Options are compared position by position rather than as a block, so a
+ * one-word fix in option 3 reads as a one-word fix instead of as four
+ * rewritten options.
+ */
+export function diffQuestions(
+  before: ContentQuestion,
+  after: ContentQuestion
+): FieldChange[] {
+  const changes: FieldChange[] = [];
+  const add = (label: string, a: string | null, b: string | null, critical?: true) => {
+    if (a === b) return;
+    changes.push({ label, before: a ?? NONE, after: b ?? NONE, ...(critical ? { critical } : {}) });
+  };
+
+  add("enunciado", before.question, after.question);
+
+  const options = Math.max(before.answers.length, after.answers.length);
+  for (let i = 0; i < options; i++) {
+    add(`opção ${i + 1}`, before.answers[i]?.text ?? null, after.answers[i]?.text ?? null);
+  }
+
+  const correctOf = (q: ContentQuestion) => {
+    const index = q.answers.findIndex((a) => a.correct);
+    return index < 0 ? null : `opção ${index + 1} — ${q.answers[index]!.text}`;
+  };
+  add("resposta certa", correctOf(before), correctOf(after), true);
+
+  add("matéria", before.topic, after.topic);
+  add("desativada", before.disabled, after.disabled, true);
+  add("fontes", describeSources(before), describeSources(after));
+  add("imagem", before.image, after.image);
+  add("tutorial", before.tutorial, after.tutorial);
+  add("calculadora", before.calc, after.calc);
+
+  // Prose is summarised rather than shown: a 2,000-character body would bury
+  // every other change in the list, and the editor already showed it.
+  if (before.explanation !== after.explanation) {
+    const summarise = (text: string | null) =>
+      text === null ? NONE : `${text.length} caracteres`;
+    const from = summarise(before.explanation);
+    const to = summarise(after.explanation);
+    changes.push({
+      label: "explicação",
+      before: from,
+      // A rewrite that happens to keep the length would otherwise read
+      // "412 caracteres → 412 caracteres" and look like nothing happened.
+      after: from === to ? `${to} (texto alterado)` : to,
+    });
+  }
+
+  return changes;
 }
 
 export type OrderAnchor =

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "content:build": "bun run scripts/content-build.ts",
     "content:check": "bun run scripts/content-build.ts --check",
     "content:new": "bun run scripts/content-new.ts",
+    "content:edit": "bun run scripts/content-edit.ts",
     "qbank": "bun run scripts/qbank.ts",
     "banco": "bun run scripts/banco.ts"
   },

--- a/public/data/cat3.json
+++ b/public/data/cat3.json
@@ -1411,7 +1411,7 @@
     },
     {
       "id": 86,
-      "question": "Qua a validade das licenças de amador de uso comum?",
+      "question": "Qual a validade das licenças de amador de uso comum?",
       "options": [
         "1 ano",
         "5 anos",

--- a/scripts/banco.ts
+++ b/scripts/banco.ts
@@ -29,6 +29,7 @@ import {
 const ROOT = process.cwd();
 const QBANK = join("scripts", "qbank.ts");
 const CONTENT_NEW = join("scripts", "content-new.ts");
+const CONTENT_EDIT = join("scripts", "content-edit.ts");
 
 /* -------------------------------------------------------------------------- */
 /* Correr as ferramentas                                                       */
@@ -83,6 +84,23 @@ const ENTRIES: Entry[] = [
     label: "Acrescentar uma pergunta",
     hint: "content:new",
     build: async () => ({ script: CONTENT_NEW, args: [] }),
+  },
+  {
+    label: "Alterar uma pergunta",
+    hint: "content:edit",
+    build: async () => {
+      const ref = await askText("Referência da pergunta (ex.: cat3#86)", { required: false });
+      if (ref.length === 0) return null;
+      return { script: CONTENT_EDIT, args: [ref] };
+    },
+  },
+  {
+    label: "Escrever explicações em falta",
+    hint: "percorre as perguntas sem explicação",
+    build: async () => ({
+      script: CONTENT_EDIT,
+      args: ["--sem-explicacao", ...(await askCategories())],
+    }),
   },
   {
     label: "Procurar uma pergunta",

--- a/scripts/content-edit.ts
+++ b/scripts/content-edit.ts
@@ -1,0 +1,543 @@
+#!/usr/bin/env bun
+/**
+ * Changes a question already in the bank.
+ *
+ *   bun run content:edit cat3#86                 # interactive, one field at a time
+ *   bun run content:edit cat3#86 --editor        # the whole file in $EDITOR
+ *   bun run content:edit cat3#86 --from fix.mdx  # replace from a file
+ *   bun run content:edit --sem-explicacao --cat 2   # walk the queue
+ *   bun run content:edit cat3#86 --disable "motivo"
+ *
+ * `content:new` existed and nothing matched it for changing a question, so an
+ * edit meant opening the MDX by hand: no duplicate review, no topic picker, no
+ * validation until the next `content:build`. That matters most for the 260
+ * questions with no explanation, which is the bank's largest remaining gap and
+ * is entirely an editing job.
+ *
+ * Every write goes through `reviewDraft`, the same review `content:new` runs,
+ * with `editing` set so the question is not reported as a duplicate of itself.
+ * The rules are in `lib/content/author.ts` and the I/O in `./content-io.ts`;
+ * this file is the loop and the prompts.
+ *
+ * `order` is deliberately untouched. Moving a question is an editorial
+ * decision about the browse sequence rather than a change to the question, and
+ * `qbank order` is where you go to make it.
+ */
+import { readFileSync } from "fs";
+import matter from "gray-matter";
+import {
+  reviewDraft,
+  diffQuestions,
+  hasErrors,
+  isWithheldReason,
+  type Draft,
+  type FieldChange,
+} from "../lib/content/author";
+import { serializeQuestionFile } from "../lib/content/source";
+import { parseRef, bankRef, type BankQuestion } from "../lib/content/analysis";
+import type { ContentQuestion } from "../lib/content/schema";
+import {
+  bold,
+  dim,
+  red,
+  green,
+  yellow,
+  interactive,
+  askText,
+  askChoice,
+  confirm as askConfirm,
+  closePrompts,
+} from "./prompt";
+import {
+  clip,
+  printFindings,
+  printQuestion,
+  loadAll,
+  loadManifest,
+  pdfLookup,
+  imageExists,
+  askAnswers,
+  askTopic,
+  askSources,
+  askImage,
+  askExplanation,
+  writeQuestion,
+} from "./content-io";
+import { CATEGORIES, type CategoryId } from "../lib/config/categories";
+
+/* -------------------------------------------------------------------------- */
+/* Arguments                                                                   */
+/* -------------------------------------------------------------------------- */
+
+const argv = process.argv.slice(2);
+const positional: string[] = [];
+const flags = new Map<string, string | true>();
+const VALUELESS = new Set([
+  "help",
+  "h",
+  "dry-run",
+  "yes",
+  "force",
+  "editor",
+  "enable",
+  "sem-explicacao",
+  "sem-fonte",
+  "desativadas",
+]);
+
+for (let i = 0; i < argv.length; i++) {
+  const arg = argv[i] ?? "";
+  if (!arg.startsWith("--")) {
+    positional.push(arg);
+    continue;
+  }
+  const [name, inline] = arg.slice(2).split("=", 2);
+  if (!name) continue;
+  if (inline !== undefined) {
+    flags.set(name, inline);
+    continue;
+  }
+  const next = argv[i + 1];
+  if (!VALUELESS.has(name) && next !== undefined && !next.startsWith("--")) {
+    flags.set(name, next);
+    i++;
+  } else {
+    flags.set(name, true);
+  }
+}
+const flag = (name: string): string | undefined => {
+  const value = flags.get(name);
+  return typeof value === "string" ? value : undefined;
+};
+const has = (name: string) => flags.has(name);
+
+const dryRun = has("dry-run");
+const assumeYes = has("yes");
+const force = has("force");
+const confirm = (question: string, fallback = false) =>
+  askConfirm(question, { fallback, assumeYes });
+
+function die(message: string, ...detail: string[]): never {
+  console.error(`\n${red("✗")} ${message}`);
+  for (const d of detail) console.error(`  ${d}`);
+  closePrompts();
+  process.exit(1);
+}
+
+function usage(): never {
+  console.log(bold("content:edit — alterar uma pergunta do banco"));
+  console.log();
+  console.log("  bun run content:edit cat3#86                interativo, campo a campo");
+  console.log("  bun run content:edit cat3#86 --editor       o ficheiro inteiro no $EDITOR");
+  console.log("  bun run content:edit cat3#86 --from fix.mdx substitui a partir de um ficheiro");
+  console.log("  bun run content:edit --sem-explicacao --cat 2   percorre a fila");
+  console.log();
+  console.log(dim("  --disable <motivo>  retira a pergunta do site sem a apagar"));
+  console.log(dim("  --enable            volta a publicá-la"));
+  console.log(dim("  --sem-explicacao    seleciona as perguntas sem explicação"));
+  console.log(dim("  --sem-fonte         seleciona as perguntas que não citam prova"));
+  console.log(dim("  --desativadas       seleciona as perguntas desativadas"));
+  console.log(dim("  --cat 3             restringe a seleção a uma categoria"));
+  console.log(dim("  --limit 10          quantas perguntas da fila percorrer"));
+  console.log(dim("  --dry-run           mostra o que escreveria, sem escrever nada"));
+  console.log(dim("  --yes               não pergunta (obrigatório quando stdin é um pipe)"));
+  console.log(dim("  --force             escreve apesar dos avisos"));
+  console.log();
+  console.log(dim("  A posição no order não se muda aqui — ver `bun run qbank order`."));
+  process.exit(0);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Choosing what to edit                                                       */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The questions this run will walk.
+ *
+ * Either named outright, or selected by what they are missing — which is the
+ * point of the queue flags: `coverage` counts the gaps and this is what turns
+ * a count into a list you can work through.
+ */
+function selection(bank: readonly BankQuestion[]): BankQuestion[] {
+  const catFlag = flag("cat");
+  const wanted =
+    catFlag === undefined
+      ? null
+      : new Set(catFlag.split(",").map((c) => c.replace(/^cat/, "").trim()));
+  if (wanted !== null) {
+    for (const c of wanted) {
+      if (!CATEGORIES.includes(c as CategoryId)) {
+        die(`categoria ${c} desconhecida`, `Categorias: ${CATEGORIES.join(", ")}`);
+      }
+    }
+  }
+
+  if (positional.length > 0) {
+    return positional.map((raw) => {
+      const ref = parseRef(raw);
+      if (ref === null) die(`${raw} não é uma referência`, "Formato: cat3#86");
+      const found = bank.find((q) => q.ref === bankRef(ref.category, ref.id));
+      if (found === undefined) die(`não existe a pergunta ${raw}`);
+      return found;
+    });
+  }
+
+  const filters: ((q: BankQuestion) => boolean)[] = [];
+  if (has("sem-explicacao")) filters.push((q) => q.explanation === null);
+  if (has("sem-fonte")) filters.push((q) => q.sources.length === 0);
+  if (has("desativadas")) filters.push((q) => q.disabled !== null);
+  if (filters.length === 0) {
+    die(
+      "nada selecionado",
+      "Passe uma referência (cat3#86) ou um filtro (--sem-explicacao, --sem-fonte, --desativadas)."
+    );
+  }
+
+  const queue = bank.filter(
+    (q) => (wanted === null || wanted.has(q.category)) && filters.every((f) => f(q))
+  );
+  const limit = Number.parseInt(flag("limit") ?? "", 10);
+  return Number.isNaN(limit) ? queue : queue.slice(0, limit);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Building the edited question                                                */
+/* -------------------------------------------------------------------------- */
+
+/** The current question as a draft, so only what is edited has to be replaced. */
+function draftOf(q: BankQuestion): Draft {
+  return {
+    category: q.category,
+    id: q.id,
+    question: q.question,
+    answers: q.answers.map((a) => (a.correct ? { text: a.text, correct: true } : { text: a.text })),
+    disabled: q.disabled,
+    topic: q.topic,
+    sources: q.sources,
+    image: q.image,
+    tutorial: q.tutorial,
+    calc: q.calc,
+    explanation: q.explanation,
+  };
+}
+
+type Field =
+  | "question"
+  | "answers"
+  | "topic"
+  | "explanation"
+  | "sources"
+  | "image"
+  | "disabled"
+  | "done";
+
+/**
+ * A menu rather than a fixed sequence.
+ *
+ * Almost every edit touches one field. Walking all of them to fix a typo in
+ * the stem — which is what `content:new`'s flow would do — is the interaction
+ * that makes people edit the MDX by hand instead.
+ */
+async function askField(draft: Draft): Promise<Field> {
+  // Hints are dimmed by `askChoice`, so nothing here dims them again: nested
+  // codes end the dim at the first reset and the rest of the line jumps back
+  // to full brightness mid-hint.
+  const summary = (text: string | null | undefined, empty = "vazio") =>
+    text == null || text.length === 0 ? empty : clip(text, 58);
+  const label = (text: string) => text.padEnd(13);
+
+  const chosen = await askChoice<Field>("O que alterar?", [
+    { value: "question", label: label("enunciado"), hint: summary(draft.question) },
+    {
+      value: "answers",
+      label: label("opções"),
+      hint: `${draft.answers.length} opções, certa: ${
+        (draft.answers.findIndex((a) => a.correct) ?? -1) + 1
+      }`,
+    },
+    { value: "topic", label: label("matéria"), hint: summary(draft.topic, "sem matéria") },
+    {
+      value: "explanation",
+      label: label("explicação"),
+      hint:
+        draft.explanation == null ? "sem explicação" : `${draft.explanation.length} caracteres`,
+    },
+    {
+      value: "sources",
+      label: label("fontes"),
+      hint: draft.sources?.length ? `${draft.sources.length} referência(s)` : "sem fonte",
+    },
+    { value: "image", label: label("imagem"), hint: summary(draft.image, "sem imagem") },
+    {
+      value: "disabled",
+      label: label("desativação"),
+      hint: draft.disabled == null ? "publicada" : `desativada: ${clip(draft.disabled, 40)}`,
+    },
+    { value: "done", label: bold(label("terminar")), hint: "rever e gravar" },
+  ]);
+  return chosen ?? "done";
+}
+
+async function editField(field: Field, draft: Draft): Promise<Draft> {
+  switch (field) {
+    case "question": {
+      console.log(`\n${dim("atual:")} ${draft.question}`);
+      return { ...draft, question: await askText(bold("Enunciado")) };
+    }
+    case "answers":
+      return { ...draft, answers: await askAnswers(draft.answers) };
+    case "topic": {
+      const topic = await askTopic(draft.topic);
+      return { ...draft, topic: topic ?? draft.topic ?? null };
+    }
+    case "explanation": {
+      console.log(`\n${bold("Explicação")} ${dim("— o corpo MDX. Pode ficar vazia.")}`);
+      console.log(dim(`  ${clip(draft.question, 100)}`));
+      return { ...draft, explanation: await askExplanation(draft.explanation ?? "") };
+    }
+    case "sources": {
+      if (draft.sources !== undefined && draft.sources.length > 0) {
+        console.log(`\n${dim("atuais (serão substituídas):")}`);
+        for (const s of draft.sources) {
+          console.log(
+            dim(`  ${s.pdf} pergunta ${s.question}${s.page == null ? "" : ` p.${s.page}`}`)
+          );
+        }
+      }
+      return { ...draft, sources: await askSources() };
+    }
+    case "image":
+      return { ...draft, image: await askImage() };
+    case "disabled": {
+      if (draft.disabled != null) {
+        console.log(`\n${dim("desativada:")} ${draft.disabled}`);
+        return (await confirm("Voltar a publicar?"))
+          ? { ...draft, disabled: null }
+          : draft;
+      }
+      const reason = await askText(
+        `\n${bold("Motivo para desativar")} ${dim("(Enter para deixar publicada)")}`,
+        { required: false }
+      );
+      return reason.length > 0 ? { ...draft, disabled: reason } : draft;
+    }
+    case "done":
+      return draft;
+  }
+}
+
+/** A whole question through $EDITOR, in the file format it is stored in. */
+async function editInEditor(current: ContentQuestion): Promise<Draft> {
+  const edited = await askExplanation(serializeQuestionFile(current));
+  if (edited === null) die("ficheiro vazio — nada alterado");
+  return draftFromSource(edited, current.id, current);
+}
+
+/**
+ * Reads a question file back into a draft.
+ *
+ * Fields are listed rather than spread, so a key the schema does not know
+ * reaches `QuestionSchema` and is refused by name instead of being carried
+ * silently into the write.
+ */
+function draftFromSource(raw: string, id: number, current: BankQuestion | ContentQuestion): Draft {
+  const { data, content } = matter(raw);
+  const fields = data as Record<string, unknown>;
+  const body = content.trim();
+  const category = ("category" in fields
+    ? String(fields.category).replace(/^cat/, "")
+    : (current as BankQuestion).category ?? null) as CategoryId;
+
+  return {
+    category,
+    id: typeof fields.id === "number" ? fields.id : id,
+    question: fields.question as string,
+    answers: fields.answers as Draft["answers"],
+    disabled: (fields.disabled ?? null) as string | null,
+    topic: (fields.topic ?? null) as string | null,
+    sources: fields.sources as Draft["sources"],
+    image: (fields.image ?? null) as string | null,
+    tutorial: (fields.tutorial ?? null) as string | null,
+    calc: (fields.calc ?? null) as string | null,
+    explanation: body.length > 0 ? body : null,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Reporting                                                                   */
+/* -------------------------------------------------------------------------- */
+
+function printDiff(changes: readonly FieldChange[]): void {
+  const width = Math.max(...changes.map((c) => c.label.length));
+  for (const c of changes) {
+    const label = c.critical === true ? red(bold(c.label.padEnd(width))) : bold(c.label.padEnd(width));
+    console.log(`  ${label}  ${dim(clip(c.before, 88))}`);
+    console.log(`  ${" ".repeat(width)}  ${green("→")} ${clip(c.after, 86)}`);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* One question                                                                */
+/* -------------------------------------------------------------------------- */
+
+/** True when something was written. */
+async function editOne(target: BankQuestion, bank: readonly BankQuestion[]): Promise<boolean> {
+  console.log(`\n${bold(target.ref)}  ${dim(target.file)}`);
+  printQuestion(target);
+
+  let draft = draftOf(target);
+
+  const disableReason = flag("disable");
+  if (disableReason !== undefined) {
+    if (!isWithheldReason(disableReason)) {
+      die("--disable precisa de um motivo em texto", 'Ex.: --disable "retirada pela ANACOM"');
+    }
+    draft = { ...draft, disabled: disableReason };
+  } else if (has("enable")) {
+    draft = { ...draft, disabled: null };
+  } else if (has("editor")) {
+    draft = await editInEditor(target);
+  } else {
+    const from = flag("from");
+    if (from !== undefined) {
+      draft = draftFromSource(
+        from === "-" ? readFileSync(0, "utf-8") : readFileSync(from, "utf-8"),
+        target.id,
+        target
+      );
+    } else if (interactive) {
+      for (;;) {
+        const field = await askField(draft);
+        if (field === "done") break;
+        draft = await editField(field, draft);
+      }
+    } else {
+      die(
+        "stdin não é um terminal e não foi passado --from, --editor, --disable nem --enable",
+        'bun run content:edit cat3#86 --disable "motivo" --yes'
+      );
+    }
+  }
+
+  const manifest = loadManifest(target.category);
+  const review = reviewDraft(draft, {
+    category: target.category,
+    anacomFile: manifest.anacomFile,
+    bank,
+    order: manifest.order,
+    // The id is in `order` and the question is in `bank`; both are expected
+    // for an edit, and `reviewDraft` inverts those two rules from this.
+    editing: target.id,
+    pdfLookup,
+    imageExists,
+  });
+
+  const question = review.question;
+  if (question === null) {
+    printFindings(review.findings);
+    die("não escrito — corrija os erros acima");
+  }
+
+  const changes = diffQuestions(target, question);
+  if (changes.length === 0) {
+    console.log(dim("\n  nada alterado"));
+    return false;
+  }
+
+  console.log(`\n${bold("Alterações")}`);
+  printDiff(changes);
+  printFindings(review.findings);
+
+  if (hasErrors(review.findings)) die("não escrito — corrija os erros acima");
+
+  // A changed correct answer, or a question withdrawn from the site, is
+  // confirmed on its own rather than folded into the warnings prompt: it is
+  // the edit that changes what every reader sees, and the diff row above is
+  // red for the same reason.
+  //
+  // It honours --yes like every other prompt. Making it unskippable would
+  // break `content:edit --disable "motivo" --yes`, which is the documented
+  // way to withdraw a question from a script; the safety here is that the
+  // change is stated plainly before it happens, not that a human is trapped
+  // into answering. Without --yes and without a terminal it still fails shut.
+  const critical = changes.find((c) => c.critical === true);
+  if (critical !== undefined && !force) {
+    console.log(`\n${yellow("!")} ${bold(critical.label)} muda.`);
+    if (!(await confirm("  Confirma?"))) {
+      console.log(dim("  cancelado"));
+      return false;
+    }
+  }
+
+  if (review.findings.length > 0 && !force) {
+    if (!(await confirm(`\n${review.findings.length} aviso(s). Continuar?`))) {
+      console.log(dim("  cancelado"));
+      return false;
+    }
+  }
+
+  if (dryRun) {
+    console.log(`\n${bold("--dry-run")} ${dim("— nada foi escrito")}`);
+    console.log(`\n${dim(`${target.file}:`)}`);
+    console.log(serializeQuestionFile(question).replace(/^/gm, "  ").trimEnd());
+    return false;
+  }
+
+  // `order` is passed through unchanged: an edit never moves a question.
+  const written = writeQuestion(target.category, question, manifest.order);
+  console.log(`\n${green("✓")} ${target.ref}`);
+  for (const f of written) console.log(`  ${f}`);
+  return true;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Run                                                                         */
+/* -------------------------------------------------------------------------- */
+
+async function main(): Promise<void> {
+  if (has("help") || has("h")) usage();
+
+  const { bank } = loadAll();
+  const targets = selection(bank);
+
+  if (targets.length === 0) {
+    console.log(dim("nada a fazer — a seleção não devolveu perguntas"));
+    return;
+  }
+  if (targets.length > 1) {
+    console.log(
+      `${bold(String(targets.length))} pergunta(s) selecionada(s)${
+        flag("limit") === undefined ? dim("  (--limit N para menos)") : ""
+      }`
+    );
+  }
+
+  let written = 0;
+  for (const [i, target] of targets.entries()) {
+    if (targets.length > 1) console.log(dim(`\n${"─".repeat(72)}\n${i + 1} de ${targets.length}`));
+
+    // Reloaded per question so each edit is reviewed against what the previous
+    // one wrote, not against the bank as it was when the run started.
+    const current = i === 0 ? bank : loadAll().bank;
+    const fresh = current.find((q) => q.ref === target.ref) ?? target;
+    if (await editOne(fresh, current)) written++;
+
+    if (targets.length > 1 && i < targets.length - 1 && interactive && !assumeYes) {
+      if (!(await askConfirm("\nContinuar para a próxima?", { fallback: true }))) break;
+    }
+  }
+
+  if (targets.length > 1) {
+    console.log(`\n${green("✓")} ${written} de ${targets.length} alterada(s)`);
+  }
+  if (written > 0) {
+    console.log(dim("\n  bun run content:check    # confirma que os artefactos batem certo"));
+  }
+  closePrompts();
+}
+
+main()
+  .then(() => closePrompts())
+  .catch((error: unknown) => {
+    die(error instanceof Error ? error.message : String(error));
+  });

--- a/scripts/content-io.ts
+++ b/scripts/content-io.ts
@@ -1,0 +1,384 @@
+/**
+ * The I/O half of the authoring scripts, shared by `content:new` and
+ * `content:edit`.
+ *
+ * Extracted when `content:edit` arrived and needed every one of these: reading
+ * the bank, resolving an image path, the field prompts, and the write path
+ * that leaves the tree in the state `content:check` expects. The alternative
+ * was a second copy of each, which is how two tools that write the same files
+ * start disagreeing about how to write them.
+ *
+ * The split matches the rest of the repo: what a question *is* and what is
+ * *allowed* live in `lib/content/`, pure and tested; this is the terminal and
+ * the filesystem. Nothing here decides anything.
+ */
+import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync, statSync } from "fs";
+import { join, resolve, extname } from "path";
+import { tmpdir, homedir } from "os";
+import { spawnSync } from "node:child_process";
+import {
+  loadCategory,
+  emitCategory,
+  serializeManifest,
+  CategoryManifestSchema,
+  MANIFEST_FILE,
+  type CategoryManifest,
+} from "../lib/content/build";
+import { serializeQuestionFile } from "../lib/content/source";
+import type { ContentCategory, ContentQuestion } from "../lib/content/schema";
+import { buildBank, type BankQuestion } from "../lib/content/analysis";
+import { EXPECTED_OPTIONS, type Draft, type Finding } from "../lib/content/author";
+import { CATEGORIES, type CategoryId } from "../lib/config/categories";
+import { TOPICS } from "../lib/config/topics";
+import { ask, askText, askChoice, closePrompts, bold, dim, red, green, yellow } from "./prompt";
+
+export const ROOT = process.cwd();
+export const EXAMS_DIR = join(ROOT, "public", "exams");
+export const PUBLIC_DIR = join(ROOT, "public");
+
+/* -------------------------------------------------------------------------- */
+/* Output                                                                      */
+/* -------------------------------------------------------------------------- */
+
+/** Truncates for a one-line summary, on a word boundary where it can. */
+export function clip(text: string, width: number): string {
+  const flat = text.replace(/\s+/g, " ").trim();
+  if (flat.length <= width) return flat;
+  const cut = flat.slice(0, width - 1);
+  const space = cut.lastIndexOf(" ");
+  return `${space > width * 0.6 ? cut.slice(0, space) : cut}…`;
+}
+
+export function printFindings(findings: readonly Finding[]): void {
+  if (findings.length === 0) {
+    console.log(`\n${green("✓")} sem problemas`);
+    return;
+  }
+  console.log();
+  for (const f of findings) {
+    console.log(`${f.level === "error" ? red("✗") : yellow("!")} ${f.message}  ${dim(f.code)}`);
+    for (const d of f.detail ?? []) console.log(`    ${dim(d)}`);
+  }
+}
+
+/** One question rendered the way both tools show it before writing. */
+export function printQuestion(q: ContentQuestion): void {
+  console.log(`  ${q.question}`);
+  for (const a of q.answers) {
+    console.log(`   ${a.correct ? green("✓") : dim("·")} ${clip(a.text, 100)}`);
+  }
+  const marks = [
+    q.topic ?? "sem matéria",
+    q.sources.length > 0
+      ? q.sources
+          .map((s) => `${s.pdf} pergunta ${s.question}${s.page === null ? "" : ` p.${s.page}`}`)
+          .join("; ")
+      : "sem fonte",
+    q.explanation === null ? "sem explicação" : `explicação, ${q.explanation.length} caracteres`,
+    ...(q.disabled === null ? [] : [`desativada: ${q.disabled}`]),
+  ];
+  console.log(`  ${dim(marks.join("  |  "))}`);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Loading                                                                     */
+/* -------------------------------------------------------------------------- */
+
+export function sourceDirOf(category: CategoryId): string {
+  return join(ROOT, "content", "questions", `cat${category}`);
+}
+
+export function loadAll(): { categories: ContentCategory[]; bank: BankQuestion[] } {
+  const categories = CATEGORIES.filter((c) => existsSync(sourceDirOf(c))).map((c) =>
+    loadCategory(sourceDirOf(c))
+  );
+  return { categories, bank: buildBank(categories) };
+}
+
+export function loadManifest(category: CategoryId): CategoryManifest {
+  return CategoryManifestSchema.parse(
+    JSON.parse(readFileSync(join(sourceDirOf(category), MANIFEST_FILE), "utf-8"))
+  );
+}
+
+/** Existence of an exam PDF, with the wrong-prefix hint `findDanglingPdfs` gives. */
+export function pdfLookup(pdf: string): { exists: boolean; alsoIn: string[] } {
+  if (existsSync(join(EXAMS_DIR, `${pdf}.pdf`))) return { exists: true, alsoIn: [] };
+  const stem = pdf.slice(pdf.indexOf("/") + 1);
+  const alsoIn = CATEGORIES.filter(
+    (c) => `cat${c}` !== pdf.split("/")[0] && existsSync(join(EXAMS_DIR, `cat${c}`, `${stem}.pdf`))
+  ).map((c) => `cat${c}`);
+  return { exists: false, alsoIn };
+}
+
+export const imageExists = (rel: string) => existsSync(join(PUBLIC_DIR, rel));
+
+/* -------------------------------------------------------------------------- */
+/* Images                                                                      */
+/* -------------------------------------------------------------------------- */
+
+export const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"]);
+
+/**
+ * What the author typed, resolved to one of the two things it can be.
+ *
+ * A figure already under `public/images/` is referenced where it lies — the
+ * same drawing is sometimes cited by more than one question. Anything else is
+ * a file somewhere on disk, to be copied in at write time.
+ */
+export type ImageInput =
+  | { kind: "public"; rel: string }
+  | { kind: "file"; from: string; ext: string }
+  | { kind: "missing" }
+  | { kind: "unsupported"; ext: string };
+
+export function classifyImage(input: string): ImageInput {
+  const rel = input.replace(/^\//, "");
+  if (rel.startsWith("images/") && imageExists(rel)) return { kind: "public", rel };
+
+  const from = resolve(input.startsWith("~/") ? join(homedir(), input.slice(2)) : input);
+  if (!existsSync(from) || !statSync(from).isFile()) return { kind: "missing" };
+  const ext = extname(from).toLowerCase();
+  if (!IMAGE_EXTENSIONS.has(ext)) return { kind: "unsupported", ext };
+  return { kind: "file", from, ext };
+}
+
+/**
+ * Named for the question rather than for the file it came from.
+ *
+ * `Screenshot 2026-08-27 at 14.03.11.png` is not a name to carry into the
+ * repo, and a descriptive one taken from the source risks colliding with a
+ * figure another question already references — which would silently replace
+ * that question's drawing.
+ */
+export const imageDestination = (category: CategoryId, id: number, ext: string) =>
+  `images/cat${category}/q${id}${ext}`;
+
+/* -------------------------------------------------------------------------- */
+/* Field prompts                                                               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Prose through $EDITOR, seeded with whatever is already there.
+ *
+ * Prose at a readline prompt is miserable, and this is the field that gives a
+ * question its value. The interface is closed first: the editor takes over the
+ * terminal, and two readers on one stdin fight over the keystrokes.
+ */
+export async function askExplanation(initial = ""): Promise<string | null> {
+  const editor = process.env.VISUAL ?? process.env.EDITOR;
+  if (editor === undefined || editor.trim().length === 0) {
+    if (initial.length > 0) {
+      console.log(dim("  explicação atual:"));
+      console.log(dim(clip(initial, 300).replace(/^/gm, "  | ")));
+      console.log(dim("  $EDITOR não definido — reescreva-a, terminando com uma linha só com ."));
+      console.log(dim("  (uma linha só com = mantém a atual)"));
+    } else {
+      console.log(
+        dim("  $EDITOR não definido — escreva a explicação, terminando com uma linha só com .")
+      );
+    }
+    const lines: string[] = [];
+    for (;;) {
+      const line = await ask(dim("| "));
+      if (line.trim() === "=") return initial.length > 0 ? initial : null;
+      if (line.trim() === ".") break;
+      lines.push(line);
+    }
+    const typed = lines.join("\n").trim();
+    return typed.length > 0 ? typed : null;
+  }
+
+  const tmp = join(tmpdir(), `content-${process.pid}.mdx`);
+  writeFileSync(tmp, initial);
+  closePrompts();
+  const result = spawnSync(editor, [tmp], { stdio: "inherit", shell: true });
+  if (result.error) {
+    unlinkSync(tmp);
+    throw new Error(`não foi possível abrir ${editor}: ${result.error.message}`);
+  }
+  const body = readFileSync(tmp, "utf-8").trim();
+  unlinkSync(tmp);
+  return body.length > 0 ? body : null;
+}
+
+export async function askAnswers(current?: Draft["answers"]): Promise<Draft["answers"]> {
+  console.log(`\n${bold("Opções")} ${dim(`(${EXPECTED_OPTIONS}; Enter numa vazia termina)`)}`);
+  if (current !== undefined) {
+    console.log(dim("  Enter mantém a opção atual, mostrada por baixo do número"));
+  }
+  const texts: string[] = [];
+  for (let i = 0; i < 8; i++) {
+    const existing = current?.[i]?.text;
+    if (existing !== undefined) console.log(dim(`  ${i + 1}. ${clip(existing, 92)}`));
+    const text = await askText(`  ${i + 1}`, { required: current === undefined && i < 2 });
+    if (text.length === 0) {
+      if (existing === undefined) break;
+      texts.push(existing);
+      continue;
+    }
+    texts.push(text);
+  }
+
+  const previous = current?.findIndex((a) => a.correct) ?? -1;
+  const correct = await askChoice<number>(
+    "Qual é a correta?",
+    texts.map((t, i) => ({
+      value: i,
+      label: clip(t, 90),
+      ...(i === previous ? { hint: "atual" } : {}),
+    }))
+  );
+  return texts.map((text, i) => (i === correct ? { text, correct: true } : { text }));
+}
+
+/**
+ * The taxonomy as a picker.
+ *
+ * `topic` is free text in the schema, and a misspelled slug is the one mistake
+ * in these files that nothing reports: the label silently stops rendering and
+ * the browse filter silently stops matching. Choosing from the list makes it
+ * unrepresentable rather than merely detectable.
+ */
+export async function askTopic(current?: string | null): Promise<string | null> {
+  return askChoice<string>(
+    "Matéria",
+    TOPICS.map((t) => ({
+      value: t.slug,
+      label: t.slug.padEnd(16),
+      hint: `${t.shortPt} — a partir de cat${t.examinedFrom}${t.slug === current ? "  (atual)" : ""}`,
+    })),
+    { allowNone: true, noneLabel: current == null ? "Enter para nenhum" : "Enter para manter a atual" }
+  );
+}
+
+/**
+ * The two numbers are asked as two sentences.
+ *
+ * `question` is the pergunta number printed in the paper and `page` is the PDF
+ * page; the papers carry about four questions per page, so they are unrelated,
+ * and typing one into both fields is the easiest mistake here to make.
+ */
+export async function askSources(): Promise<Draft["sources"]> {
+  const sources: NonNullable<Draft["sources"]> = [];
+  for (;;) {
+    console.log(
+      `\n${bold("Prova oficial")} ${dim(
+        sources.length === 0 ? "(Enter para saltar)" : "(Enter para terminar)"
+      )}`
+    );
+    const pdf = await askText("  Ficheiro sob public/exams (ex.: cat3/2023_08_18)", {
+      required: false,
+    });
+    if (pdf.length === 0) return sources;
+
+    const { exists, alsoIn } = pdfLookup(pdf);
+    console.log(
+      exists
+        ? `  ${green("✓")} ${dim("existe em public/exams")}`
+        : `  ${yellow("!")} ${dim(
+            alsoIn.length > 0
+              ? `não existe aqui, mas existe em ${alsoIn.join(", ")}`
+              : "não existe em public/exams"
+          )}`
+    );
+
+    const question = Number.parseInt(await askText("  Número da pergunta impresso na prova"), 10);
+    const pageRaw = await askText("  Página do PDF em que está impressa (Enter se desconhecida)", {
+      required: false,
+    });
+
+    sources.push({
+      pdf,
+      question,
+      page: pageRaw.length > 0 ? Number.parseInt(pageRaw, 10) : null,
+    });
+  }
+}
+
+/**
+ * Validated as it is typed, not at the end.
+ *
+ * The path is the one field here the author can get wrong without noticing —
+ * a typo yields a question that renders a broken image — and finding out after
+ * everything else has been entered is the wrong moment.
+ */
+export async function askImage(): Promise<string | null> {
+  for (;;) {
+    const input = await askText(
+      `\n${bold("Imagem")} ${dim("caminho do ficheiro, ou images/cat3/x.png já em public/ (Enter se nenhuma)")}`,
+      { required: false }
+    );
+    if (input.length === 0) return null;
+
+    const classified = classifyImage(input);
+    if (classified.kind === "public") {
+      console.log(`  ${green("✓")} ${dim("já está em public/, referenciada onde está")}`);
+      return input;
+    }
+    if (classified.kind === "file") {
+      console.log(`  ${green("✓")} ${dim(`${classified.from} — copiada ao escrever`)}`);
+      return input;
+    }
+    console.log(
+      `  ${red("✗")} ${dim(
+        classified.kind === "unsupported"
+          ? `${classified.ext} não é um formato de imagem (${[...IMAGE_EXTENSIONS].join(", ")})`
+          : "não existe, nem sob public/ nem como ficheiro"
+      )}`
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Writing                                                                     */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Writes a question and regenerates its category's artifacts.
+ *
+ * `order` is passed rather than derived: adding a question inserts into it,
+ * editing one leaves it alone, and neither tool should have to know how the
+ * other does it.
+ *
+ * The category is reloaded from disk rather than reusing what is in memory, so
+ * a round-trip surprise — anything the serializer drops — surfaces here rather
+ * than in the next `content:check`.
+ */
+export function writeQuestion(
+  category: CategoryId,
+  question: ContentQuestion,
+  order: readonly number[]
+): string[] {
+  const sourceDir = sourceDirOf(category);
+  const manifest = loadManifest(category);
+  const questionFile = join(sourceDir, `${String(question.id).padStart(4, "0")}.mdx`);
+
+  writeFileSync(questionFile, serializeQuestionFile(question));
+  writeFileSync(
+    join(sourceDir, MANIFEST_FILE),
+    serializeManifest({ ...manifest, order: [...order] })
+  );
+
+  const { appJson, notes } = emitCategory(loadCategory(sourceDir), EXAMS_DIR);
+  const dataFile = join(ROOT, "public", "data", `cat${category}.json`);
+  writeFileSync(dataFile, appJson);
+
+  const written = [questionFile, join(sourceDir, MANIFEST_FILE), dataFile];
+
+  const noteFile = join(ROOT, "content", "notes", `cat${category}`, `${question.id}.mdx`);
+  const note = notes.get(question.id);
+  if (note !== undefined) {
+    mkdirSync(join(noteFile, ".."), { recursive: true });
+    writeFileSync(noteFile, note);
+    written.push(noteFile);
+  } else if (existsSync(noteFile)) {
+    // The explanation was removed, or the question was withheld. Leaving the
+    // note behind would keep it served: `/api/notes` reads from disk without
+    // consulting the bank.
+    unlinkSync(noteFile);
+    written.push(`${noteFile} (removido)`);
+  }
+
+  return written.map((f) => f.replace(`${ROOT}/`, ""));
+}

--- a/scripts/content-new.ts
+++ b/scripts/content-new.ts
@@ -19,37 +19,18 @@
  * draft is fixed and re-fed unchanged, and the file that is finally written is
  * the file that was reviewed.
  */
-import {
-  existsSync,
-  readFileSync,
-  writeFileSync,
-  unlinkSync,
-  mkdirSync,
-  copyFileSync,
-  statSync,
-} from "fs";
-import { join, resolve, extname } from "path";
-import { tmpdir, homedir } from "os";
-import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync } from "fs";
+import { join } from "path";
 import matter from "gray-matter";
-import {
-  loadCategory,
-  emitCategory,
-  serializeManifest,
-  CategoryManifestSchema,
-  MANIFEST_FILE,
-  type CategoryManifest,
-} from "../lib/content/build";
-import { serializeQuestionFile, questionFileName } from "../lib/content/source";
-import { buildBank, orderEntries, type BankQuestion } from "../lib/content/analysis";
+import { MANIFEST_FILE } from "../lib/content/build";
+import { questionFileName, serializeQuestionFile } from "../lib/content/source";
+import { buildBank, orderEntries } from "../lib/content/analysis";
 import {
   reviewDraft,
   insertIntoOrder,
   nextId,
   hasErrors,
-  EXPECTED_OPTIONS,
   type Draft,
-  type Finding,
   type OrderAnchor,
 } from "../lib/content/author";
 import {
@@ -57,7 +38,6 @@ import {
   dim,
   red,
   green,
-  yellow,
   interactive,
   ask,
   askText,
@@ -65,16 +45,33 @@ import {
   confirm as askConfirm,
   closePrompts,
 } from "./prompt";
-import { TOPICS, topicShortLabel } from "../lib/config/topics";
+import {
+  ROOT,
+  EXAMS_DIR,
+  PUBLIC_DIR,
+  IMAGE_EXTENSIONS,
+  clip,
+  printFindings,
+  sourceDirOf,
+  loadAll,
+  loadManifest,
+  pdfLookup,
+  imageExists,
+  classifyImage,
+  imageDestination,
+  askAnswers,
+  askTopic,
+  askSources,
+  askImage,
+  askExplanation,
+  writeQuestion,
+} from "./content-io";
+import { topicShortLabel } from "../lib/config/topics";
 import { CATEGORIES, type CategoryId } from "../lib/config/categories";
 import type { ContentCategory } from "../lib/content/schema";
 
 // Resolved from the working directory, like the other content scripts; these
 // are always invoked via `bun run` from the project root.
-const ROOT = process.cwd();
-const EXAMS_DIR = join(ROOT, "public", "exams");
-const PUBLIC_DIR = join(ROOT, "public");
-
 /* -------------------------------------------------------------------------- */
 /* Arguments                                                                   */
 /* -------------------------------------------------------------------------- */
@@ -112,15 +109,6 @@ const force = has("force");
 /* Output                                                                      */
 /* -------------------------------------------------------------------------- */
 
-/** Truncates for a one-line summary, on a word boundary where it can. */
-function clip(text: string, width: number): string {
-  const flat = text.replace(/\s+/g, " ").trim();
-  if (flat.length <= width) return flat;
-  const cut = flat.slice(0, width - 1);
-  const space = cut.lastIndexOf(" ");
-  return `${space > width * 0.6 ? cut.slice(0, space) : cut}…`;
-}
-
 function die(message: string, ...detail: string[]): never {
   console.error(`\n${red("✗")} ${message}`);
   for (const d of detail) console.error(`  ${d}`);
@@ -153,109 +141,9 @@ function usage(): never {
 const confirm = (question: string, fallback = false) =>
   askConfirm(question, { fallback, assumeYes });
 
-/**
- * The explanation body, through $EDITOR.
- *
- * Prose at a readline prompt is miserable, and this is the field that gives a
- * question its value. The interface is closed first: the editor takes over the
- * terminal, and two readers on one stdin fight over the keystrokes.
- */
-async function askExplanation(): Promise<string | null> {
-  const editor = process.env.VISUAL ?? process.env.EDITOR;
-  if (editor === undefined || editor.trim().length === 0) {
-    console.log(dim("  $EDITOR não definido — escreva a explicação, terminando com uma linha só com ."));
-    const lines: string[] = [];
-    for (;;) {
-      const line = await ask(dim("| "));
-      if (line.trim() === ".") break;
-      lines.push(line);
-    }
-    const typed = lines.join("\n").trim();
-    return typed.length > 0 ? typed : null;
-  }
-
-  const tmp = join(tmpdir(), `content-new-${process.pid}.mdx`);
-  writeFileSync(tmp, "");
-  closePrompts();
-  const result = spawnSync(editor, [tmp], { stdio: "inherit", shell: true });
-  if (result.error) {
-    unlinkSync(tmp);
-    die(`não foi possível abrir ${editor}`, result.error.message);
-  }
-  const body = readFileSync(tmp, "utf-8").trim();
-  unlinkSync(tmp);
-  return body.length > 0 ? body : null;
-}
-
 /* -------------------------------------------------------------------------- */
 /* Loading                                                                     */
 /* -------------------------------------------------------------------------- */
-
-function sourceDirOf(category: CategoryId): string {
-  return join(ROOT, "content", "questions", `cat${category}`);
-}
-
-function loadAll(): { categories: ContentCategory[]; bank: BankQuestion[] } {
-  const categories = CATEGORIES.filter((c) => existsSync(sourceDirOf(c))).map((c) =>
-    loadCategory(sourceDirOf(c))
-  );
-  return { categories, bank: buildBank(categories) };
-}
-
-function loadManifest(category: CategoryId): CategoryManifest {
-  return CategoryManifestSchema.parse(
-    JSON.parse(readFileSync(join(sourceDirOf(category), MANIFEST_FILE), "utf-8"))
-  );
-}
-
-/** Existence of an exam PDF, with the wrong-prefix hint `findDanglingPdfs` gives. */
-function pdfLookup(pdf: string): { exists: boolean; alsoIn: string[] } {
-  if (existsSync(join(EXAMS_DIR, `${pdf}.pdf`))) return { exists: true, alsoIn: [] };
-  const stem = pdf.slice(pdf.indexOf("/") + 1);
-  const alsoIn = CATEGORIES.filter(
-    (c) => `cat${c}` !== pdf.split("/")[0] && existsSync(join(EXAMS_DIR, `cat${c}`, `${stem}.pdf`))
-  ).map((c) => `cat${c}`);
-  return { exists: false, alsoIn };
-}
-
-const imageExists = (rel: string) => existsSync(join(PUBLIC_DIR, rel));
-
-const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"]);
-
-/**
- * What the author typed, resolved to one of the two things it can be.
- *
- * A figure already under `public/images/` is referenced where it lies — the
- * same drawing is sometimes cited by more than one question. Anything else is
- * a file somewhere on disk, to be copied in at write time.
- */
-type ImageInput =
-  | { kind: "public"; rel: string }
-  | { kind: "file"; from: string; ext: string }
-  | { kind: "missing" }
-  | { kind: "unsupported"; ext: string };
-
-function classifyImage(input: string): ImageInput {
-  const rel = input.replace(/^\//, "");
-  if (rel.startsWith("images/") && imageExists(rel)) return { kind: "public", rel };
-
-  const from = resolve(input.startsWith("~/") ? join(homedir(), input.slice(2)) : input);
-  if (!existsSync(from) || !statSync(from).isFile()) return { kind: "missing" };
-  const ext = extname(from).toLowerCase();
-  if (!IMAGE_EXTENSIONS.has(ext)) return { kind: "unsupported", ext };
-  return { kind: "file", from, ext };
-}
-
-/**
- * Named for the question rather than for the file it came from.
- *
- * `Screenshot 2026-08-27 at 14.03.11.png` is not a name to carry into the
- * repo, and a descriptive one taken from the source risks colliding with a
- * figure another question already references — which would silently replace
- * that question's drawing. The id is new, so this name cannot be taken.
- */
-const imageDestination = (category: CategoryId, id: number, ext: string) =>
-  `images/cat${category}/q${id}${ext}`;
 
 /* -------------------------------------------------------------------------- */
 /* Drafts from a file                                                          */
@@ -327,121 +215,6 @@ async function askCategory(): Promise<CategoryId> {
   return chosen ?? "3";
 }
 
-async function askAnswers(): Promise<Draft["answers"]> {
-  console.log(`\n${bold("Opções")} ${dim(`(${EXPECTED_OPTIONS}; Enter numa vazia termina)`)}`);
-  const texts: string[] = [];
-  for (let i = 0; i < 8; i++) {
-    const text = await askText(`  ${i + 1}`, { required: i < 2 });
-    if (text.length === 0) break;
-    texts.push(text);
-  }
-
-  const correct = await askChoice<number>(
-    "Qual é a correta?",
-    texts.map((t, i) => ({ value: i, label: clip(t, 90) }))
-  );
-  return texts.map((text, i) => (i === correct ? { text, correct: true } : { text }));
-}
-
-/**
- * The taxonomy as a picker.
- *
- * `topic` is free text in the schema, and a misspelled slug is the one mistake
- * in this file that nothing reports: the label silently stops rendering and
- * the browse filter silently stops matching. Choosing from the list makes it
- * unrepresentable rather than merely detectable.
- */
-async function askTopic(): Promise<string | null> {
-  return askChoice<string>(
-    "Matéria",
-    TOPICS.map((t) => ({
-      value: t.slug,
-      label: t.slug.padEnd(16),
-      hint: `${t.shortPt} — a partir de cat${t.examinedFrom}`,
-    })),
-    { allowNone: true }
-  );
-}
-
-/**
- * The two numbers are asked as two sentences.
- *
- * `question` is the pergunta number printed in the paper and `page` is the PDF
- * page; the papers carry about four questions per page, so they are unrelated,
- * and typing one into both fields is the easiest mistake here to make.
- */
-async function askSources(): Promise<Draft["sources"]> {
-  const sources: NonNullable<Draft["sources"]> = [];
-  for (;;) {
-    console.log(
-      `\n${bold("Prova oficial")} ${dim(
-        sources.length === 0 ? "(Enter para saltar)" : "(Enter para terminar)"
-      )}`
-    );
-    const pdf = await askText("  Ficheiro sob public/exams (ex.: cat3/2023_08_18)", {
-      required: false,
-    });
-    if (pdf.length === 0) return sources;
-
-    const { exists, alsoIn } = pdfLookup(pdf);
-    console.log(
-      exists
-        ? `  ${green("✓")} ${dim("existe em public/exams")}`
-        : `  ${yellow("!")} ${dim(
-            alsoIn.length > 0
-              ? `não existe aqui, mas existe em ${alsoIn.join(", ")}`
-              : "não existe em public/exams"
-          )}`
-    );
-
-    const question = Number.parseInt(await askText("  Número da pergunta impresso na prova"), 10);
-    const pageRaw = await askText("  Página do PDF em que está impressa (Enter se desconhecida)", {
-      required: false,
-    });
-
-    sources.push({
-      pdf,
-      question,
-      page: pageRaw.length > 0 ? Number.parseInt(pageRaw, 10) : null,
-    });
-  }
-}
-
-/**
- * Validated as it is typed, not at the end.
- *
- * The path is the one field here the author can get wrong without noticing —
- * a typo yields a question that renders a broken image — and finding out after
- * the enunciado, the options and the explanation have all been entered is the
- * wrong moment.
- */
-async function askImage(): Promise<string | null> {
-  for (;;) {
-    const input = await askText(
-      `\n${bold("Imagem")} ${dim("caminho do ficheiro, ou images/cat3/x.png já em public/ (Enter se nenhuma)")}`,
-      { required: false }
-    );
-    if (input.length === 0) return null;
-
-    const classified = classifyImage(input);
-    if (classified.kind === "public") {
-      console.log(`  ${green("✓")} ${dim("já está em public/, referenciada onde está")}`);
-      return input;
-    }
-    if (classified.kind === "file") {
-      console.log(`  ${green("✓")} ${dim(`${classified.from} — copiada ao escrever`)}`);
-      return input;
-    }
-    console.log(
-      `  ${red("✗")} ${dim(
-        classified.kind === "unsupported"
-          ? `${classified.ext} não é um formato de imagem (${[...IMAGE_EXTENSIONS].join(", ")})`
-          : "não existe, nem sob public/ nem como ficheiro"
-      )}`
-    );
-  }
-}
-
 async function askDraft(): Promise<Draft> {
   const catFlag = flag("cat");
   const category =
@@ -505,18 +278,6 @@ function printSummary(draft: Draft, id: number, review: ReturnType<typeof review
     q.explanation === null ? "sem explicação" : `explicação, ${q.explanation.length} caracteres`,
   ];
   console.log(`  ${dim(marks.join("  |  "))}`);
-}
-
-function printFindings(findings: readonly Finding[]): void {
-  if (findings.length === 0) {
-    console.log(`\n${green("✓")} sem problemas`);
-    return;
-  }
-  console.log();
-  for (const f of findings) {
-    console.log(`${f.level === "error" ? red("✗") : yellow("!")} ${f.message}  ${dim(f.code)}`);
-    for (const d of f.detail ?? []) console.log(`    ${dim(d)}`);
-  }
 }
 
 /* -------------------------------------------------------------------------- */
@@ -690,12 +451,11 @@ async function main(): Promise<void> {
   const position = order.indexOf(id) + 1;
 
   const questionFile = join(sourceDir, questionFileName(id));
-  const body = serializeQuestionFile(question);
 
   if (dryRun) {
     console.log(`\n${bold("--dry-run")} ${dim("— nada foi escrito")}`);
     console.log(`\n${dim(`${questionFile.replace(`${ROOT}/`, "")}:`)}`);
-    console.log(body.replace(/^/gm, "  ").trimEnd());
+    console.log(serializeQuestionFile(question).replace(/^/gm, "  ").trimEnd());
     console.log(
       `\n${dim(
         `category.json: order posição ${position} de ${order.length}, depois de ${
@@ -710,37 +470,20 @@ async function main(): Promise<void> {
     return;
   }
 
-  writeFileSync(questionFile, body);
-  writeFileSync(join(sourceDir, MANIFEST_FILE), serializeManifest({ ...manifest, order }));
+  // The image lands before the question, so a file that references it is never
+  // committed ahead of the figure it points at.
   if (imageCopy !== null) {
     mkdirSync(join(imageCopy.to, ".."), { recursive: true });
     copyFileSync(imageCopy.from, imageCopy.to);
   }
 
-  // Reloaded rather than reused: this parses back what was just written, so a
-  // round-trip surprise surfaces here instead of in the next `content:check`.
-  const { appJson, notes } = emitCategory(loadCategory(sourceDir), EXAMS_DIR);
-  const dataFile = join(ROOT, "public", "data", `cat${draft.category}.json`);
-  writeFileSync(dataFile, appJson);
-
-  const written = [
-    questionFile,
-    join(sourceDir, MANIFEST_FILE),
-    dataFile,
-    ...(imageCopy === null ? [] : [imageCopy.to]),
-  ];
-  const note = notes.get(id);
-  if (note !== undefined) {
-    const noteFile = join(ROOT, "content", "notes", `cat${draft.category}`, `${id}.mdx`);
-    mkdirSync(join(noteFile, ".."), { recursive: true });
-    writeFileSync(noteFile, note);
-    written.push(noteFile);
-  }
+  const written = writeQuestion(draft.category, question, order);
+  if (imageCopy !== null) written.push(imageCopy.to.replace(`${ROOT}/`, ""));
 
   console.log(
     `\n${green("✓")} cat${draft.category}#${id}, posição ${position} de ${order.length}`
   );
-  for (const f of written) console.log(`  ${f.replace(`${ROOT}/`, "")}`);
+  for (const f of written) console.log(`  ${f}`);
   console.log(dim("\n  bun run content:check    # confirma que os artefactos batem certo"));
   closePrompts();
 }


### PR DESCRIPTION
Havia o `content:new` e não havia nada para o outro lado. Alterar uma pergunta era abrir o MDX à mão: sem revisão de duplicados, sem escolha da matéria a partir da lista, sem validação nenhuma até ao `content:build` seguinte.

Isso pesa sobretudo nas **260 perguntas sem explicação**, quase todas da categoria 2 — a maior lacuna que resta no banco, e um trabalho inteiramente de edição.

```bash
bun run content:edit cat3#86                     # menu, campo a campo
bun run content:edit cat3#86 --editor            # ficheiro inteiro no $EDITOR
bun run content:edit cat3#86 --from correcao.mdx # a partir de um ficheiro
bun run content:edit --sem-explicacao --cat 2    # percorre a fila
bun run content:edit cat3#161 --disable "motivo" # / --enable
```

## Um menu, não uma sequência

Quase todas as alterações mexem num campo só. Percorrer todos para corrigir uma gralha no enunciado é o que leva as pessoas a editar o MDX à mão.

```
O que alterar?
   1  enunciado      Qual a validade das licenças de amador de uso comum?
   2  opções         4 opções, certa: 3
   3  matéria        regulamentacao
   4  explicação     261 caracteres
   5  fontes         1 referência(s)
   6  imagem         sem imagem
   7  desativação    publicada
   8  terminar       rever e gravar
```

## As alterações são ditas antes de acontecerem

```
Alterações
  enunciado  Qua a validade das licenças de amador de uso comum?
             → Qual a validade das licenças de amador de uso comum?
```

As opções comparam-se uma a uma: uma correção de uma palavra na opção 3 lê-se como uma correção de uma palavra, não como quatro opções reescritas. A explicação é resumida em caracteres — um corpo de 2000 enterrava tudo o resto — e uma reescrita do mesmo comprimento diz `(texto alterado)`, para não parecer que nada aconteceu.

A `resposta certa` e a `desativada` aparecem a vermelho e confirmam-se à parte.

## `reviewDraft` recebe `editing`

Duas regras invertem-se numa edição: o id é suposto estar no `order`, e a pergunta já está no banco, onde se relataria como duplicado exato de si mesma. As duas ficam dentro do `reviewDraft`, porque quem se esquecesse de uma delas obtinha uma revisão confiante e errada.

## O que não faz

**Não mexe no `order`.** Mudar uma pergunta de lugar é uma decisão editorial sobre a sequência de navegação, não uma alteração à pergunta — `qbank order` é onde se encontra o lugar.

## Duas coisas que apareceram a construir

- **Um bug meu.** A confirmação das alterações críticas ignorava o `--yes`, por isso `content:edit cat3#86 --disable "motivo" --yes` — o exemplo da minha própria ajuda — era cancelado em silêncio. Passa a respeitar o `--yes` como todas as outras; a segurança está em a alteração ser dita antes de acontecer, não em prender alguém a uma pergunta.
- **`--disable ""` tinha de ser erro.** O schema converte texto opcional vazio em `null`, por isso um motivo em branco **publicaria** a pergunta em vez de a retirar — o contrário do pedido, comunicado como sucesso.

## Partilhado, não duplicado

O `scripts/content-io.ts` passa a ser a metade de I/O dos dois scripts: leitura, resolução de imagens, as perguntas de cada campo e um único caminho de escrita — que também varre a nota gerada quando a explicação é apagada ou a pergunta desativada. O `content:new` foi religado a ele e produz exatamente o mesmo de antes (verificado contra o `--dry-run` anterior).

## Primeira utilização real

Corrige a cat3#86, que estava no ar a dizer **"Qua a validade das licenças de amador de uso comum?"** — a gralha que nenhuma verificação por comparação podia ver, porque o `dupes` só encontra gralhas em perguntas que tenham um par próximo (301 das 1018).

## Documentação

`docs/editar-conteudo.md`, em pt-PT: porque existe, o que faz e o que não faz, cada modo, as filas de trabalho, a tabela de opções, os erros comuns e o mapa do código. Ligado a partir do `novas-questoes.md` e do `CLAUDE.md`.

Acrescentado também ao `bun run banco`: **"Alterar uma pergunta"** e **"Escrever explicações em falta"**, que percorre a lacuna das 260 a partir do menu português.

## Estado

`lint`, `type-check`, 374 testes (13 novos sobre o `editing`, o `diffQuestions` e o motivo em branco), `content:check` e `next build` passam.