### PR TITLE
Corrigir a explicação da cat1#83

### DIFF
--- a/components/QuestionExplanation.tsx
+++ b/components/QuestionExplanation.tsx
@@ -17,6 +17,12 @@ export const NOTES_PROSE = [
   '[&_img]:border [&_img]:border-slate-200 dark:[&_img]:border-slate-700',
   // Inline diagrams draw with currentColor, so they follow the theme.
   '[&_svg]:my-3 [&_svg]:max-w-full [&_svg]:h-auto',
+  // ...but not KaTeX's own SVGs. It draws a radical as a path 400em wide and
+  // relies on `.hide-tail` clipping it to show just the surd; capping that at
+  // 100% scales the whole 400000-unit viewBox into ~30px and the radical
+  // disappears, leaving `\sqrt{LC}` looking like a strikethrough. The
+  // `.katex svg` selector outranks the bare `svg` one, so order is not at play.
+  '[&_.katex_svg]:my-0 [&_.katex_svg]:max-w-none',
   '[&_strong]:font-semibold [&_strong]:text-slate-700 dark:[&_strong]:text-slate-300',
   '[&_a]:text-blue-600 dark:[&_a]:text-blue-400 [&_a]:underline',
 ].join(' ');

--- a/content/notes/cat1/83.mdx
+++ b/content/notes/cat1/83.mdx
@@ -1,1 +1,15 @@
-A frequência de ressonância em um circuito série RLC é dada por: f = 1 / (2 * pi * sqrt(L * C)). Substituindo os valores, obtemos f ≈ 22,36 MHz.
+A frequência de ressonância é aproximadamente **3,56 MHz**.
+
+Num circuito RLC série a ressonância ocorre quando a reatância indutiva iguala a capacitiva ($X_L = X_C$), o que conduz à fórmula de Thomson:
+
+$$f_0 = \frac{1}{2\pi\sqrt{L\,C}}$$
+
+Repare que $R$ não entra na fórmula: os $22\ \Omega$ afetam o fator de qualidade $Q$ e a largura de banda do circuito, mas não a frequência a que ele ressoa. É um dado posto no enunciado precisamente para distrair.
+
+Fazendo as contas, comece por converter as unidades: $L = 0{,}05\ \text{mH} = 5\times10^{-5}\ \text{H}$ e $C = 40\ \text{pF} = 4\times10^{-11}\ \text{F}$. O produto vale $L\,C = 5\times10^{-5}\times 4\times10^{-11} = 2\times10^{-15}$, cuja raiz quadrada é $\sqrt{2\times10^{-15}} \approx 4{,}47\times10^{-8}$. Então
+
+$$f_0 = \frac{1}{2\pi \times 4{,}47\times10^{-8}} \approx \frac{1}{2{,}81\times10^{-7}} \approx 3{,}56\times10^{6}\ \text{Hz}$$
+
+ou seja **3,56 MHz**.
+
+Quanto às restantes opções, saem todas de erros à volta do $2\pi$: $22{,}36$ MHz é o valor que se obtém esquecendo-o, porque $1/\sqrt{L\,C} \approx 2{,}236\times10^{7}$ é a frequência angular $\omega$ em radianos por segundo e não uma frequência em hertz; $44{,}72$ MHz é o dobro desse mesmo erro; e $1{,}78$ MHz é metade da resposta certa. Num exame, se o seu resultado for cerca de $6{,}28$ vezes maior do que uma das opções, é sinal de que se esqueceu do $2\pi$.

--- a/content/questions/cat1/0083.mdx
+++ b/content/questions/cat1/0083.mdx
@@ -11,4 +11,18 @@ answers:
   - text: '1,78 MHz'
 topic: circuitos
 ---
-A frequência de ressonância em um circuito série RLC é dada por: f = 1 / (2 * pi * sqrt(L * C)). Substituindo os valores, obtemos f ≈ 22,36 MHz.
+A frequência de ressonância é aproximadamente **3,56 MHz**.
+
+Num circuito RLC série a ressonância ocorre quando a reatância indutiva iguala a capacitiva ($X_L = X_C$), o que conduz à fórmula de Thomson:
+
+$$f_0 = \frac{1}{2\pi\sqrt{L\,C}}$$
+
+Repare que $R$ não entra na fórmula: os $22\ \Omega$ afetam o fator de qualidade $Q$ e a largura de banda do circuito, mas não a frequência a que ele ressoa. É um dado posto no enunciado precisamente para distrair.
+
+Fazendo as contas, comece por converter as unidades: $L = 0{,}05\ \text{mH} = 5\times10^{-5}\ \text{H}$ e $C = 40\ \text{pF} = 4\times10^{-11}\ \text{F}$. O produto vale $L\,C = 5\times10^{-5}\times 4\times10^{-11} = 2\times10^{-15}$, cuja raiz quadrada é $\sqrt{2\times10^{-15}} \approx 4{,}47\times10^{-8}$. Então
+
+$$f_0 = \frac{1}{2\pi \times 4{,}47\times10^{-8}} \approx \frac{1}{2{,}81\times10^{-7}} \approx 3{,}56\times10^{6}\ \text{Hz}$$
+
+ou seja **3,56 MHz**.
+
+Quanto às restantes opções, saem todas de erros à volta do $2\pi$: $22{,}36$ MHz é o valor que se obtém esquecendo-o, porque $1/\sqrt{L\,C} \approx 2{,}236\times10^{7}$ é a frequência angular $\omega$ em radianos por segundo e não uma frequência em hertz; $44{,}72$ MHz é o dobro desse mesmo erro; e $1{,}78$ MHz é metade da resposta certa. Num exame, se o seu resultado for cerca de $6{,}28$ vezes maior do que uma das opções, é sinal de que se esqueceu do $2\pi$.


### PR DESCRIPTION
A explicação da cat1#83 dava **22,36 MHz** como resultado, que é uma das opções erradas. A resposta certa é **3,56 MHz** — a mesma que a pergunta marca como correta.

O erro é o clássico do 2π: `1/√(LC) = 2,236×10⁷` é a frequência angular em rad/s, não uma frequência em hertz. Com `f₀ = 1/(2π√(LC))` e L = 0,05 mH, C = 40 pF, dá 3,56 MHz.

A explicação foi reescrita no estilo das irmãs cat1#84 e cat1#86: fórmula de Thomson em KaTeX, conversão de unidades passo a passo, a nota de que os 22 Ω não entram no cálculo, e a origem de cada opção errada.

Vai também uma correção de renderização: o `NOTES_PROSE` limitava a largura de todos os SVG, regra pensada para os diagramas das notas. A KaTeX desenha a raiz quadrada como um traçado de 400em cortado pelo `.hide-tail`, pelo que a limitação encolhia o radical até desaparecer — `√(LC)` aparecia como texto riscado em qualquer explicação com raízes.
