### PR TITLE
Corrigir "de de envolvente" na cat1#120

### DIFF
--- a/content/questions/cat1/0120.mdx
+++ b/content/questions/cat1/0120.mdx
@@ -4,7 +4,7 @@ question: 'A figura representa:'
 answers:
   - text: um detetor de produto
   - text: um detetor de frequência modulada
-  - text: um detetor de de envolvente
+  - text: um detetor de envolvente
     correct: true
   - text: um detetor de fase
 topic: circuitos

--- a/public/data/cat1.json
+++ b/public/data/cat1.json
@@ -2247,7 +2247,7 @@
       "options": [
         "um detetor de produto",
         "um detetor de frequência modulada",
-        "um detetor de de envolvente",
+        "um detetor de envolvente",
         "um detetor de fase"
       ],
       "correctIndex": 2,


### PR DESCRIPTION
A opção correta da cat1#120 dizia "um detetor de de envolvente". Passa a dizer "um detetor de envolvente".

**Nota:** o "de" repetido está na própria prova — cat1/2026_09_01, pergunta 31, página 9 — e não é um erro de transcrição nem de OCR; vê-se no digitalizado, entre "um detetor de frequência modulada" e "um detetor de fase".

Corrige-se à mesma: é uma gralha evidente, é a resposta certa, e quem estuda por aqui lê a frase como português e não como fac-símile da prova. Se preferires manter a fidelidade ao enunciado original, basta reverter este PR.
