### PR TITLE
Melhorar o fim do exame

### DIFF
--- a/__tests__/integration/test-exam-review-explanation.test.tsx
+++ b/__tests__/integration/test-exam-review-explanation.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { ExamResults } from "@/components/ExamResults";
+
+/**
+ * The exam review is the last thing a candidate sees, and it is where they
+ * find out *why* they got something wrong. These cover the wiring that makes
+ * that possible: the bank id reaching the panel, and the fetch happening only
+ * for the question actually being read.
+ */
+
+const answers = [
+  {
+    index: 0,
+    questionId: 109,
+    question: "Qual a sequência de símbolos usados em telegrafia para sinal de perigo?",
+    options: ["...---...", "---...---"],
+    selectedIndex: 1,
+    correctIndex: 0,
+    status: "incorrect" as const,
+    hasNotesMdx: true,
+    notes: null,
+  },
+  {
+    index: 1,
+    questionId: 163,
+    question: "Qual a expressão usada em fonia para sinal de perigo?",
+    options: ["HELP", "MAYDAY"],
+    selectedIndex: 1,
+    correctIndex: 1,
+    status: "correct" as const,
+    hasNotesMdx: true,
+    notes: null,
+  },
+];
+
+function renderResults() {
+  return render(
+    <ExamResults
+      category="3"
+      score={1}
+      totalQuestions={2}
+      timeLeft={600}
+      reviewAnswers={answers}
+      onStartNew={() => {}}
+    />
+  );
+}
+
+describe("Integration: explanations in the exam review", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockImplementation((url: string) => Promise.resolve({
+      ok: true,
+      status: 200,
+      json: async () => ({ html: `<p>Explicação de ${url}</p>` }),
+    }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches nothing until a question is opened", () => {
+    renderResults();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("shows the explanation for the question being reviewed", async () => {
+    renderResults();
+
+    fireEvent.click(screen.getByText(/telegrafia para sinal de perigo/));
+
+    await waitFor(() =>
+      expect(screen.getByText("Explicação de /api/notes/3/109")).toBeInTheDocument()
+    );
+  });
+
+  it("asks for the note of the opened question only", async () => {
+    renderResults();
+
+    fireEvent.click(screen.getByText(/telegrafia para sinal de perigo/));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledWith("/api/notes/3/109");
+    expect(fetchMock).not.toHaveBeenCalledWith("/api/notes/3/163");
+  });
+
+  it("explains a correct answer too, not only a mistake", async () => {
+    renderResults();
+
+    fireEvent.click(screen.getByText(/fonia para sinal de perigo/));
+
+    await waitFor(() =>
+      expect(screen.getByText("Explicação de /api/notes/3/163")).toBeInTheDocument()
+    );
+  });
+});

--- a/__tests__/unit/test-QuestionExplanation.test.tsx
+++ b/__tests__/unit/test-QuestionExplanation.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QuestionExplanation } from "@/components/QuestionExplanation";
+
+function mockFetchOnce(body: unknown, ok = true) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 404,
+    json: async () => body,
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+describe("Unit: QuestionExplanation", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches the note for the question and renders it", async () => {
+    const fetchMock = mockFetchOnce({ html: "<p>Porque sim.</p>" });
+
+    render(<QuestionExplanation categoryId="3" questionId={109} hasNotesMdx />);
+
+    await waitFor(() => expect(screen.getByText("Porque sim.")).toBeInTheDocument());
+    expect(fetchMock).toHaveBeenCalledWith("/api/notes/3/109");
+  });
+
+  it("does not fetch when the question has no note file", () => {
+    const fetchMock = mockFetchOnce({ html: "<p>nunca</p>" });
+
+    render(<QuestionExplanation categoryId="3" questionId={109} hasNotesMdx={false} />);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch without a category, since the note cannot be addressed", () => {
+    const fetchMock = mockFetchOnce({ html: "<p>nunca</p>" });
+
+    render(<QuestionExplanation categoryId={undefined} questionId={109} hasNotesMdx />);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing at all when there is no explanation to show", () => {
+    mockFetchOnce({ html: "" });
+
+    const { container } = render(
+      <QuestionExplanation categoryId="3" questionId={109} hasNotesMdx={false} inlineNotes={null} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("falls back to the inline explanation when there is no note file", () => {
+    mockFetchOnce({ html: "" });
+
+    render(
+      <QuestionExplanation
+        categoryId="3"
+        questionId={109}
+        hasNotesMdx={false}
+        inlineNotes="<p>Explicação embutida.</p>"
+      />
+    );
+
+    expect(screen.getByText("Explicação embutida.")).toBeInTheDocument();
+  });
+
+  it("prefers the fetched note over the inline one", async () => {
+    mockFetchOnce({ html: "<p>Do ficheiro.</p>" });
+
+    render(
+      <QuestionExplanation
+        categoryId="3"
+        questionId={109}
+        hasNotesMdx
+        inlineNotes="<p>Embutida.</p>"
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText("Do ficheiro.")).toBeInTheDocument());
+    expect(screen.queryByText("Embutida.")).not.toBeInTheDocument();
+  });
+
+  it("reports a failed fetch instead of showing an empty explanation", async () => {
+    mockFetchOnce({}, false);
+
+    render(<QuestionExplanation categoryId="3" questionId={109} hasNotesMdx />);
+
+    await waitFor(() => expect(screen.getByText("notesError")).toBeInTheDocument());
+  });
+
+  it("strips scripts out of the note before rendering it", async () => {
+    mockFetchOnce({ html: '<p>Seguro.</p><script>window.__x = 1;</script>' });
+
+    const { container } = render(<QuestionExplanation categoryId="3" questionId={109} hasNotesMdx />);
+
+    await waitFor(() => expect(screen.getByText("Seguro.")).toBeInTheDocument());
+    expect(container.querySelector("script")).toBeNull();
+  });
+
+  it("shows the heading it is given, and only alongside content", async () => {
+    mockFetchOnce({ html: "<p>Corpo.</p>" });
+
+    render(
+      <QuestionExplanation
+        categoryId="3"
+        questionId={109}
+        hasNotesMdx
+        heading={<p>Explicação</p>}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText("Explicação")).toBeInTheDocument());
+  });
+});

--- a/__tests__/unit/test-messages-parity.test.ts
+++ b/__tests__/unit/test-messages-parity.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import en from "@/messages/en.json";
+import pt from "@/messages/pt.json";
+
+/**
+ * A key added to one locale and forgotten in the other fails silently: the
+ * visitor gets the raw key back where the sentence should be, and only in the
+ * language nobody testing the change happens to be using.
+ */
+function keyPaths(value: unknown, prefix = ""): string[] {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return [];
+  return Object.entries(value as Record<string, unknown>).flatMap(([key, child]) => {
+    const path = prefix ? `${prefix}.${key}` : key;
+    return [path, ...keyPaths(child, path)];
+  });
+}
+
+describe("Unit: message catalogues", () => {
+  const enKeys = keyPaths(en);
+  const ptKeys = keyPaths(pt);
+
+  it("defines every English key in Portuguese", () => {
+    expect([...enKeys].filter((k) => !ptKeys.includes(k))).toEqual([]);
+  });
+
+  it("defines every Portuguese key in English", () => {
+    expect([...ptKeys].filter((k) => !enKeys.includes(k))).toEqual([]);
+  });
+
+  it("leaves no message empty", () => {
+    const empty = (obj: unknown, prefix = ""): string[] => {
+      if (typeof obj === "string") return obj.trim().length === 0 ? [prefix] : [];
+      if (obj === null || typeof obj !== "object") return [];
+      return Object.entries(obj as Record<string, unknown>).flatMap(([k, v]) =>
+        empty(v, prefix ? `${prefix}.${k}` : k)
+      );
+    };
+    expect(empty(pt)).toEqual([]);
+    expect(empty(en)).toEqual([]);
+  });
+});

