### PR TITLE
Mostrar a questão seguinte a partir do topo, nos flashcards

### DIFF
--- a/app/browse/[category]/flash/page.tsx
+++ b/app/browse/[category]/flash/page.tsx
@@ -120,6 +120,15 @@ export default function FlashBrowsePage() {
     setAnsweredCount(0);
   }, [category]);
 
+  // Answering scrolls the page down to the explanation, so a new card has to be
+  // brought back into view. `order` is in the deps because finishing a round
+  // reshuffles it while leaving the cursor at 0. The jump is instant on purpose:
+  // a smooth scroll is animated over the *next* card, which is usually shorter
+  // than the answered one, and gets clamped to its new bottom on the way up.
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: "auto" });
+  }, [cursor, order]);
+
   const handleLaunchCalculator = useCallback((code: string) => {
     openCalculator(code as CalculatorCode);
   }, [openCalculator]);
@@ -221,7 +230,7 @@ export default function FlashBrowsePage() {
         subtitle={t("flashCard", { position: sessionPosition, total: category.questions.length })}
       >
         <span className="text-xs font-medium text-slate-500 dark:text-slate-400 tabular-nums">
-          {answeredCount} reviewed
+          {t("flashReviewed", { count: answeredCount })}
         </span>
       </StudyHeader>
 

--- a/components/QuestionFilters.tsx
+++ b/components/QuestionFilters.tsx
@@ -38,7 +38,7 @@ export function QuestionFilters({
   const t = useTranslations("Browse");
 
   return (
-    <div className="sticky top-[6.25rem] z-10 -mx-4 sm:mx-0 mb-4 border-b border-slate-200/60 bg-white/80 px-4 py-2.5 backdrop-blur-xl dark:border-slate-700/40 dark:bg-slate-900/80">
+    <div className="sticky top-[6.25rem] z-10 mb-4 border-b border-slate-200/60 bg-white/80 px-4 py-2.5 backdrop-blur-xl dark:border-slate-700/40 dark:bg-slate-900/80">
       <div className="flex items-center gap-2">
         <div className="flex flex-1 items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-1.5 focus-within:border-amber-400 dark:border-slate-700 dark:bg-slate-800">
           <Search className="h-3.5 w-3.5 shrink-0 text-slate-400" aria-hidden="true" />

--- a/components/StudyHeader.tsx
+++ b/components/StudyHeader.tsx
@@ -40,7 +40,7 @@ export function StudyHeader({
   const href = backHref ?? "/";
 
   return (
-    <div className="sticky top-14 z-10 -mx-4 sm:-mx-0 mb-4">
+    <div className="sticky top-14 z-10 mb-4">
       {/* Category accent stripe */}
       <div className={`h-[2px] ${accent}`} />
 
@@ -78,7 +78,7 @@ export function StudyHeader({
                   <span className="text-slate-200 dark:text-slate-700 select-none hidden sm:inline">
                     &middot;
                   </span>
-                  <span className="text-xs text-slate-400 dark:text-slate-500 leading-none hidden sm:inline truncate">
+                  <span className="text-xs text-slate-400 dark:text-slate-500 leading-none hidden sm:inline truncate min-w-0">
                     {subtitle}
                   </span>
                 </>

--- a/messages/en.json
+++ b/messages/en.json
@@ -66,6 +66,7 @@
     "flashNext": "Next question",
     "flashNoQuestions": "There are no questions available for this category yet.",
     "flashNotFound": "We could not find category {id}. Try choosing a category from the Browse menu.",
+    "flashReviewed": "{count} reviewed",
     "flashSubtitle": "Practice one random question at a time. Reviewed {count} so far.",
     "flashTitle": "Flashcards Category {id}",
     "loading": "Loading questions...",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -66,6 +66,7 @@
     "flashNext": "Próxima questão",
     "flashNoQuestions": "Ainda não há questões disponíveis para esta categoria.",
     "flashNotFound": "Não encontrámos a categoria {id}. Tenta escolher uma categoria no menu Explorar.",
+    "flashReviewed": "{count, plural, =0 {0 revistos} =1 {1 revisto} other {# revistos}}",
     "flashSubtitle": "Pratica uma questão aleatória de cada vez. Já reviste {count}.",
     "flashTitle": "Flashcards Categoria {id}",
     "loading": "A carregar questões...",


### PR DESCRIPTION
Três correcções no ecrã de flashcards (`/browse/[cat]/flash`), todas visíveis em telemóvel.

## A carta seguinte aparecia a meio

Responder empurra a página para baixo, até à explicação, e o *Próxima questão* mudava de carta sem trazer a página de volta ao topo. Passa a saltar para o topo sempre que a carta muda — `order` está nas dependências porque acabar uma ronda baralha-a deixando o cursor em 0.

O salto é instantâneo de propósito. Com `behavior: "smooth"` medi-o a falhar: a partir de y=1000 a página ficava em 186, porque a carta seguinte é mais curta e a animação fica presa no novo fundo a meio do caminho. Instantâneo aterra em 0 — confirmado em três cartas seguidas, de y=313, 404 e 1215.

## Scroll horizontal em telemóvel

Era o cabeçalho, não o texto: `StudyHeader` trazia `-mx-4` dentro de um `<main>` que já é `-mx-4` para ficar de margem a margem. Num ecrã de 412px ocupava de −16px a 411px numa viewport de 395px — 16px de scroll horizontal. Tirar a margem duplicada arruma o flash, o exame e a prática inteligente, que usam todos o mesmo `main`.

A barra de filtros do browse (`QuestionFilters`) tinha exactamente o mesmo defeito, e era a razão de `/browse/1` continuar a transbordar depois de arranjar o cabeçalho.

O subtítulo levou `min-w-0` para o `truncate` poder mesmo encolher em ecrã grande.

## "0 reviewed" em inglês

Estava escrito à mão no meio da página portuguesa. Passa a chave i18n, com concordância: `0 revistos` / `1 revisto` / `3 revistos`.

## Verificação

`type-check`, `lint` e os 430 testes passam. Comportamento confirmado no browser a 412px e a 360px: sem scroll horizontal em `/browse/1`, `/browse/1/flash` e `/exam/3`.