--- a/__tests__/unit/test-shuffle-options.test.ts
+++ b/__tests__/unit/test-shuffle-options.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import {
+  shuffleQuestionOptions,
+  shuffleAllOptions,
+  toCanonicalAnswers,
+} from "@/lib/exam/shuffle-options";
+
+const q = (id: number, options: string[], correctIndex: number) => ({ id, options, correctIndex });
+
+/** A deterministic stand-in for Math.random, so a shuffle can be asserted exactly. */
+function scriptedRng(values: number[]): () => number {
+  let i = 0;
+  return () => values[i++ % values.length] ?? 0;
+}
+
+describe("Unit: shuffleQuestionOptions", () => {
+  it("keeps the correct answer pointing at the same text", () => {
+    const original = q(1, ["A", "B", "C", "D"], 2);
+
+    for (let run = 0; run < 50; run++) {
+      const { question } = shuffleQuestionOptions(original);
+      expect(question.options[question.correctIndex]).toBe("C");
+    }
+  });
+
+  it("keeps every option, exactly once", () => {
+    const { question } = shuffleQuestionOptions(q(1, ["A", "B", "C", "D"], 0));
+
+    expect([...question.options].sort()).toEqual(["A", "B", "C", "D"]);
+  });
+
+  it("does not mutate the question it was given", () => {
+    const original = q(1, ["A", "B", "C", "D"], 0);
+    shuffleQuestionOptions(original);
+
+    expect(original.options).toEqual(["A", "B", "C", "D"]);
+    expect(original.correctIndex).toBe(0);
+  });
+
+  it("returns a permutation that reads the shuffled order back to the original", () => {
+    const original = q(1, ["A", "B", "C", "D"], 1);
+    const { question, permutation } = shuffleQuestionOptions(original);
+
+    question.options.forEach((text, position) => {
+      expect(original.options[permutation[position]!]).toBe(text);
+    });
+  });
+
+  it("actually moves the answer around, given a real spread of draws", () => {
+    const positions = new Set<number>();
+    for (let run = 0; run < 200; run++) {
+      positions.add(shuffleQuestionOptions(q(1, ["A", "B", "C", "D"], 0)).question.correctIndex);
+    }
+
+    expect(positions.size).toBeGreaterThan(1);
+  });
+
+  it("handles a question with a single option", () => {
+    const { question } = shuffleQuestionOptions(q(1, ["A"], 0));
+
+    expect(question.options).toEqual(["A"]);
+    expect(question.correctIndex).toBe(0);
+  });
+
+  it("is deterministic for a given sequence of draws", () => {
+    const draws = [0.9, 0.1, 0.5, 0.3];
+    const a = shuffleQuestionOptions(q(1, ["A", "B", "C", "D"], 0), scriptedRng(draws));
+    const b = shuffleQuestionOptions(q(1, ["A", "B", "C", "D"], 0), scriptedRng(draws));
+
+    expect(a.question.options).toEqual(b.question.options);
+    expect(a.question.correctIndex).toBe(b.question.correctIndex);
+  });
+});
+
+describe("Unit: shuffleAllOptions", () => {
+  it("shuffles each question and keys the permutations by id", () => {
+    const { questions, permutations } = shuffleAllOptions([
+      q(7, ["A", "B"], 0),
+      q(9, ["C", "D"], 1),
+    ]);
+
+    expect(questions).toHaveLength(2);
+    expect(Object.keys(permutations).sort()).toEqual(["7", "9"]);
+    expect(questions[0]!.options[questions[0]!.correctIndex]).toBe("A");
+    expect(questions[1]!.options[questions[1]!.correctIndex]).toBe("D");
+  });
+});
+
+describe("Unit: toCanonicalAnswers", () => {
+  it("translates a shuffled answer back to the bank's own order", () => {
+    // Shuffled order is [C, A, D, B]; the candidate picked position 0, i.e. C.
+    const permutations = { 1: [2, 0, 3, 1] };
+
+    expect(toCanonicalAnswers({ 1: 0 }, permutations)).toEqual({ 1: 2 });
+    expect(toCanonicalAnswers({ 1: 3 }, permutations)).toEqual({ 1: 1 });
+  });
+
+  it("passes an unshuffled question through untouched", () => {
+    expect(toCanonicalAnswers({ 5: 2 }, {})).toEqual({ 5: 2 });
+  });
+
+  it("round-trips: what was recorded points at the text that was chosen", () => {
+    const original = q(1, ["A", "B", "C", "D"], 3);
+    const { question, permutation } = shuffleQuestionOptions(original);
+
+    for (let chosen = 0; chosen < 4; chosen++) {
+      const canonical = toCanonicalAnswers({ 1: chosen }, { 1: permutation })[1]!;
+      expect(original.options[canonical]).toBe(question.options[chosen]);
+    }
+  });
+
+  it("marks the same attempt correct before and after translation", () => {
+    const original = q(1, ["A", "B", "C", "D"], 2);
+    const { question, permutation } = shuffleQuestionOptions(original);
+
+    const chosen = question.correctIndex;
+    const canonical = toCanonicalAnswers({ 1: chosen }, { 1: permutation })[1]!;
+
+    expect(canonical).toBe(original.correctIndex);
+  });
+
+  it("leaves an out-of-range answer alone rather than inventing one", () => {
+    expect(toCanonicalAnswers({ 1: 9 }, { 1: [1, 0] })).toEqual({ 1: 9 });
+  });
+});

--- a/__tests__/unit/test-topic-icon.test.tsx
+++ b/__tests__/unit/test-topic-icon.test.tsx
@@ -1,16 +1,33 @@
 import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
-import { TopicIcon, TOPIC_ICONS } from "@/components/TopicIcon";
+import { TopicIcon, TOPIC_STYLES, topicTileClass } from "@/components/TopicIcon";
 import { TOPIC_SLUGS } from "@/lib/config";
 
 describe("Unit: TopicIcon", () => {
-  it("has an icon for every topic in the taxonomy", () => {
-    expect(Object.keys(TOPIC_ICONS).sort()).toEqual([...TOPIC_SLUGS].sort());
+  it("has a style for every topic in the taxonomy", () => {
+    expect(Object.keys(TOPIC_STYLES).sort()).toEqual([...TOPIC_SLUGS].sort());
   });
 
   it("gives each topic its own icon, so they stay distinguishable", () => {
-    const icons = Object.values(TOPIC_ICONS);
+    const icons = Object.values(TOPIC_STYLES).map((s) => s.icon);
     expect(new Set(icons).size).toBe(icons.length);
+  });
+
+  it("gives each topic its own colour too", () => {
+    const colours = Object.values(TOPIC_STYLES).map((s) => s.fg);
+    expect(new Set(colours).size).toBe(colours.length);
+  });
+
+  it("defines both themes for every colour, so neither renders unreadable", () => {
+    for (const [slug, style] of Object.entries(TOPIC_STYLES)) {
+      expect(style.fg, slug).toMatch(/dark:/);
+      expect(style.tile, slug).toMatch(/dark:/);
+    }
+  });
+
+  it("has no tile for a slug outside the taxonomy, so the caller can fall back", () => {
+    expect(topicTileClass("entidades")).toBe("");
+    expect(topicTileClass("antenas")).not.toBe("");
   });
 
   it("renders an icon for a real slug", () => {

--- a/__tests__/unit/test-topic-icon.test.tsx
+++ b/__tests__/unit/test-topic-icon.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { TopicIcon, TOPIC_ICONS } from "@/components/TopicIcon";
+import { TOPIC_SLUGS } from "@/lib/config";
+
+describe("Unit: TopicIcon", () => {
+  it("has an icon for every topic in the taxonomy", () => {
+    expect(Object.keys(TOPIC_ICONS).sort()).toEqual([...TOPIC_SLUGS].sort());
+  });
+
+  it("gives each topic its own icon, so they stay distinguishable", () => {
+    const icons = Object.values(TOPIC_ICONS);
+    expect(new Set(icons).size).toBe(icons.length);
+  });
+
+  it("renders an icon for a real slug", () => {
+    const { container } = render(<TopicIcon slug="antenas" />);
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("renders nothing for a slug outside the taxonomy", () => {
+    // `topic` is free text in the schema, so a typo reaches the UI.
+    const { container } = render(<TopicIcon slug="entidades" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("is hidden from assistive tech, since the label is always beside it", () => {
+    const { container } = render(<TopicIcon slug="teoria" />);
+    expect(container.querySelector("svg")?.getAttribute("aria-hidden")).toBe("true");
+  });
+});

--- a/__tests__/unit/test-weak-topics.test.ts
+++ b/__tests__/unit/test-weak-topics.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { weakTopics } from "@/lib/exam/weak-topics";
+
+type Status = "correct" | "incorrect" | "unanswered";
+const a = (materia: string | null, status: Status) => ({ materia, status });
+
+describe("Unit: weakTopics", () => {
+  it("counts wrong and unanswered alike, since neither is knowledge", () => {
+    const [topic] = weakTopics([
+      a("teoria", "correct"),
+      a("teoria", "incorrect"),
+      a("teoria", "unanswered"),
+    ]);
+
+    expect(topic).toMatchObject({ slug: "teoria", total: 3, missed: 2 });
+    expect(topic?.accuracy).toBeCloseTo(1 / 3);
+  });
+
+  it("leaves out a topic answered perfectly", () => {
+    const topics = weakTopics([
+      a("teoria", "correct"),
+      a("antenas", "incorrect"),
+    ]);
+
+    expect(topics.map((t) => t.slug)).toEqual(["antenas"]);
+  });
+
+  it("returns nothing at all for a flawless attempt", () => {
+    expect(weakTopics([a("teoria", "correct"), a("antenas", "correct")])).toEqual([]);
+  });
+
+  it("ranks by how many were missed, not by the rate", () => {
+    const topics = weakTopics([
+      // one out of one wrong: a perfect failure rate, but a small hole
+      a("antenas", "incorrect"),
+      // four out of ten wrong: a better rate, but the bigger problem
+      ...Array.from({ length: 4 }, () => a("teoria", "incorrect")),
+      ...Array.from({ length: 6 }, () => a("teoria", "correct")),
+    ]);
+
+    expect(topics.map((t) => t.slug)).toEqual(["teoria", "antenas"]);
+  });
+
+  it("breaks a tie on misses with the worse rate", () => {
+    const topics = weakTopics([
+      a("antenas", "incorrect"),
+      a("antenas", "correct"),
+      a("antenas", "correct"),
+      a("teoria", "incorrect"),
+      a("teoria", "correct"),
+    ]);
+
+    // Both missed one; teoria got half right, antenas two thirds.
+    expect(topics.map((t) => t.slug)).toEqual(["teoria", "antenas"]);
+  });
+
+  it("ignores questions with no topic rather than inventing one", () => {
+    const topics = weakTopics([a(null, "incorrect"), a("teoria", "incorrect")]);
+
+    expect(topics.map((t) => t.slug)).toEqual(["teoria"]);
+  });
+
+  it("caps the list so the advice stays actionable", () => {
+    const topics = weakTopics(
+      ["a", "b", "c", "d", "e", "f"].map((slug) => a(slug, "incorrect")),
+      3
+    );
+
+    expect(topics).toHaveLength(3);
+  });
+
+  it("handles an empty attempt", () => {
+    expect(weakTopics([])).toEqual([]);
+  });
+});

--- a/app/exam/[category]/page.tsx
+++ b/app/exam/[category]/page.tsx
@@ -298,6 +298,7 @@ export default function ExamPage() {
       status: status as 'correct' | 'incorrect' | 'unanswered',
       hasNotesMdx: q.hasNotesMdx,
       notes: q.notes,
+      materia: q.materia,
     };
   });
 

--- a/app/exam/[category]/page.tsx
+++ b/app/exam/[category]/page.tsx
@@ -11,6 +11,7 @@ import { PageLoading } from '@/components/shared/Loading';
 import { AnswerOption, type AnswerOptionState } from '@/components/ui/answer-option';
 import { Button } from '@/components/ui/button';
 import { StudyHeader } from '@/components/StudyHeader';
+import { QuestionExplanation } from '@/components/QuestionExplanation';
 import { useProgressContext } from '@/components/providers/ProgressProvider';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import type { ExamAttempt, QuestionAttempt } from '@/lib/types/progress';
@@ -22,6 +23,8 @@ export default function ExamPage() {
   const params = useParams();
   const searchParams = useSearchParams();
   const t = useTranslations('Exam');
+  // The explanation reuses the question card's label — same thing, same word.
+  const tq = useTranslations('QuestionCard');
   const { recordExamWithGamification, recordQuestionBatch, gamification } = useProgressContext();
   const [timeLeft, setTimeLeft] = useState<number>(DURATION_SECONDS);
   // Wall-clock deadline (epoch ms) the countdown runs toward; null when no exam
@@ -307,7 +310,14 @@ export default function ExamPage() {
           mode="exam"
           backHref="/"
           subtitle={t('resultsSubtitle')}
-        />
+        >
+          {/* The two post-exam views are complementary, not a sequence: the
+              cards below summarise, the question pages show each answer in
+              place. Without this, results was a one-way door. */}
+          <Button size="sm" variant="outline" onClick={() => setResultsOpen(false)}>
+            {t('viewQuestions')}
+          </Button>
+        </StudyHeader>
         <ExamResults
           category={category.id}
           score={score}
@@ -408,6 +418,21 @@ export default function ExamPage() {
                   </div>
                 )}
               </div>
+
+              {/* `selected !== correctIndex` is both cases at once: answered
+                  wrongly, and not answered at all. A question already answered
+                  correctly needs no explanation here — it is one tap away in
+                  the results review if the candidate wants it anyway. */}
+              {quizEnded && selected !== q.correctIndex && (
+                <QuestionExplanation
+                  categoryId={category.id}
+                  questionId={q.id}
+                  hasNotesMdx={q.hasNotesMdx}
+                  inlineNotes={q.notes}
+                  className="mt-4 pt-4 border-t border-slate-200 dark:border-slate-700 text-sm"
+                  heading={<p className="mb-2 font-semibold text-slate-700 dark:text-slate-300">{tq('explanation')}</p>}
+                />
+              )}
             </div>
           );
         })}

--- a/app/exam/[category]/page.tsx
+++ b/app/exam/[category]/page.tsx
@@ -5,12 +5,21 @@ import { useTranslations } from 'next-intl';
 import { Category } from '@/lib/types';
 import { loadData } from '@/lib/data';
 import { decodeReplayIds, decodeReplayAnswers } from '@/lib/exam/replay';
+import {
+  shuffleAllOptions,
+  toCanonicalAnswers,
+  readShuffleOptionsPreference,
+  writeShuffleOptionsPreference,
+  type OptionPermutation,
+} from '@/lib/exam/shuffle-options';
 import { EXAM_CONFIG, DEFAULT_CATEGORY } from '@/lib/config';
 import { ExamResults } from '@/components/ExamResults';
 import { PageLoading } from '@/components/shared/Loading';
 import { AnswerOption, type AnswerOptionState } from '@/components/ui/answer-option';
 import { Button } from '@/components/ui/button';
 import { StudyHeader } from '@/components/StudyHeader';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
+import { Shuffle } from 'lucide-react';
 import { QuestionExplanation } from '@/components/QuestionExplanation';
 import { useProgressContext } from '@/components/providers/ProgressProvider';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
@@ -36,9 +45,23 @@ export default function ExamPage() {
   const [quizEnded, setQuizEnded] = useState(false);
   const [resultsOpen, setResultsOpen] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
+  // Off on the server and on the first client render, then reconciled from
+  // storage in an effect: reading localStorage while rendering would make the
+  // markup differ between the two and trip hydration.
+  const [shuffleOptions, setShuffleOptions] = useState(false);
+  const [pendingShuffle, setPendingShuffle] = useState<boolean | null>(null);
+  /** Shuffled position -> bank position, per question id. Empty when off. */
+  const [permutations, setPermutations] = useState<Record<number, OptionPermutation>>({});
+  const shuffleRef = useRef(false);
   const progressSavedRef = useRef(false);
   const isReplayRef = useRef(false);
   const [gamificationResult, setGamificationResult] = useState<GamificationResult | null>(null);
+
+  React.useEffect(() => {
+    const stored = readShuffleOptionsPreference();
+    setShuffleOptions(stored);
+    shuffleRef.current = stored;
+  }, []);
 
   // Timer: wall-clock countdown toward a fixed deadline. Deriving the remaining
   // time from Date.now() on each tick — rather than decrementing a per-tick
@@ -144,7 +167,9 @@ export default function ExamPage() {
       passed,
       timestamp: Date.now(),
       questionIds: category.questions.map(q => q.id),
-      answers: { ...answers },
+      // Recorded in the bank's order, never the shuffled one, so replay links
+      // and per-question stats stay meaningful.
+      answers: toCanonicalAnswers(answers, permutations),
     };
 
     // Record individual question attempts
@@ -166,7 +191,7 @@ export default function ExamPage() {
         recordQuestionBatch(questionAttempts);
       }
     });
-  }, [quizEnded, category, answers, score, timeLeft, recordExamWithGamification, recordQuestionBatch]);
+  }, [quizEnded, category, answers, score, timeLeft, permutations, recordExamWithGamification, recordQuestionBatch]);
 
   React.useEffect(() => {
     const cat = typeof params.category === 'string'
@@ -221,10 +246,27 @@ export default function ExamPage() {
         }
       }
       const sample = qs.slice(0, Math.min(MAX_QUESTIONS, qs.length));
-      setCategory({ id: base.id, name: base.name, questions: sample });
+      // A replay above returns early: its answers are positional against the
+      // bank's order, so shuffling one would misreport what was chosen.
+      const dealt = shuffleRef.current ? shuffleAllOptions(sample) : { questions: sample, permutations: {} };
+      setPermutations(dealt.permutations);
+      setCategory({ id: base.id, name: base.name, questions: dealt.questions });
       setDeadline(Date.now() + DURATION_SECONDS * 1000);
     });
   }, [params.category, searchParams]);
+
+  /**
+   * Save the choice and deal a fresh exam with it. The restart is the point:
+   * re-shuffling the questions already on screen would move the options out
+   * from under answers the candidate has given.
+   */
+  const applyShufflePreference = (enabled: boolean) => {
+    writeShuffleOptionsPreference(enabled);
+    setShuffleOptions(enabled);
+    shuffleRef.current = enabled;
+    setPendingShuffle(null);
+    startNewQuiz();
+  };
 
   const startNewQuiz = () => {
     if (!category) return;
@@ -245,7 +287,9 @@ export default function ExamPage() {
         }
       }
       const sample = qs.slice(0, Math.min(MAX_QUESTIONS, qs.length));
-      setCategory({ id: base.id, name: base.name, questions: sample });
+      const dealt = shuffleRef.current ? shuffleAllOptions(sample) : { questions: sample, permutations: {} };
+      setPermutations(dealt.permutations);
+      setCategory({ id: base.id, name: base.name, questions: dealt.questions });
       setAnswers({});
       setScore(0);
       setTimeLeft(DURATION_SECONDS);
@@ -342,6 +386,22 @@ export default function ExamPage() {
         backHref="/"
         subtitle={`${answeredCount}/${category.questions.length}`}
       >
+        {/* Only on the first page, and only while the exam is live: turning
+            this on deals a new exam, which is not something to offer beside a
+            question already answered. */}
+        {!quizEnded && currentPage === 1 && (
+          <label className="flex items-center gap-1.5 text-xs text-slate-600 dark:text-slate-300 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={shuffleOptions}
+              onChange={() => setPendingShuffle(!shuffleOptions)}
+              className="w-4 h-4 rounded border-slate-300 dark:border-slate-600 accent-amber-500 cursor-pointer"
+            />
+            <Shuffle className="w-3.5 h-3.5" aria-hidden="true" />
+            <span className="hidden sm:inline">{t('shuffle.label')}</span>
+          </label>
+        )}
+
         {/* Timer */}
         <div className={`font-mono text-sm px-2.5 py-1 rounded-md font-semibold tabular-nums ${
           timeLeft <= 60
@@ -466,6 +526,25 @@ export default function ExamPage() {
 
       {/* Spacer for fixed bottom nav on mobile */}
       <div className="h-16 sm:hidden" />
+
+      <Dialog open={pendingShuffle !== null} onOpenChange={(open) => { if (!open) setPendingShuffle(null); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {pendingShuffle ? t('shuffle.confirmTitleOn') : t('shuffle.confirmTitleOff')}
+            </DialogTitle>
+            <DialogDescription>{t('shuffle.confirmBody')}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" size="sm" onClick={() => setPendingShuffle(null)}>
+              {t('shuffle.cancel')}
+            </Button>
+            <Button size="sm" onClick={() => applyShufflePreference(pendingShuffle === true)}>
+              {t('shuffle.restart')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </main>
   );
 }

--- a/app/exam/[category]/page.tsx
+++ b/app/exam/[category]/page.tsx
@@ -287,11 +287,14 @@ export default function ExamPage() {
     const status = sel === undefined ? 'unanswered' : sel === q.correctIndex ? 'correct' : 'incorrect';
     return {
       index: idx,
+      questionId: q.id,
       question: q.question,
       options: q.options,
       selectedIndex: sel,
       correctIndex: q.correctIndex,
       status: status as 'correct' | 'incorrect' | 'unanswered',
+      hasNotesMdx: q.hasNotesMdx,
+      notes: q.notes,
     };
   });
 

--- a/components/ExamResults.tsx
+++ b/components/ExamResults.tsx
@@ -9,16 +9,21 @@ import { cn } from '@/lib/utils';
 import type { GamificationResult } from '@/lib/types/gamification';
 import { ShareButton } from './ShareButton';
 import { createExamResultShare } from '@/lib/share';
+import { QuestionExplanation } from './QuestionExplanation';
 
 type AnswerStatus = 'correct' | 'incorrect' | 'unanswered';
 
 interface ReviewAnswer {
   index: number;
+  /** The bank id, which is what `/api/notes` is addressed by. */
+  questionId: number;
   question: string;
   options: string[];
   selectedIndex: number | undefined;
   correctIndex: number;
   status: AnswerStatus;
+  hasNotesMdx?: boolean;
+  notes?: string | null;
 }
 
 export interface ExamResultsProps {
@@ -86,6 +91,9 @@ export function ExamResults({
   gamificationEnabled = false,
 }: ExamResultsProps) {
   const t = useTranslations('ExamResults');
+  // The explanation reuses the question card's copy — it is the same label
+  // answering the same question, and two spellings of it would drift.
+  const tq = useTranslations('QuestionCard');
   const tGamification = useTranslations('Gamification');
   const passed = score >= passingScore;
   const isPerfect = score === totalQuestions;
@@ -411,6 +419,16 @@ export function ExamResults({
                       );
                     })}
                   </div>
+                  {/* Mounted with the open panel, so only the question being
+                      reviewed fetches its explanation, not all forty. */}
+                  <QuestionExplanation
+                    categoryId={category}
+                    questionId={item.questionId}
+                    hasNotesMdx={item.hasNotesMdx}
+                    inlineNotes={item.notes}
+                    className="mt-3 pt-3 border-t border-border/60 text-sm"
+                    heading={<p className="mb-2 font-semibold text-foreground">{tq('explanation')}</p>}
+                  />
                 </AccordionContent>
               </AccordionItem>
             ))}

--- a/components/ExamResults.tsx
+++ b/components/ExamResults.tsx
@@ -10,6 +10,10 @@ import type { GamificationResult } from '@/lib/types/gamification';
 import { ShareButton } from './ShareButton';
 import { createExamResultShare } from '@/lib/share';
 import { QuestionExplanation } from './QuestionExplanation';
+import Link from 'next/link';
+import { useLocale } from 'next-intl';
+import { topicShortLabel } from '@/lib/config';
+import { weakTopics } from '@/lib/exam/weak-topics';
 
 type AnswerStatus = 'correct' | 'incorrect' | 'unanswered';
 
@@ -24,6 +28,8 @@ interface ReviewAnswer {
   status: AnswerStatus;
   hasNotesMdx?: boolean;
   notes?: string | null;
+  /** The shipped name for the source's `topic`; drives the study advice. */
+  materia?: string | null;
 }
 
 export interface ExamResultsProps {
@@ -95,6 +101,7 @@ export function ExamResults({
   // answering the same question, and two spellings of it would drift.
   const tq = useTranslations('QuestionCard');
   const tGamification = useTranslations('Gamification');
+  const locale = useLocale();
   const passed = score >= passingScore;
   const isPerfect = score === totalQuestions;
   const [filter, setFilter] = useState<'all' | AnswerStatus>('all');
@@ -151,6 +158,8 @@ export function ExamResults({
     incorrect: reviewAnswers.filter(a => a.status === 'incorrect').length,
     unanswered: reviewAnswers.filter(a => a.status === 'unanswered').length,
   }), [reviewAnswers]);
+
+  const studyAreas = useMemo(() => weakTopics(reviewAnswers), [reviewAnswers]);
 
   const filteredAnswers = useMemo(() =>
     filter === 'all' ? reviewAnswers : reviewAnswers.filter(a => a.status === filter),
@@ -307,6 +316,47 @@ export function ExamResults({
         </Button>
         <ShareButton content={shareContent} iconOnly />
       </div>
+
+      {/* What to study next. Absent after a flawless attempt: there is nothing
+          to advise, and an empty panel would read as a broken one. */}
+      {studyAreas.length > 0 && (
+        <section className="mx-4 sm:mx-0 mt-8">
+          <h2 className="text-lg font-semibold text-foreground mb-1">{t('studyAreas.title')}</h2>
+          <p className="text-sm text-muted-foreground mb-4">{t('studyAreas.subtitle')}</p>
+          <ul className="space-y-2">
+            {studyAreas.map((topic) => {
+              const label = topicShortLabel(topic.slug, locale) ?? topic.slug;
+              const missedShare = Math.round((topic.missed / topic.total) * 100);
+              return (
+                <li key={topic.slug}>
+                  <Link
+                    href={`/browse/${category}?topic=${encodeURIComponent(topic.slug)}`}
+                    className="group flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3 transition-colors hover:border-amber-300 dark:hover:border-amber-700"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-baseline justify-between gap-3">
+                        <span className="font-medium text-foreground truncate">{label}</span>
+                        <span className="text-xs text-muted-foreground tabular-nums whitespace-nowrap">
+                          {t('studyAreas.missed', { missed: topic.missed, total: topic.total })}
+                        </span>
+                      </div>
+                      <div className="mt-2 h-1.5 rounded-full bg-muted overflow-hidden">
+                        <div
+                          className="h-full rounded-full bg-amber-500 dark:bg-amber-400"
+                          style={{ width: `${missedShare}%` }}
+                        />
+                      </div>
+                    </div>
+                    <span className="text-xs font-medium text-muted-foreground group-hover:text-foreground whitespace-nowrap">
+                      {t('studyAreas.practice')}
+                    </span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
 
       {/* Review Section */}
       <section className="mx-4 sm:mx-0 mt-8">

--- a/components/ExamResults.tsx
+++ b/components/ExamResults.tsx
@@ -14,6 +14,7 @@ import Link from 'next/link';
 import { useLocale } from 'next-intl';
 import { topicShortLabel } from '@/lib/config';
 import { weakTopics } from '@/lib/exam/weak-topics';
+import { TopicIcon } from './TopicIcon';
 
 type AnswerStatus = 'correct' | 'incorrect' | 'unanswered';
 
@@ -328,29 +329,36 @@ export function ExamResults({
               const label = topicShortLabel(topic.slug, locale) ?? topic.slug;
               const missedShare = Math.round((topic.missed / topic.total) * 100);
               return (
-                <li key={topic.slug}>
-                  <Link
-                    href={`/browse/${category}?topic=${encodeURIComponent(topic.slug)}`}
-                    className="group flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3 transition-colors hover:border-amber-300 dark:hover:border-amber-700"
-                  >
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-baseline justify-between gap-3">
-                        <span className="font-medium text-foreground truncate">{label}</span>
-                        <span className="text-xs text-muted-foreground tabular-nums whitespace-nowrap">
-                          {t('studyAreas.missed', { missed: topic.missed, total: topic.total })}
-                        </span>
-                      </div>
-                      <div className="mt-2 h-1.5 rounded-full bg-muted overflow-hidden">
-                        <div
-                          className="h-full rounded-full bg-amber-500 dark:bg-amber-400"
-                          style={{ width: `${missedShare}%` }}
-                        />
-                      </div>
+                <li
+                  key={topic.slug}
+                  className="flex items-center gap-3 rounded-lg border border-border bg-card px-3 py-3 sm:px-4"
+                >
+                  <span className="shrink-0 grid place-items-center w-9 h-9 rounded-lg bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">
+                    <TopicIcon slug={topic.slug} className="w-[18px] h-[18px]" />
+                  </span>
+
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-baseline justify-between gap-3">
+                      <span className="font-medium text-foreground truncate">{label}</span>
+                      <span className="text-xs text-muted-foreground tabular-nums whitespace-nowrap">
+                        {t('studyAreas.missed', { missed: topic.missed, total: topic.total })}
+                      </span>
                     </div>
-                    <span className="text-xs font-medium text-muted-foreground group-hover:text-foreground whitespace-nowrap">
+                    <div className="mt-2 h-1.5 rounded-full bg-muted overflow-hidden">
+                      <div
+                        className="h-full rounded-full bg-amber-500 dark:bg-amber-400"
+                        style={{ width: `${missedShare}%` }}
+                      />
+                    </div>
+                  </div>
+
+                  {/* The only interactive thing in the row: a link dressed as a
+                      button reads as an action, and keeps one tab stop per topic. */}
+                  <Button asChild size="sm" variant="outline" className="shrink-0">
+                    <Link href={`/browse/${category}?topic=${encodeURIComponent(topic.slug)}`}>
                       {t('studyAreas.practice')}
-                    </span>
-                  </Link>
+                    </Link>
+                  </Button>
                 </li>
               );
             })}

--- a/components/ExamResults.tsx
+++ b/components/ExamResults.tsx
@@ -14,7 +14,7 @@ import Link from 'next/link';
 import { useLocale } from 'next-intl';
 import { topicShortLabel } from '@/lib/config';
 import { weakTopics } from '@/lib/exam/weak-topics';
-import { TopicIcon } from './TopicIcon';
+import { TopicIcon, topicTileClass } from './TopicIcon';
 
 type AnswerStatus = 'correct' | 'incorrect' | 'unanswered';
 
@@ -333,7 +333,12 @@ export function ExamResults({
                   key={topic.slug}
                   className="flex items-center gap-3 rounded-lg border border-border bg-card px-3 py-3 sm:px-4"
                 >
-                  <span className="shrink-0 grid place-items-center w-9 h-9 rounded-lg bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">
+                  {/* Colour identifies the topic; the bar below stays amber,
+                      which is what carries "this is the gap". */}
+                  <span className={cn(
+                    "shrink-0 grid place-items-center w-9 h-9 rounded-lg",
+                    topicTileClass(topic.slug) || "bg-muted text-muted-foreground"
+                  )}>
                     <TopicIcon slug={topic.slug} className="w-[18px] h-[18px]" />
                   </span>
 

--- a/components/QuestionCard.tsx
+++ b/components/QuestionCard.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React from 'react';
-import DOMPurify from 'dompurify';
 import { Calculator, ChevronRight, FileText, FileX } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 import { Question, SourceRef } from '@/lib/types';
@@ -12,6 +11,7 @@ import BookmarkButton from '@/components/BookmarkButton';
 import { Highlight } from '@/components/ui/highlight';
 import PdfPageDialog from '@/components/PdfPageDialog';
 import StudyGuideLink from '@/components/StudyGuideLink';
+import { QuestionExplanation } from '@/components/QuestionExplanation';
 import {
   RESOURCE_ROW, RESOURCE_ROW_INERT, RESOURCE_TILE, RESOURCE_TITLE, RESOURCE_SUBTITLE, RESOURCE_CHEVRON,
 } from '@/components/ui/resource-row';
@@ -88,23 +88,6 @@ function buildSourceLink(source: SourceRef, locale: string) {
   };
 }
 
-// The notes arrive as sanitized MDX-rendered HTML, so Tailwind's preflight has
-// already stripped paragraph margins and list markers from it. Restore the
-// rhythm for the tags the notes corpus actually uses: prose, the occasional
-// bullet list, and the formula/diagram images.
-const NOTES_PROSE = [
-  'max-w-[68ch] leading-relaxed',
-  '[&_p]:mb-3 [&_p:last-child]:mb-0',
-  '[&_ul]:my-3 [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:space-y-1',
-  '[&_ol]:my-3 [&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:space-y-1',
-  '[&_img]:my-3 [&_img]:max-w-full [&_img]:h-auto [&_img]:rounded-lg',
-  '[&_img]:border [&_img]:border-slate-200 dark:[&_img]:border-slate-700',
-  // Inline diagrams draw with currentColor, so they follow the theme.
-  '[&_svg]:my-3 [&_svg]:max-w-full [&_svg]:h-auto',
-  '[&_strong]:font-semibold [&_strong]:text-slate-700 dark:[&_strong]:text-slate-300',
-  '[&_a]:text-blue-600 dark:[&_a]:text-blue-400 [&_a]:underline',
-].join(' ');
-
 /** Normalize calc field to array of calculator codes */
 function normalizeCalcCodes(calc: string | string[] | null | undefined): string[] {
   if (!calc) return [];
@@ -135,56 +118,6 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
   const tc = useTranslations('Calculators');
   const locale = useLocale();
   const isAnswered = selectedOption !== undefined;
-  const [remoteNotesHtml, setRemoteNotesHtml] = React.useState<string | null>(null);
-  const [remoteNotesLoading, setRemoteNotesLoading] = React.useState(false);
-  const [remoteNotesError, setRemoteNotesError] = React.useState<string | null>(null);
-
-  // One key for the whole request. It is the only dependency of the fetch
-  // effect on purpose: putting the loading flag in the deps makes the effect
-  // tear itself down the moment it sets it, which cancels its own response.
-  const notesKey = ended && categoryId && question.hasNotesMdx
-    ? `${encodeURIComponent(categoryId)}/${encodeURIComponent(String(question.id))}`
-    : null;
-
-  React.useEffect(() => {
-    setRemoteNotesHtml(null);
-    setRemoteNotesError(null);
-  }, [question.id, categoryId]);
-
-  React.useEffect(() => {
-    if (!notesKey) return;
-
-    let cancelled = false;
-    setRemoteNotesLoading(true);
-    setRemoteNotesError(null);
-    fetch(`/api/notes/${notesKey}`)
-      .then((res) => {
-        if (!res.ok) {
-          throw new Error(`Failed to load notes: ${res.status}`);
-        }
-        return res.json();
-      })
-      .then((data) => {
-        if (cancelled) return;
-        const html = typeof data?.html === 'string' ? data.html : '';
-        setRemoteNotesHtml(html.length > 0 ? html : null);
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        console.error(err);
-        setRemoteNotesError('Unable to load notes.');
-      })
-      .finally(() => {
-        if (cancelled) return;
-        setRemoteNotesLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [notesKey]);
-
-  const resolvedNotes = remoteNotesHtml ?? question.notes ?? null;
   // `materia` is the shipped name for the source's `topic` field.
   const topicLabel = question.materia ? topicShortLabel(question.materia, locale) : null;
   const showsDifficulty =
@@ -313,24 +246,13 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
 
       {ended && (
         <div className="mt-5 border-t border-slate-200 dark:border-slate-700 pt-4 space-y-4 text-sm">
-          {(remoteNotesLoading || remoteNotesError || resolvedNotes) && (
-            <div className="text-slate-600 dark:text-slate-400">
-              <p className="mb-2 font-semibold text-slate-700 dark:text-slate-300">{t('explanation')}</p>
-              {remoteNotesLoading && (
-                <div className="max-w-[68ch] space-y-2" aria-hidden="true">
-                  <div className="h-3 rounded bg-slate-200 dark:bg-slate-700 animate-pulse motion-reduce:animate-none" />
-                  <div className="h-3 rounded bg-slate-200 dark:bg-slate-700 animate-pulse motion-reduce:animate-none" />
-                  <div className="h-3 w-2/3 rounded bg-slate-200 dark:bg-slate-700 animate-pulse motion-reduce:animate-none" />
-                </div>
-              )}
-              {remoteNotesError && !remoteNotesLoading && (
-                <p className="text-red-600 dark:text-red-400">{t('notesError')}</p>
-              )}
-              {!remoteNotesLoading && !remoteNotesError && resolvedNotes && (
-                <div className={NOTES_PROSE} dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(resolvedNotes) }} />
-              )}
-            </div>
-          )}
+          <QuestionExplanation
+            categoryId={categoryId}
+            questionId={question.id}
+            hasNotesMdx={question.hasNotesMdx}
+            inlineNotes={question.notes}
+            heading={<p className="mb-2 font-semibold text-slate-700 dark:text-slate-300">{t('explanation')}</p>}
+          />
           {question.tutorial && (
             <div>
               <p className="mb-2 font-semibold text-slate-700 dark:text-slate-300">{t('studyLibrary')}</p>

--- a/components/QuestionCard.tsx
+++ b/components/QuestionCard.tsx
@@ -193,7 +193,7 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
           {topicLabel ? (
             <span className="min-w-0 flex items-center gap-1.5 truncate text-[10px] font-semibold uppercase tracking-widest text-slate-500 dark:text-slate-400">
               <span className="sr-only">{t('topic')}: </span>
-              <TopicIcon slug={question.materia ?? ''} className="w-3.5 h-3.5 shrink-0" />
+              <TopicIcon slug={question.materia ?? ''} colored className="w-3.5 h-3.5 shrink-0" />
               <span className="truncate">{topicLabel}</span>
             </span>
           ) : (

--- a/components/QuestionCard.tsx
+++ b/components/QuestionCard.tsx
@@ -12,6 +12,7 @@ import { Highlight } from '@/components/ui/highlight';
 import PdfPageDialog from '@/components/PdfPageDialog';
 import StudyGuideLink from '@/components/StudyGuideLink';
 import { QuestionExplanation } from '@/components/QuestionExplanation';
+import { TopicIcon } from '@/components/TopicIcon';
 import {
   RESOURCE_ROW, RESOURCE_ROW_INERT, RESOURCE_TILE, RESOURCE_TITLE, RESOURCE_SUBTITLE, RESOURCE_CHEVRON,
 } from '@/components/ui/resource-row';
@@ -190,9 +191,10 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
       {(topicLabel || showsDifficulty || showsBookmark) && (
         <div className="flex items-center justify-between gap-3 mb-2">
           {topicLabel ? (
-            <span className="min-w-0 truncate text-[10px] font-semibold uppercase tracking-widest text-slate-500 dark:text-slate-400">
+            <span className="min-w-0 flex items-center gap-1.5 truncate text-[10px] font-semibold uppercase tracking-widest text-slate-500 dark:text-slate-400">
               <span className="sr-only">{t('topic')}: </span>
-              {topicLabel}
+              <TopicIcon slug={question.materia ?? ''} className="w-3.5 h-3.5 shrink-0" />
+              <span className="truncate">{topicLabel}</span>
             </span>
           ) : (
             <span aria-hidden="true" />

--- a/components/QuestionExplanation.tsx
+++ b/components/QuestionExplanation.tsx
@@ -1,0 +1,124 @@
+"use client";
+import React from 'react';
+import { useTranslations } from 'next-intl';
+import DOMPurify from 'dompurify';
+import { cn } from '@/lib/utils';
+
+// The notes arrive as sanitized MDX-rendered HTML, so Tailwind's preflight has
+// already stripped paragraph margins and list markers from it. Restore the
+// rhythm for the tags the notes corpus actually uses: prose, the occasional
+// bullet list, and the formula/diagram images.
+export const NOTES_PROSE = [
+  'max-w-[68ch] leading-relaxed',
+  '[&_p]:mb-3 [&_p:last-child]:mb-0',
+  '[&_ul]:my-3 [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:space-y-1',
+  '[&_ol]:my-3 [&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:space-y-1',
+  '[&_img]:my-3 [&_img]:max-w-full [&_img]:h-auto [&_img]:rounded-lg',
+  '[&_img]:border [&_img]:border-slate-200 dark:[&_img]:border-slate-700',
+  // Inline diagrams draw with currentColor, so they follow the theme.
+  '[&_svg]:my-3 [&_svg]:max-w-full [&_svg]:h-auto',
+  '[&_strong]:font-semibold [&_strong]:text-slate-700 dark:[&_strong]:text-slate-300',
+  '[&_a]:text-blue-600 dark:[&_a]:text-blue-400 [&_a]:underline',
+].join(' ');
+
+export interface QuestionExplanationProps {
+  /** '1' | '2' | '3'. Without it there is no note to address. */
+  categoryId: string | undefined;
+  questionId: number;
+  /** Whether the bank generated a note file for this question. */
+  hasNotesMdx?: boolean;
+  /** Explanation shipped inline with the question, used when there is no file. */
+  inlineNotes?: string | null;
+  /** Rendered above the explanation. Pass null for callers that head it themselves. */
+  heading?: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * The explanation for one question, fetched from `/api/notes` on mount.
+ *
+ * Shared by the question card and the exam review so the two cannot drift:
+ * they answer the same question ("why is this the right answer?") and any fix
+ * to the fetch or the prose styling has to reach both.
+ *
+ * Mount this only when the explanation is actually visible — it fetches
+ * immediately, and the exam review has forty of these behind an accordion.
+ */
+export const QuestionExplanation: React.FC<QuestionExplanationProps> = ({
+  categoryId,
+  questionId,
+  hasNotesMdx,
+  inlineNotes,
+  heading,
+  className,
+}) => {
+  const t = useTranslations('QuestionCard');
+  const [html, setHtml] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState(false);
+
+  // One key for the whole request. It is the only dependency of the fetch
+  // effect on purpose: putting the loading flag in the deps makes the effect
+  // tear itself down the moment it sets it, which cancels its own response.
+  const notesKey = categoryId && hasNotesMdx
+    ? `${encodeURIComponent(categoryId)}/${encodeURIComponent(String(questionId))}`
+    : null;
+
+  React.useEffect(() => {
+    setHtml(null);
+    setError(false);
+  }, [questionId, categoryId]);
+
+  React.useEffect(() => {
+    if (!notesKey) return;
+
+    let cancelled = false;
+    setLoading(true);
+    setError(false);
+    fetch(`/api/notes/${notesKey}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`Failed to load notes: ${res.status}`);
+        return res.json();
+      })
+      .then((data) => {
+        if (cancelled) return;
+        const body = typeof data?.html === 'string' ? data.html : '';
+        setHtml(body.length > 0 ? body : null);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error(err);
+        setError(true);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [notesKey]);
+
+  const resolved = html ?? inlineNotes ?? null;
+  if (!loading && !error && !resolved) return null;
+
+  return (
+    <div className={cn('text-slate-600 dark:text-slate-400', className)}>
+      {heading}
+      {loading && (
+        <div className="max-w-[68ch] space-y-2" aria-hidden="true">
+          <div className="h-3 rounded bg-slate-200 dark:bg-slate-700 animate-pulse motion-reduce:animate-none" />
+          <div className="h-3 rounded bg-slate-200 dark:bg-slate-700 animate-pulse motion-reduce:animate-none" />
+          <div className="h-3 w-2/3 rounded bg-slate-200 dark:bg-slate-700 animate-pulse motion-reduce:animate-none" />
+        </div>
+      )}
+      {error && !loading && (
+        <p className="text-red-600 dark:text-red-400">{t('notesError')}</p>
+      )}
+      {!loading && !error && resolved && (
+        <div className={NOTES_PROSE} dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(resolved) }} />
+      )}
+    </div>
+  );
+};

--- a/components/QuestionFilters.tsx
+++ b/components/QuestionFilters.tsx
@@ -84,7 +84,7 @@ export function QuestionFilters({
             aria-pressed={activeTopic === slug}
             className={`${CHIP} ${activeTopic === slug ? CHIP_ON : CHIP_OFF}`}
           >
-            <TopicIcon slug={slug} className="w-3.5 h-3.5 shrink-0 opacity-70" />
+            <TopicIcon slug={slug} colored className="w-3.5 h-3.5 shrink-0" />
             {label}
             <span className="font-mono text-[10px] tabular-nums opacity-60">{count}</span>
           </button>

--- a/components/QuestionFilters.tsx
+++ b/components/QuestionFilters.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { Search, X } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import { TOPICS, topicShortLabel } from "@/lib/config";
+import { TopicIcon } from "@/components/TopicIcon";
 
 export type TopicCount = { slug: string; label: string; count: number };
 
@@ -83,6 +84,7 @@ export function QuestionFilters({
             aria-pressed={activeTopic === slug}
             className={`${CHIP} ${activeTopic === slug ? CHIP_ON : CHIP_OFF}`}
           >
+            <TopicIcon slug={slug} className="w-3.5 h-3.5 shrink-0 opacity-70" />
             {label}
             <span className="font-mono text-[10px] tabular-nums opacity-60">{count}</span>
           </button>

--- a/components/TopicIcon.tsx
+++ b/components/TopicIcon.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {
+  Antenna,
+  AudioLines,
+  CircuitBoard,
+  Gauge,
+  Headphones,
+  Microchip,
+  RadioReceiver,
+  RadioTower,
+  Scale,
+  ShieldAlert,
+  Waves,
+  Zap,
+  type LucideIcon,
+} from 'lucide-react';
+import { isTopicSlug, type TopicSlug } from '@/lib/config';
+import { cn } from '@/lib/utils';
+
+/**
+ * One icon per exam topic, for anywhere a topic is named.
+ *
+ * The map is a total `Record<TopicSlug, …>` on purpose: a thirteenth topic
+ * added to the taxonomy fails to compile until it is given an icon here,
+ * rather than silently falling back to a generic one everywhere at once.
+ *
+ * Each choice comes from the topic's own scope in `lib/config/topics.ts`, not
+ * from the word in its name — `medidas` is instruments, hence a gauge.
+ */
+const TOPIC_ICONS: Record<TopicSlug, LucideIcon> = {
+  teoria: Zap,               // eletricidade e eletromagnetismo
+  componentes: Microchip,    // dispositivos considerados isoladamente
+  circuitos: CircuitBoard,   // os componentes já montados
+  recetores: RadioReceiver,
+  emissores: RadioTower,
+  antenas: Antenna,
+  propagacao: Waves,         // a onda a viajar
+  medidas: Gauge,            // instrumentos de medida
+  interferencias: AudioLines, // o sinal sujo
+  seguranca: ShieldAlert,
+  operacao: Headphones,      // operar a estação
+  regulamentacao: Scale,     // a lei
+};
+
+export interface TopicIconProps {
+  slug: string;
+  className?: string;
+}
+
+/**
+ * Decorative by default: every place that shows this also shows the topic's
+ * name, so announcing the icon would just repeat it.
+ */
+export const TopicIcon: React.FC<TopicIconProps> = ({ slug, className }) => {
+  if (!isTopicSlug(slug)) return null;
+  const Icon = TOPIC_ICONS[slug];
+  return <Icon className={cn('w-4 h-4', className)} aria-hidden="true" />;
+};
+
+export { TOPIC_ICONS };

--- a/components/TopicIcon.tsx
+++ b/components/TopicIcon.tsx
@@ -17,33 +17,105 @@ import {
 import { isTopicSlug, type TopicSlug } from '@/lib/config';
 import { cn } from '@/lib/utils';
 
+type TopicStyle = {
+  icon: LucideIcon;
+  /** Bare icon, on the page's own background. */
+  fg: string;
+  /** Filled square, for when the topic is the subject of the row. */
+  tile: string;
+};
+
 /**
- * One icon per exam topic, for anywhere a topic is named.
+ * One icon and one colour per exam topic, for anywhere a topic is named.
  *
  * The map is a total `Record<TopicSlug, …>` on purpose: a thirteenth topic
- * added to the taxonomy fails to compile until it is given an icon here,
+ * added to the taxonomy fails to compile until it is given a style here,
  * rather than silently falling back to a generic one everywhere at once.
  *
- * Each choice comes from the topic's own scope in `lib/config/topics.ts`, not
- * from the word in its name — `medidas` is instruments, hence a gauge.
+ * Icons come from the topic's `scope` in `lib/config/topics.ts`, not from the
+ * word in its name — `medidas` is instruments, hence a gauge. Colours run the
+ * hue wheel so neighbouring topics never share one, and are grouped by family:
+ * the equipment chain (componentes → antenas) sits in the blues, the wave
+ * subjects in the greens, and the human/legal ones at the ends.
+ *
+ * The classes are written out in full because Tailwind scans source text; a
+ * colour assembled from pieces at runtime would be purged from the build.
  */
-const TOPIC_ICONS: Record<TopicSlug, LucideIcon> = {
-  teoria: Zap,               // eletricidade e eletromagnetismo
-  componentes: Microchip,    // dispositivos considerados isoladamente
-  circuitos: CircuitBoard,   // os componentes já montados
-  recetores: RadioReceiver,
-  emissores: RadioTower,
-  antenas: Antenna,
-  propagacao: Waves,         // a onda a viajar
-  medidas: Gauge,            // instrumentos de medida
-  interferencias: AudioLines, // o sinal sujo
-  seguranca: ShieldAlert,
-  operacao: Headphones,      // operar a estação
-  regulamentacao: Scale,     // a lei
+const TOPIC_STYLES: Record<TopicSlug, TopicStyle> = {
+  teoria: {
+    icon: Zap, // eletricidade e eletromagnetismo
+    fg: 'text-amber-600 dark:text-amber-400',
+    tile: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+  },
+  componentes: {
+    icon: Microchip, // dispositivos considerados isoladamente
+    fg: 'text-violet-600 dark:text-violet-400',
+    tile: 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300',
+  },
+  circuitos: {
+    icon: CircuitBoard, // os componentes já montados
+    fg: 'text-indigo-600 dark:text-indigo-400',
+    tile: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300',
+  },
+  recetores: {
+    icon: RadioReceiver,
+    fg: 'text-sky-600 dark:text-sky-400',
+    tile: 'bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300',
+  },
+  emissores: {
+    icon: RadioTower,
+    fg: 'text-blue-600 dark:text-blue-400',
+    tile: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  },
+  antenas: {
+    icon: Antenna,
+    fg: 'text-cyan-600 dark:text-cyan-400',
+    tile: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300',
+  },
+  propagacao: {
+    icon: Waves, // a onda a viajar
+    fg: 'text-teal-600 dark:text-teal-400',
+    tile: 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300',
+  },
+  medidas: {
+    icon: Gauge, // instrumentos de medida
+    fg: 'text-emerald-600 dark:text-emerald-400',
+    tile: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+  },
+  interferencias: {
+    icon: AudioLines, // o sinal sujo
+    fg: 'text-rose-600 dark:text-rose-400',
+    tile: 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300',
+  },
+  seguranca: {
+    icon: ShieldAlert,
+    fg: 'text-orange-600 dark:text-orange-400',
+    tile: 'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300',
+  },
+  operacao: {
+    icon: Headphones, // operar a estação
+    fg: 'text-fuchsia-600 dark:text-fuchsia-400',
+    tile: 'bg-fuchsia-100 text-fuchsia-700 dark:bg-fuchsia-900/40 dark:text-fuchsia-300',
+  },
+  regulamentacao: {
+    icon: Scale, // a lei
+    fg: 'text-slate-600 dark:text-slate-300',
+    tile: 'bg-slate-200 text-slate-700 dark:bg-slate-700 dark:text-slate-200',
+  },
 };
+
+/** Classes for a filled square holding the topic's icon; empty for an unknown slug. */
+export function topicTileClass(slug: string): string {
+  return isTopicSlug(slug) ? TOPIC_STYLES[slug].tile : '';
+}
 
 export interface TopicIconProps {
   slug: string;
+  /**
+   * Colour the icon by topic. Off inside a tile, which already carries the
+   * colour, and off where the surrounding text owns the colour.
+   */
+  colored?: boolean;
   className?: string;
 }
 
@@ -51,10 +123,10 @@ export interface TopicIconProps {
  * Decorative by default: every place that shows this also shows the topic's
  * name, so announcing the icon would just repeat it.
  */
-export const TopicIcon: React.FC<TopicIconProps> = ({ slug, className }) => {
+export const TopicIcon: React.FC<TopicIconProps> = ({ slug, colored = false, className }) => {
   if (!isTopicSlug(slug)) return null;
-  const Icon = TOPIC_ICONS[slug];
-  return <Icon className={cn('w-4 h-4', className)} aria-hidden="true" />;
+  const { icon: Icon, fg } = TOPIC_STYLES[slug];
+  return <Icon className={cn('w-4 h-4', colored && fg, className)} aria-hidden="true" />;
 };
 
-export { TOPIC_ICONS };
+export { TOPIC_STYLES };

--- a/content/questions/cat3/0033.mdx
+++ b/content/questions/cat3/0033.mdx
@@ -9,7 +9,7 @@ answers:
   - text: >-
       Um trabalho realizado em 1995 por amadores num grupo de trabalho de gestão
       de frequências
-topic: entidades
+topic: operacao
 sources:
   - pdf: cat3/2023_09_21
     question: 15
@@ -18,7 +18,6 @@ sources:
     question: 14
     page: 4
 tutorial: entidades
-  
 ---
 A resposta correta é **o Regulamento das Radiocomunicações da UIT**. A UIT (União Internacional das Telecomunicações) é a organização mundial que atribui as faixas de frequências aos vários serviços de rádio, incluindo o serviço de amador. A IARU, que é a associação internacional dos radioamadores, pega nessas faixas atribuídas e elabora planos de bandas: recomendações sobre que partes de cada banda usar para fonia, telegrafia, modos digitais, etc. Ou seja, a IARU organiza o espaço que o Regulamento da UIT define, e é por isso que os seus planos têm de partir desse documento.
 

--- a/content/questions/cat3/0034.mdx
+++ b/content/questions/cat3/0034.mdx
@@ -9,8 +9,8 @@ answers:
   - text: >-
       Um trabalho realizado em 1995 por amadores num grupo de trabalho de gestão
       de frequências
+topic: operacao
 tutorial: entidades
-topic: entidades
 ---
 **Os planos da IARU baseiam-se no Regulamento das Radiocomunicações da UIT.** A UIT (União Internacional das Telecomunicações) é o organismo mundial que decide, através desse regulamento, que faixas de frequências ficam atribuídas a cada serviço, incluindo o serviço de amador. A IARU, que é a união internacional das associações de radioamadores, parte dessas faixas e elabora planos de bandas: uma organização interna que sugere, por exemplo, onde fazer telegrafia, fonia ou modos digitais dentro de cada banda.
 

--- a/lib/exam/shuffle-options.ts
+++ b/lib/exam/shuffle-options.ts
@@ -1,0 +1,119 @@
+/**
+ * Shuffling the answer options of an exam question.
+ *
+ * The official papers put the correct answer in a visible pattern — over the
+ * cat3 bank it is not evenly spread across the four positions — so a candidate
+ * who practises on the bank can learn the position instead of the answer.
+ * Shuffling removes that crutch.
+ *
+ * What is *recorded* stays in the bank's own order. The shuffle is a property
+ * of one sitting, not of the answer the candidate gave: translating back on the
+ * way out means progress, statistics and the dashboard's replay links keep
+ * working with no idea this feature exists. The alternative — storing shuffled
+ * indices — would have made every replay link show the answers against the
+ * wrong options, silently, which is the exact failure `lib/exam/replay.ts`
+ * exists to prevent.
+ */
+
+/** Shuffled position -> index the option had in the bank. */
+export type OptionPermutation = number[];
+
+type Shufflable = { id: number; options: string[]; correctIndex: number };
+
+export type ShuffleResult<Q> = {
+  questions: Q[];
+  /** Keyed by question id; absent for a question left in its original order. */
+  permutations: Record<number, OptionPermutation>;
+};
+
+/**
+ * A new question with its options reordered, plus the permutation needed to
+ * read the answer back. The input is not mutated — the loaded bank is shared
+ * between every consumer on the page.
+ */
+export function shuffleQuestionOptions<Q extends Shufflable>(
+  question: Q,
+  rng: () => number = Math.random
+): { question: Q; permutation: OptionPermutation } {
+  const permutation = question.options.map((_, i) => i);
+
+  // Fisher-Yates over the positions, so every ordering is equally likely.
+  for (let i = permutation.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    const a = permutation[i];
+    const b = permutation[j];
+    if (a === undefined || b === undefined) continue;
+    permutation[i] = b;
+    permutation[j] = a;
+  }
+
+  const options = permutation.map((original) => question.options[original] ?? '');
+  const correctIndex = permutation.indexOf(question.correctIndex);
+
+  return {
+    question: { ...question, options, correctIndex },
+    permutation,
+  };
+}
+
+export function shuffleAllOptions<Q extends Shufflable>(
+  questions: readonly Q[],
+  rng: () => number = Math.random
+): ShuffleResult<Q> {
+  const out: Q[] = [];
+  const permutations: Record<number, OptionPermutation> = {};
+
+  for (const question of questions) {
+    const shuffled = shuffleQuestionOptions(question, rng);
+    out.push(shuffled.question);
+    permutations[question.id] = shuffled.permutation;
+  }
+
+  return { questions: out, permutations };
+}
+
+/**
+ * Answers given against shuffled options, expressed in the bank's own order.
+ *
+ * A question with no permutation is passed through untouched, which is what
+ * makes this safe to call unconditionally — an unshuffled exam maps to itself.
+ */
+export function toCanonicalAnswers(
+  answers: Readonly<Record<number, number>>,
+  permutations: Readonly<Record<number, OptionPermutation>>
+): Record<number, number> {
+  const out: Record<number, number> = {};
+
+  for (const [key, chosen] of Object.entries(answers)) {
+    const id = Number(key);
+    const permutation = permutations[id];
+    const original = permutation?.[chosen];
+    out[id] = original ?? chosen;
+  }
+
+  return out;
+}
+
+/* -------------------------------------------------------------------------- */
+/* The candidate's preference                                                  */
+/* -------------------------------------------------------------------------- */
+
+export const SHUFFLE_OPTIONS_KEY = 'hamradio:exam-shuffle-options';
+
+/** Off unless the candidate turned it on; storage being unreadable means off. */
+export function readShuffleOptionsPreference(): boolean {
+  try {
+    return window.localStorage.getItem(SHUFFLE_OPTIONS_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function writeShuffleOptionsPreference(enabled: boolean): void {
+  try {
+    window.localStorage.setItem(SHUFFLE_OPTIONS_KEY, enabled ? 'true' : 'false');
+  } catch {
+    // A private window with storage blocked still gets the exam it asked for;
+    // it just will not be remembered.
+  }
+}

--- a/lib/exam/weak-topics.ts
+++ b/lib/exam/weak-topics.ts
@@ -1,0 +1,59 @@
+/**
+ * Which subject areas an exam attempt exposed as weak.
+ *
+ * The score says whether you passed; it does not say what to do next. The bank
+ * already carries a topic on every question, so the attempt itself can answer
+ * "what should I study?" without any extra bookkeeping.
+ */
+
+export type TopicOutcome = {
+  slug: string;
+  /** Questions of this topic in the attempt. */
+  total: number;
+  /** Wrong plus unanswered — both mean the candidate could not produce it. */
+  missed: number;
+  /** correct / total, 0..1. */
+  accuracy: number;
+};
+
+type Scored = {
+  materia?: string | null;
+  status: 'correct' | 'incorrect' | 'unanswered';
+};
+
+/**
+ * Topics the attempt got wrong, worst first.
+ *
+ * "Worst" is the count of misses before the rate: four wrong out of twelve is
+ * a bigger hole in a 40-question exam than one wrong out of one, even though
+ * the rate says otherwise. The rate breaks ties, so a topic that was mostly
+ * missed outranks one that was mostly right.
+ *
+ * Topics answered perfectly are absent: this is a list of things to do, and a
+ * to-do list with completed items is just a scoreboard again.
+ */
+export function weakTopics(answers: readonly Scored[], limit = 4): TopicOutcome[] {
+  const byTopic = new Map<string, { total: number; missed: number }>();
+
+  for (const answer of answers) {
+    const slug = answer.materia;
+    // A question with no topic cannot be turned into advice, and guessing one
+    // would send the candidate to the wrong chapter.
+    if (!slug) continue;
+    const row = byTopic.get(slug) ?? { total: 0, missed: 0 };
+    row.total += 1;
+    if (answer.status !== 'correct') row.missed += 1;
+    byTopic.set(slug, row);
+  }
+
+  return [...byTopic.entries()]
+    .map(([slug, { total, missed }]) => ({
+      slug,
+      total,
+      missed,
+      accuracy: total === 0 ? 0 : (total - missed) / total,
+    }))
+    .filter((topic) => topic.missed > 0)
+    .sort((a, b) => b.missed - a.missed || a.accuracy - b.accuracy || a.slug.localeCompare(b.slug))
+    .slice(0, limit);
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -461,6 +461,12 @@
       "summary": "Summary",
       "review": "Review"
     },
+    "studyAreas": {
+      "title": "Where to study next",
+      "subtitle": "The topics this exam found weakest, hardest first.",
+      "missed": "{missed} of {total} missed",
+      "practice": "Practise"
+    },
     "status": {
       "passed": "You Passed!",
       "failed": "Not yet",

--- a/messages/en.json
+++ b/messages/en.json
@@ -226,6 +226,7 @@
     "page": "Page {current} / {total}",
     "takeAnother": "Take Another",
     "endQuiz": "End Quiz",
+    "viewQuestions": "View Questions",
     "viewResults": "View Results",
     "resultsSubtitle": "Results",
     "score": "Score: {score} / {total}",

--- a/messages/en.json
+++ b/messages/en.json
@@ -228,6 +228,14 @@
     "endQuiz": "End Quiz",
     "viewQuestions": "View Questions",
     "viewResults": "View Results",
+    "shuffle": {
+      "label": "Shuffle options",
+      "confirmTitleOn": "Shuffle the options?",
+      "confirmTitleOff": "Stop shuffling the options?",
+      "confirmBody": "The option order can only change in a new exam, so this one restarts from scratch. The answers you have given are lost.",
+      "cancel": "Cancel",
+      "restart": "Restart"
+    },
     "resultsSubtitle": "Results",
     "score": "Score: {score} / {total}",
     "questionId": "ID: {id}",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -461,6 +461,12 @@
       "summary": "Resumo",
       "review": "Rever"
     },
+    "studyAreas": {
+      "title": "Onde estudar a seguir",
+      "subtitle": "As matérias que este exame mostrou mais fracas, a começar pela que te custou mais.",
+      "missed": "{missed} de {total} por acertar",
+      "practice": "Praticar"
+    },
     "status": {
       "passed": "Aprovado!",
       "failed": "Reprovado",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -228,6 +228,14 @@
     "endQuiz": "Terminar",
     "viewQuestions": "Ver Perguntas",
     "viewResults": "Ver Resultados",
+    "shuffle": {
+      "label": "Baralhar opções",
+      "confirmTitleOn": "Baralhar as opções?",
+      "confirmTitleOff": "Deixar de baralhar as opções?",
+      "confirmBody": "A ordem das opções só pode mudar num exame novo, por isso este recomeça do zero. As respostas que já deu perdem-se.",
+      "cancel": "Cancelar",
+      "restart": "Recomeçar"
+    },
     "resultsSubtitle": "Resultados",
     "score": "Pontuação: {score} / {total}",
     "questionId": "ID: {id}",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -226,6 +226,7 @@
     "page": "Página {current} / {total}",
     "takeAnother": "Fazer Outro",
     "endQuiz": "Terminar",
+    "viewQuestions": "Ver Perguntas",
     "viewResults": "Ver Resultados",
     "resultsSubtitle": "Resultados",
     "score": "Pontuação: {score} / {total}",

--- a/public/data/cat3.json
+++ b/public/data/cat3.json
@@ -602,7 +602,7 @@
         }
       ],
       "tutorial": "entidades",
-      "materia": "entidades"
+      "materia": "operacao"
     },
     {
       "id": 34,
@@ -616,7 +616,7 @@
       "correctIndex": 0,
       "hasNotesMdx": true,
       "tutorial": "entidades",
-      "materia": "entidades"
+      "materia": "operacao"
     },
     {
       "id": 35,


### PR DESCRIPTION
Sete commits, todos no que acontece depois de responder à última pergunta.

**A explicação na revisão.** O cartão de resultados assinalava a resposta certa
mas não dizia porquê. A explicação já existia — a mesma que o cartão de
pergunta vai buscar ao `/api/notes` — só não chegava aqui.

**Voltar às perguntas.** Terminado o exame só havia o cartão de resultados, e a
seta do cabeçalho vai para a página inicial. Passa a haver um "Ver Perguntas",
simétrico ao "Ver Resultados", e volta-se à página em que se ia. Aí, as
perguntas erradas e as que ficaram por responder mostram a explicação por baixo
das opções.

**Que matérias estudar a seguir.** A nota diz se passou, não diz o que fazer a
seguir. Como cada pergunta traz a matéria, a própria prova responde a isso: as
matérias mais fracas da tentativa, da que mais custou para a que menos, com
ligação para as praticar. Erradas e por responder contam do mesmo lado, e ordena
pelo número de falhas antes da taxa — quatro em doze é um buraco maior do que
uma em uma.

**Ícones e cores por matéria.** Reutilizáveis, usados nos três sítios onde as
matérias aparecem: o painel novo, os chips do /browse e a etiqueta do cartão.

**Baralhar a posição da resposta certa.** Uma caixa antes do cronómetro, na
primeira página. O que fica registado continua na ordem do banco, para os links
de repetição e as estatísticas não passarem a apontar para as opções erradas.

Vai também uma correção de conteúdo que este trabalho destapou: as cat3#33 e
\#34 tinham `topic: entidades`, que não é um dos doze slugs, e por isso não
tinham etiqueta nem apareciam no filtro. O `qbank topics` já o dizia.